### PR TITLE
Add robot-name ported from Ruby

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,6 +16,7 @@
     "allergies",
     "bob",
     "rna-transcription",
+    "robot-names",
     "roman-numerals",
     "atbash-cipher",
     "phone-number",

--- a/robot-name/bonus.go
+++ b/robot-name/bonus.go
@@ -1,0 +1,42 @@
+// +build bonus
+
+package robotname
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+type Robot struct {
+	name string
+}
+
+var issued = map[string]bool{}
+
+func (r *Robot) Name() string {
+	if r.name > "" {
+		return r.name
+	}
+	a1 := rand.Intn(26)
+	a2 := rand.Intn(26)
+	n := rand.Intn(1000)
+	start := fmt.Sprintf("%c%c%03d", 'A'+byte(a1), 'A'+byte(a2), n)
+	r.name = start
+	for issued[r.name] {
+		if n = (n + 1) % 1000; n == 0 {
+			if a2 = (a2 + 1) % 26; a2 > 0 {
+				a1 = (a1 + 1) % 26
+			}
+		}
+		r.name = fmt.Sprintf("%c%c%03d", 'A'+byte(a1), 'A'+byte(a2), n)
+		if r.name == start {
+			panic("all valid robot names issued")
+		}
+	}
+	issued[r.name] = true
+	return r.name
+}
+
+func (r *Robot) Reset() {
+	*r = Robot{}
+}

--- a/robot-name/bonus_test.go
+++ b/robot-name/bonus_test.go
@@ -1,0 +1,29 @@
+// +build bonus
+
+package robotname
+
+import "testing"
+
+func TestCollisions(t *testing.T) {
+	m := map[string]bool{}
+	// Test uniqueness for new robots.
+	// 10k should be plenty to catch names generated
+	// randomly without a uniqueness check.
+	for i := 0; i < 10000; i++ {
+		n := New().Name()
+		if m[n] {
+			t.Fatalf("Name %s reissued after %d robots.", n, i)
+		}
+		m[n] = true
+	}
+	// Test that names aren't recycled either.
+	r := New()
+	for i := 0; i < 10000; i++ {
+		r.Reset()
+		n := r.Name()
+		if m[n] {
+			t.Fatalf("Name %s reissued after Reset.", n)
+		}
+		m[n] = true
+	}
+}

--- a/robot-name/example.go
+++ b/robot-name/example.go
@@ -1,0 +1,26 @@
+// +build !bonus
+
+package robotname
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+type Robot struct {
+	name string
+}
+
+func (r *Robot) Name() string {
+	if r.name == "" {
+		r.name = fmt.Sprintf("%c%c%03d",
+			'A'+byte(rand.Intn(26)),
+			'A'+byte(rand.Intn(26)),
+			rand.Intn(1000))
+	}
+	return r.name
+}
+
+func (r *Robot) Reset() {
+	*r = Robot{}
+}

--- a/robot-name/robot_name_test.go
+++ b/robot-name/robot_name_test.go
@@ -1,0 +1,51 @@
+package robotname
+
+import (
+	"regexp"
+	"testing"
+)
+
+func New() *Robot { return new(Robot) }
+
+var namePat = regexp.MustCompile(`^[A-Z]{2}\d{3}$`)
+
+func TestNameValid(t *testing.T) {
+	n := New().Name()
+	if !namePat.MatchString(n) {
+		t.Errorf(`Invalid robot name %q, want form "AA###".`, n)
+	}
+}
+
+func TestNameSticks(t *testing.T) {
+	r := New()
+	n1 := r.Name()
+	n2 := r.Name()
+	if n2 != n1 {
+		t.Errorf(`Robot name changed.  Now %s, was %s.`, n2, n1)
+	}
+}
+
+func TestSuccessiveRobotsHaveDifferentNames(t *testing.T) {
+	n1 := New().Name()
+	if New().Name() == n1 {
+		t.Errorf(`Robots with same name.  Two %s's.`, n1)
+	}
+}
+
+func TestResetName(t *testing.T) {
+	r := New()
+	n1 := r.Name()
+	r.Reset()
+	if r.Name() == n1 {
+		t.Errorf(`Robot name not cleared on reset.  Still %s.`, n1)
+	}
+}
+
+// Note if you go for bonus points, this benchmark likely won't be
+// meaningful.  Bonus thought exercise, why won't it be meaningful?
+func BenchmarkName(b *testing.B) {
+	// Benchmark combined time to create robot and name.
+	for i := 0; i < b.N; i++ {
+		New().Name()
+	}
+}


### PR DESCRIPTION
Just a guess at what file names might work.  Example.go and robot_name_test.go follow existing conventions.  Example.go has a build tag in it but that has no effect when you test the program normally.  robot_name_test.go has a comment mentioning bonus tasks, but not mentioning any other files.  So, if existing stuff -- the cli and whatever else -- delivers just robot_name_test.go to the user, everything thing should look fine for the user.

The bonus solution is in the separate file bonus.go and the bonus test in bonus_test.go.  If the cli can also deliver bonus_test.go, then we could update the Go help page with the `-tags bonus` instruction for running it.

If the current behavior of the cli is to deliver all .go files except example.go, we have a problem.  It would deliver bonus.go, the bonus solution.  It seems unlikely things would be written that way, but I thought I would mention it.

Finally, example.go and bonus.go have build constraints in them so that `go test` runs example.go and ignores bonus.go.  `go test -tags bonus` runs bonus.go and ignores example.go.  This should allow both files to exist, for Travis for example.  Also the user does not have to use or understand this trick.  He can write his program just as he normally would and use `-tags bonus` or not according to whether he wants to run the extra test in bonus_test.
