### PR TITLE
octal: make more idiomatic

### DIFF
--- a/octal/example.go
+++ b/octal/example.go
@@ -1,21 +1,18 @@
 package octal
 
 import (
-	"math"
-	"strconv"
+	"fmt"
 )
 
-// Easy way:
-// r, _ = strconv.ParseInt(input, 8, 0)
-//
-// Let's do it the hard way.
-
-func ToDecimal(s string) (n int64) {
-	length := len(s)
-
-	for i := length; i > 0; i-- {
-		v, _ := strconv.ParseInt(string(s[i-1]), 10, 0)
-		n = n + (v * int64(math.Pow(8, float64(length-i))))
+func ParseOctal(octal string) (int64, error) {
+	num := int64(0)
+	for _, digit := range octal {
+		// if any digits aren't octal digits (0-7), return 0
+		if digit < '0' || digit > '7' {
+			return 0, fmt.Errorf("unexpected rune '%c'", octal)
+		}
+		// multiply the current number by 8 (left shift) and add the digit
+		num = num<<3 + int64(digit-'0')
 	}
-	return n
+	return num, nil
 }

--- a/octal/octal_test.go
+++ b/octal/octal_test.go
@@ -5,32 +5,44 @@ import (
 )
 
 var testCases = []struct {
-	input    string
-	expected int64
+	input       string
+	expectedNum int64
+	expectErr   bool
 }{
-	{"1", 1},
-	{"10", 8},
-	{"1234567", 342391},
-	{"carrot", 0},
+	{"1", 1, false},
+	{"10", 8, false},
+	{"1234567", 342391, false},
+	{"carrot", 0, true},
+	{"35682", 0, true},
 }
 
-func TestToDecimal(t *testing.T) {
+func TestParseOctal(t *testing.T) {
 	for _, test := range testCases {
-		actual := ToDecimal(test.input)
-		if actual != test.expected {
-			t.Fatalf("ToDecimal(%s): expected[%d], actual [%d]", test.input, test.expected, actual)
+		actualNum, actualErr := ParseOctal(test.input)
+		if actualNum != test.expectedNum {
+			t.Fatalf("ParseOctal(%s): expected[%d], actual [%d]",
+				test.input, test.expectedNum, actualNum)
+		}
+
+		// if we expect an error and there isn't one
+		if test.expectErr && actualErr == nil {
+			t.Errorf("ParseOctal(%s): expected an error, but error is nil", test.input)
+		}
+		// if we don't expect an error and there is one
+		if !test.expectErr && actualErr != nil {
+			t.Errorf("ParseOctal(%s): expected no error, but error is: %s", test.input, actualErr)
 		}
 	}
 }
 
-func BenchmarkToDecimal(b *testing.B) {
+func BenchmarkParseOctal(b *testing.B) {
 	b.StopTimer()
 
 	for _, test := range testCases {
 		b.StartTimer()
 
 		for i := 0; i < b.N; i++ {
-			ToDecimal(test.input)
+			ParseOctal(test.input)
 		}
 
 		b.StopTimer()


### PR DESCRIPTION
- extend the test file to require error cases.
- improve on the example solution
- change the name from ToDecimal to ParseOctal as it's more accurate
