### PR TITLE
add exercise luhn

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,7 @@
     "scrabble-score",
     "hamming",
     "sum-of-multiples",
+    "luhn",
     "palindrome-product",
     "anagram",
     "word-count",

--- a/luhn/example.go
+++ b/luhn/example.go
@@ -1,0 +1,39 @@
+package luhn
+
+func Valid(n string) bool {
+	d := extract(n)
+	if len(d) == 0 {
+		return false
+	}
+	last := len(d) - 1
+	return (check(d[:last])+d[last])%10 == 0
+}
+
+func extract(n string) []int {
+	d := make([]int, 0, len(n))
+	for _, r := range n {
+		if r >= '0' && r <= '9' {
+			d = append(d, int(r-'0'))
+		}
+	}
+	return d
+}
+
+func check(d []int) int {
+	for i := len(d) - 1; i >= 0; i -= 2 {
+		x := 2 * d[i]
+		if x > 9 {
+			x -= 9
+		}
+		d[i] = x
+	}
+	s := 0
+	for _, x := range d {
+		s += x
+	}
+	return s
+}
+
+func AddCheck(raw string) string {
+	return raw + string('0'+(10-check(extract(raw))%10)%10)
+}

--- a/luhn/luhn_test.go
+++ b/luhn/luhn_test.go
@@ -1,0 +1,54 @@
+package luhn
+
+import "testing"
+
+var validTests = []struct {
+	n  string
+	ok bool
+}{
+	{"738", false},
+	{"8739567", true},
+	{"1111", false},
+	{"8763", true},
+	{"    ", false},
+	{"", false},
+	{"2323 2005 7766 3554", true},
+}
+
+var addTests = []struct{ raw, luhn string }{
+	{"123", "1230"},
+	{"873956", "8739567"},
+	{"837263756", "8372637564"},
+	{"2323 2005 7766 355", "2323 2005 7766 3554"},
+	// bonus Unicode cases
+	// {"2323·2005·7766·355", "2323·2005·7766·3554"},
+	// {"１２３", "１２３０"},
+}
+
+func TestValid(t *testing.T) {
+	for _, test := range validTests {
+		if ok := Valid(test.n); ok != test.ok {
+			t.Fatalf("Valid(%s) = %t, want %t.", test.n, ok, test.ok)
+		}
+	}
+}
+
+func TestAddCheck(t *testing.T) {
+	for _, test := range addTests {
+		if luhn := AddCheck(test.raw); luhn != test.luhn {
+			t.Fatalf("AddCheck(%s) = %s, want %s.", test.raw, luhn, test.luhn)
+		}
+	}
+}
+
+func BenchmarkValid(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Valid("2323 2005 7766 3554")
+	}
+}
+
+func BenchmarkAddCheck(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		AddCheck("2323 2005 7766 355")
+	}
+}


### PR DESCRIPTION
Following the readme more than the Ruby example.  Luhn inputs are digit strings, not integers, and as the readme example shows, they can be grouped with spaces or presumably other characters.  Implementation is two functions, but with a nice opportunity to factor out most of each into common code.
