### PR TITLE
Adapt anagram exercise in line with other implementations

### DIFF
--- a/anagram/anagram_test.go
+++ b/anagram/anagram_test.go
@@ -123,7 +123,7 @@ var testCases = []struct {
 			"Carthorse",
 			"radishes",
 		},
-		expected:    []string{"carthorse"},
+		expected:    []string{"Carthorse"},
 		description: "candidates are case insensitive",
 	},
 }

--- a/anagram/example.go
+++ b/anagram/example.go
@@ -9,8 +9,7 @@ func Detect(subject string, candidates []string) []string {
 	subject = strings.ToLower(subject)
 	var matches []string
 	for _, c := range candidates {
-		c = strings.ToLower(c)
-		if isAnagram(subject, c) {
+		if isAnagram(subject, strings.ToLower(c)) {
 			matches = append(matches, c)
 		}
 	}


### PR DESCRIPTION
In the majority of implementations the resulting list of
anagrams is a selection of the strings in the candidate
list. In contrast the Go implementation lowercased the
results. This commit removes this deviation.
