### PR TITLE
Complete EXERCISES.txt

### DIFF
--- a/EXERCISES.txt
+++ b/EXERCISES.txt
@@ -17,3 +17,5 @@ phone-number
 octal
 bottles
 nucleotide-count
+hexadecimal
+binary-search-tree


### PR DESCRIPTION
The hexadecimal and binary-search-tree weren't included in the EXERCISES.txt file and therefore weren't automatically fetched by the CLI.
