### PR TITLE
add exercise pythagorean triplet

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,6 +16,7 @@
     "parallel-letter-frequency",
     "hamming",
     "sum-of-multiples",
+    "pythagorean-triplet",
     "luhn",
     "largest-series-product",
     "sieve",

--- a/pythagorean-triplet/example.go
+++ b/pythagorean-triplet/example.go
@@ -1,0 +1,32 @@
+package pythagorean
+
+type Triplet [3]int
+
+func pyth(a, b, c int) bool {
+	return a*a+b*b == c*c
+}
+
+func Range(min, max int) (ts []Triplet) {
+	for a := min; a <= max; a++ {
+		for b := a; b <= max; b++ {
+			for c := b; c <= max; c++ {
+				if pyth(a, b, c) {
+					ts = append(ts, Triplet{a, b, c})
+				}
+			}
+		}
+	}
+	return
+}
+
+func Sum(sum int) (ts []Triplet) {
+	max := sum / 2
+	for a := 1; a <= max; a++ {
+		for b := a; b <= max; b++ {
+			if c := sum - a - b; pyth(a, b, c) {
+				ts = append(ts, Triplet{a, b, c})
+			}
+		}
+	}
+	return
+}

--- a/pythagorean-triplet/pythagorean_triplet_test.go
+++ b/pythagorean-triplet/pythagorean_triplet_test.go
@@ -1,0 +1,73 @@
+package pythagorean
+
+// Use this type defintion,
+//
+//    type Triplet [3]int
+//
+// and implement two functions,
+//
+//    Range(min, max int) []Triplet
+//    Sum(p int) []Triplet
+//
+// Range returns a list of all Pythagorean triplets with sides in the
+// range min to max inclusive.
+//
+// Sum returns a list of all Pythagorean triplets where the sum a+b+c
+// (the perimeter) is equal to p.
+//
+// The three elements of each returned triplet must be in order,
+// t[0] <= t[1] <= t[2], and the list of triplets must be in lexicographic
+// order.
+
+import (
+	"reflect"
+	"testing"
+)
+
+var rangeTests = []struct {
+	min, max int
+	ts       []Triplet
+}{
+	{1, 10, []Triplet{{3, 4, 5}, {6, 8, 10}}},
+	{11, 20, []Triplet{{12, 16, 20}}},
+}
+
+func TestRange(t *testing.T) {
+	for _, test := range rangeTests {
+		ts := Range(test.min, test.max)
+		if !reflect.DeepEqual(ts, test.ts) {
+			t.Fatalf("Range(%d, %d) = %v, want %v",
+				test.min, test.max, ts, test.ts)
+		}
+	}
+}
+
+var sumTests = []struct {
+	sum int
+	ts  []Triplet
+}{
+	{180, []Triplet{{18, 80, 82}, {30, 72, 78}, {45, 60, 75}}},
+	{1000, []Triplet{{200, 375, 425}}},
+}
+
+func TestSum(t *testing.T) {
+	for _, test := range sumTests {
+		ts := Sum(test.sum)
+		if !reflect.DeepEqual(ts, test.ts) {
+			t.Fatalf("Sum(%d) = %v, want %v",
+				test.sum, ts, test.ts)
+		}
+	}
+}
+
+func BenchmarkRange(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Range(1, 100)
+	}
+}
+
+func BenchmarkSum(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Sum(1000)
+	}
+}


### PR DESCRIPTION
I hope I got the intent of this one.  I require two functions, one to solves the Project Euler problem of finding triplets with a specified perimeter and one from Ruby to generate triplets with sides within a range of values.

Other parts of the Ruby example seemed to be about doing something according to various conditions which might be specified.  You can kind of do something like this in Go with struct literals but I really didn't see the point of it in this context of Pythagorean triplets.

The test cases are easily solvable by brute force but certainly there is room for people to apply more advanced algorithms if they like.
