### PR TITLE
add exercise ocr numbers

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,6 +37,7 @@
     "nth-prime",
     "octal",
     "beer-song",
+    "ocr-numbers",
     "wordy",
     "nucleotide-count",
     "grade-school",

--- a/ocr-numbers/example.go
+++ b/ocr-numbers/example.go
@@ -1,0 +1,58 @@
+package ocr
+
+import "strings"
+
+var digit = map[string]byte{
+	" _ | ||_|   ": '0',
+	"     |  |   ": '1',
+	" _  _||_    ": '2',
+	" _  _| _|   ": '3',
+	"   |_|  |   ": '4',
+	" _ |_  _|   ": '5',
+	" _ |_ |_|   ": '6',
+	" _   |  |   ": '7',
+	" _ |_||_|   ": '8',
+	" _ |_| _|   ": '9',
+}
+
+func recognizeDigit(lines []string, start int) byte {
+	if len(lines) < 4 {
+		return '?'
+	}
+	need := start + 3
+	for _, l := range lines {
+		if len(l) < need {
+			return '?'
+		}
+	}
+	if d, ok := digit[lines[0][start:need]+
+		lines[1][start:need]+
+		lines[2][start:need]+
+		lines[3][start:need]]; ok {
+		return d
+	}
+	return '?'
+}
+
+func Recognize(s string) []string {
+	lines := strings.Split(s, "\n")
+	if len(lines[0]) == 0 {
+		lines = lines[1:]
+	}
+	r := make([]string, (len(lines)+3)/4)
+	for i := range r {
+		max := 0
+		for l := 0; l < 4 && l < len(lines); l++ {
+			if n := len(lines[l]); n > max {
+				max = n
+			}
+		}
+		b := make([]byte, (max+2)/3)
+		for j := range b {
+			b[j] = recognizeDigit(lines, j*3)
+		}
+		r[i] = string(b)
+		lines = lines[4:]
+	}
+	return r
+}

--- a/ocr-numbers/ocr_numbers_test.go
+++ b/ocr-numbers/ocr_numbers_test.go
@@ -1,0 +1,130 @@
+// Go requirements:
+//
+// Define a function recognizeDigit as README Step 1 except make it recognize
+// all ten digits 0 to 9.  Pick what you like for parameters and return values
+// but make it useful as a subroutine for README step 2.
+//
+// For README Step 2 define,
+//
+//    func Recognize(string) []string
+//
+// and implement it using recognizeDigit.
+//
+// Input strings tested here have a \n at the beginning of each line and
+// no trailing \n on the last line. (This makes for readable raw string
+// literals.)
+//
+// For bonus points, gracefully handle misformatted data.  What should you
+// do with a partial cell?  Discard it?  Pad with spaces?  Report it with a
+// "?" character?  What should you do if the first character is not \n?
+
+package ocr
+
+import (
+	"reflect"
+	"testing"
+)
+
+var tests = []struct {
+	in  string
+	out []string
+}{
+	{`
+ _ 
+| |
+|_|
+   `, []string{"0"}},
+	{`
+   
+  |
+  |
+   `, []string{"1"}},
+	{`
+ _ 
+ _|
+|_ 
+   `, []string{"2"}},
+	{`
+ _ 
+ _|
+ _|
+   `, []string{"3"}},
+	{`
+   
+|_|
+  |
+   `, []string{"4"}},
+	{`
+ _ 
+|_ 
+ _|
+   `, []string{"5"}},
+	{`
+ _ 
+|_ 
+|_|
+   `, []string{"6"}},
+	{`
+ _ 
+  |
+  |
+   `, []string{"7"}},
+	{`
+ _ 
+|_|
+|_|
+   `, []string{"8"}},
+	{`
+ _ 
+|_|
+ _|
+   `, []string{"9"}},
+	{`
+    _ 
+  || |
+  ||_|
+      `, []string{"10"}},
+	{`
+   
+| |
+| |
+   `, []string{"?"}},
+	{`
+       _     _        _  _ 
+  |  || |  || |  |  || || |
+  |  ||_|  ||_|  |  ||_||_|
+                           `, []string{"110101100"}},
+	{`
+       _     _           _ 
+  |  || |  || |     || || |
+  |  | _|  ||_|  |  ||_||_|
+                           `, []string{"11?10?1?0"}},
+	{`
+    _  _     _  _  _  _  _  _ 
+  | _| _||_||_ |_   ||_||_|| |
+  ||_  _|  | _||_|  ||_| _||_|
+                              `, []string{"1234567890"}},
+	{`
+    _  _ 
+  | _| _|
+  ||_  _|
+         
+    _  _ 
+|_||_ |_ 
+  | _||_|
+         
+ _  _  _ 
+  ||_||_|
+  ||_| _|
+         `, []string{"123", "456", "789"}},
+}
+
+var _ = recognizeDigit // step 1.
+
+func TestRecognize(t *testing.T) {
+	for _, test := range tests {
+		if res := Recognize(test.in); !reflect.DeepEqual(res, test.out) {
+			t.Fatalf("Recognize(`%s`) = %q, want %q.", test.in, res, test.out)
+		}
+	}
+}


### PR DESCRIPTION
I tried to keep the two-part scheme of the readme, while, of course, changing a few little things here and there.  For part one, the test program requires that something is defined but that's all.  Instructions are to define a function and then use it as a subroutine but I don't actually check that.  I think it would be possible to find and parse the source, search the AST... but that seemed too much trouble.  Easy enough to let nitpickers cry foul if someone doesn't follow directions.  The reason for not checking step 1 with the test program is that I didn't want to constrain the function signature.  Better to let the solver pick an optimal signature for however they are implementing step 2.

Also I resisted adding test cases for ill-formatted data.  I mentioned in the test program instruction comments that it's good to handle ill-formatted data; and the example program does something well defined with ill-formatted data.  Adding tests though, even as a separate file with a build tag, would dictate how to handle ill-formed data and I thought there was room for different views.
