### PR TITLE
add exercise difference of squares

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "gigasecond",
     "raindrops",
     "triangle",
+    "difference-of-squares",
     "grains",
     "etl",
     "scrabble-score",

--- a/difference-of-squares/difference_of_squares_test.go
+++ b/difference-of-squares/difference_of_squares_test.go
@@ -1,0 +1,54 @@
+package diffsquares
+
+import "testing"
+
+var tests = []struct{ n, sqOfSums, sumOfSq int }{
+	{5, 225, 55},
+	{10, 3025, 385},
+	{100, 25502500, 338350},
+}
+
+func TestSquareOfSums(t *testing.T) {
+	for _, test := range tests {
+		if s := SquareOfSums(test.n); s != test.sqOfSums {
+			t.Fatalf("SquareOfSums(%d) = %d, want %d", test.n, s, test.sqOfSums)
+		}
+	}
+}
+
+func TestSumOfSquares(t *testing.T) {
+	for _, test := range tests {
+		if s := SumOfSquares(test.n); s != test.sumOfSq {
+			t.Fatalf("SumOfSquares(%d) = %d, want %d", test.n, s, test.sumOfSq)
+		}
+	}
+}
+
+func TestDifference(t *testing.T) {
+	for _, test := range tests {
+		want := test.sqOfSums - test.sumOfSq
+		if s := Difference(test.n); s != want {
+			t.Fatalf("Difference(%d) = %d, want %d", test.n, s, want)
+		}
+	}
+}
+
+// Benchmark functions on just a single number (100, from the original PE problem)
+// to avoid overhead of iterating over tests.
+func BenchmarkSquareOfSums(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SquareOfSums(100)
+	}
+}
+
+func BenchmarkSumOfSquares(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SumOfSquares(100)
+	}
+}
+
+func BenchmarkDifference(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Difference(100)
+	}
+}

--- a/difference-of-squares/example.go
+++ b/difference-of-squares/example.go
@@ -1,0 +1,20 @@
+package diffsquares
+
+func SquareOfSums(n int) int {
+	s := 0
+	for i := 0; i <= n; i++ {
+		s += i
+	}
+	return s * s
+}
+
+func SumOfSquares(n int) (s int) {
+	for i := 0; i <= n; i++ {
+		s += i * i
+	}
+	return
+}
+
+func Difference(n int) int {
+	return SquareOfSums(n) - SumOfSquares(n)
+}


### PR DESCRIPTION
Again, no objects, just three separate functions.  This keeps the exercise very simple.  For the difference, solvers can compose the other two functions or write something new.  (Loops can be combined at least, but If they are coding closed formulas, the difference nicely reduces algebraically.)  The three functions are benchmarked separately so solvers can compare the time of the difference function to the sum of times of the other two.
