### PR TITLE
nucleotide-count: Model nucleotides as bytes

### DIFF
--- a/nucleotide-count/example.go
+++ b/nucleotide-count/example.go
@@ -5,24 +5,24 @@ import (
 	"strings"
 )
 
-type Histogram map[string]int
+type Histogram map[byte]int
 
 type DNA string
 
-func (dna DNA) Count(nucleotide string) (count int, err error) {
+func (dna DNA) Count(nucleotide byte) (count int, err error) {
 	validNucleotides := "ACGT"
-	if !strings.Contains(validNucleotides, nucleotide) {
-		return 0, errors.New("dna: invalid nucleotide " + nucleotide)
+	if !strings.Contains(validNucleotides, string(nucleotide)) {
+		return 0, errors.New("dna: invalid nucleotide " + string(nucleotide))
 	}
 
-	return strings.Count(string(dna), nucleotide), nil
+	return strings.Count(string(dna), string(nucleotide)), nil
 }
 
 func (dna DNA) Counts() Histogram {
-	a, _ := dna.Count("A")
-	c, _ := dna.Count("C")
-	t, _ := dna.Count("T")
-	g, _ := dna.Count("G")
+	a, _ := dna.Count('A')
+	c, _ := dna.Count('C')
+	t, _ := dna.Count('T')
+	g, _ := dna.Count('G')
 
-	return Histogram{"A": a, "C": c, "T": t, "G": g}
+	return Histogram{'A': a, 'C': c, 'T': t, 'G': g}
 }

--- a/nucleotide-count/nucleotide_count_test.go
+++ b/nucleotide-count/nucleotide_count_test.go
@@ -22,13 +22,13 @@ func (h Histogram) sameMappings(o Histogram) (res bool) {
 
 var tallyTests = []struct {
 	strand     string
-	nucleotide string
+	nucleotide byte
 	expected   int
 }{
-	{"", "A", 0},
-	{"ACT", "G", 0},
-	{"CCCCC", "C", 5},
-	{"GGGGGTAACCCGG", "T", 1},
+	{"", 'A', 0},
+	{"ACT", 'G', 0},
+	{"CCCCC", 'C', 5},
+	{"GGGGGTAACCCGG", 'T', 1},
 }
 
 func TestNucleotideCounts(t *testing.T) {
@@ -43,7 +43,7 @@ func TestNucleotideCounts(t *testing.T) {
 
 func TestHasErrorForInvalidNucleotides(t *testing.T) {
 	dna := DNA("GATTACA")
-	count, err := dna.Count("X")
+	count, err := dna.Count('X')
 	if count != 0 {
 		t.Fatalf("Got \"%v\", expected \"%v\"", count, 0)
 	}
@@ -57,8 +57,8 @@ func TestHasErrorForInvalidNucleotides(t *testing.T) {
 // Just roll with it.
 func TestCountingDoesntChangeCount(t *testing.T) {
 	dna := DNA("CGATTGGG")
-	dna.Count("T")
-	count, _ := dna.Count("T")
+	dna.Count('T')
+	count, _ := dna.Count('T')
 	if count != 2 {
 		t.Fatalf("Got \"%v\", expected \"%v\"", count, 2)
 	}
@@ -72,15 +72,15 @@ type histogramTest struct {
 var histogramTests = []histogramTest{
 	{
 		"",
-		Histogram{"A": 0, "C": 0, "T": 0, "G": 0},
+		Histogram{'A': 0, 'C': 0, 'T': 0, 'G': 0},
 	},
 	{
 		"GGGGGGGG",
-		Histogram{"A": 0, "C": 0, "T": 0, "G": 8},
+		Histogram{'A': 0, 'C': 0, 'T': 0, 'G': 8},
 	},
 	{
 		"AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
-		Histogram{"A": 20, "C": 12, "T": 21, "G": 17},
+		Histogram{'A': 20, 'C': 12, 'T': 21, 'G': 17},
 	},
 }
 


### PR DESCRIPTION
Unlike other languages, Go has two datatypes for single letters: rune
and byte. As our abbreviations for the nucleotides, A, C, G and T, can
all be ASCII-encoded, multibyte runes aren't needed.
