### PR TITLE
add exercise trinary

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,6 +28,7 @@
     "beer-song",
     "nucleotide-count",
     "grade-school",
+    "trinary",
     "hexadecimal",
     "meetup",
     "binary-search-tree",

--- a/trinary/example.go
+++ b/trinary/example.go
@@ -1,0 +1,37 @@
+package trinary
+
+import (
+	"fmt"
+	"math"
+)
+
+func ParseTrinary(s string) (int64, error) {
+	const third = math.MaxInt64 / 3
+	overflow := false
+	var d int64
+	for _, r := range s {
+		switch r {
+		case '0', '1', '2':
+			if overflow {
+				continue
+			}
+			if d > third {
+				overflow = true
+				continue
+			}
+			d *= 3
+			t := int64(r - '0')
+			if t > math.MaxInt64-d {
+				overflow = true
+				continue
+			}
+			d += t
+		default:
+			return 0, fmt.Errorf("invalid: %s", s)
+		}
+	}
+	if overflow {
+		return 0, fmt.Errorf("overflow: %s", s)
+	}
+	return d, nil
+}

--- a/trinary/trinary_test.go
+++ b/trinary/trinary_test.go
@@ -1,0 +1,43 @@
+package trinary
+
+import "testing"
+
+var tests = []struct {
+	arg  string
+	want int64
+	ok   bool
+}{
+	{"0", 0, true},
+	{"1", 1, true},
+	{"2", 2, true},
+	{"10", 3, true},
+	{"201", 19, true},
+	{"0201", 19, true},
+	{"0000000000000000000000000000000000000000201", 19, true},
+	{"2021110011022210012102010021220101220221", 9223372036854775807, true},
+	{"2021110011022210012102010021220101220222", 0, false},
+}
+
+func TestParseTrinary(t *testing.T) {
+	for _, test := range tests {
+		switch res, err := ParseTrinary(test.arg); {
+		case err != nil:
+			if test.ok {
+				t.Errorf("ParseTrinary(%q) returned error %q, Error not expected",
+					test.arg, err)
+			}
+		case !test.ok:
+			t.Errorf("ParseTrinary(%q) = %d, %v, expected error", test.arg, res, err)
+		case res != test.want:
+			t.Errorf("ParseTrinary(%q) = %d, want %d", test.arg, res, test.want)
+		}
+	}
+}
+
+func BenchmarkParseTrinary(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
+			ParseTrinary(test.arg)
+		}
+	}
+}


### PR DESCRIPTION
Another in the sequence of number conversions.  In the test data I included an overflow case but no invalid syntax cases.  The required parse functions in the four exercises binary, octal, trinary, and hexadecimal all have the same basic signature now of returning an integer value and an error of the Go error type.  Probably this is best as otherwise experienced Go programmers will constantly be annoyed and be trying to change it.  Next I'd like to actually remove the invalid syntax test cases from the binary example so the sequence of exercises would go,
1. Binary, returns error type, but all test cases will be valid and error checking can be skirted by simply returning nil for the error.  A comment in the test program (or readme) might say that error checking can be omitted or implemented as a bonus exercise.
2. Octal, returns error type and some test cases have invalid syntax.  Syntax errors anyway are no longer a bonus exercise.  Solutions must catch this and return an error.
3. Trinary, returns error type and some test cases overflow the integer result.  Solutions must catch this and return an error.  I'm putting this after octal in the config because I suspect most people will find testing for overflow more challenging than testing for invalid syntax.
4. Hexadecimal, returns error type and test data includes both invalid syntax and overflow cases.  Solutions must catch both and return a distinguishable error.  Solutions must also include a function that handles the error return and correctly identifies what kind of error was returned.
