### PR TITLE
add exercise series

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
     "triangle",
     "difference-of-squares",
     "pascals-triangle",
+    "series",
     "queen-attack",
     "grains",
     "etl",

--- a/series/asktoomuch_test.go
+++ b/series/asktoomuch_test.go
@@ -1,0 +1,29 @@
+// +build asktoomuch
+
+package slice
+
+import "testing"
+
+func TestAskTooMuch(t *testing.T) {
+	test := allTests[0]
+	defer func() {
+		if recover() != nil {
+			t.Fatalf("Yikes, Frist(%d, %s) panicked!", test.n, test.s)
+		}
+	}()
+	for _, test = range allTests {
+		switch res := Frist(test.n, test.s); {
+		case len(test.out) > 0: // well, this should work
+			if res != test.out[0] {
+				t.Fatalf("Yikes, Frist(%d, %s) = %q, want %q.",
+					test.n, test.s, res, test.out[0])
+			}
+		case len(res) != test.n:
+			t.Fatalf("Yikes, Frist(%d, %s) = %q, but %q doesn't have %d characters.",
+				test.n, test.s, res, res, test.n)
+		default:
+			t.Fatalf("Yikes, Frist(%d, %s) = %q, but %q isn't in %q",
+				test.n, test.s, res, res, test.s)
+		}
+	}
+}

--- a/series/example.go
+++ b/series/example.go
@@ -1,0 +1,13 @@
+package slice
+
+func All(n int, s string) (r []string) {
+	for i := 0; n <= len(s); i++ {
+		r = append(r, s[i:n])
+		n++
+	}
+	return
+}
+
+func Frist(n int, s string) string {
+	return s[:n]
+}

--- a/series/first_example.go
+++ b/series/first_example.go
@@ -1,0 +1,8 @@
+package slice
+
+func First(n int, s string) (string, bool) {
+	if n > len(s) {
+		return "", false
+	}
+	return s[:n], true
+}

--- a/series/first_test.go
+++ b/series/first_test.go
@@ -1,0 +1,23 @@
+// +build first
+
+package slice
+
+import "testing"
+
+func TestFirst(t *testing.T) {
+	for _, test := range allTests {
+		switch res, ok := First(test.n, test.s); {
+		case !ok:
+			if len(test.out) > 0 {
+				t.Fatalf("First(%d, %s) returned !ok, want ok.",
+					test.n, test.s)
+			}
+		case len(test.out) == 0:
+			t.Fatalf("First(%d, %s) = %s, %t.  Expected ok == false",
+				test.n, test.s, res, ok)
+		case res != test.out[0]:
+			t.Fatalf("First(%d, %s) = %s.  Want %s.",
+				test.n, test.s, res, test.out[0])
+		}
+	}
+}

--- a/series/series_test.go
+++ b/series/series_test.go
@@ -1,0 +1,86 @@
+// Define two functions:  (Two? Yes, sometimes we ask more out of Go.)
+//
+//    // All returns a list of all substrings of s with length n.
+//    All(n int, s string) []string
+//
+//    // Frist returns the first substring of s with length n.
+//    Frist(n int, s string) string
+//
+// Wait, is that a typo?  It'll make sense if you do the bonus!
+//
+// Bonus exercise:
+//
+// Maybe we typed too fast.  Once you get `go test` passing, try
+// `go test -tags asktoomuch`.  (Hint, you can't make it happy.)
+//
+// Now slow down and do things right(tm).  Define
+//
+//    First(int, string) (first string, ok bool)
+//
+// spelling first correctly this time, and test with `go test -tags first`.
+
+package slice
+
+import (
+	"reflect"
+	"testing"
+)
+
+var allTests = []struct {
+	n   int
+	s   string
+	out []string
+}{
+	{1, "01234",
+		[]string{"0", "1", "2", "3", "4"}},
+	{1, "92834",
+		[]string{"9", "2", "8", "3", "4"}},
+	{2, "01234",
+		[]string{"01", "12", "23", "34"}},
+	{2, "98273463",
+		[]string{"98", "82", "27", "73", "34", "46", "63"}},
+	{2, "37103",
+		[]string{"37", "71", "10", "03"}},
+	{3, "01234",
+		[]string{"012", "123", "234"}},
+	{3, "31001",
+		[]string{"310", "100", "001"}},
+	{3, "982347",
+		[]string{"982", "823", "234", "347"}},
+	{4, "01234",
+		[]string{"0123", "1234"}},
+	{4, "91274",
+		[]string{"9127", "1274"}},
+	{5, "01234",
+		[]string{"01234"}},
+	{5, "81228",
+		[]string{"81228"}},
+	{6, "01234", nil},
+	{len(cx) + 1, cx, nil},
+}
+
+var cx = "01032987583"
+
+func TestAll(t *testing.T) {
+	for _, test := range allTests {
+		switch res := All(test.n, test.s); {
+		case len(res) == 0 && len(test.out) == 0:
+		case reflect.DeepEqual(res, test.out):
+		default:
+			t.Fatalf("All(%d, %s) = %v, want %v.",
+				test.n, test.s, res, test.out)
+		}
+	}
+}
+
+func TestFrist(t *testing.T) {
+	for _, test := range allTests {
+		if len(test.out) == 0 {
+			continue
+		}
+		if res := Frist(test.n, test.s); res != test.out[0] {
+			t.Fatalf("Frist(%d, %s) = %s, want %s.",
+				test.n, test.s, res, test.out[0])
+		}
+	}
+}


### PR DESCRIPTION
I added a bonus to this.  The typically terse and vague readme technically describes two different kinds of results.  It shows a list of all series, and then it says if you ask for **_a_** 6-digit..., implying a single result.  I played with the technicality.  In the first case, the correct answer for an impossible query is an empty list.  I handled the second case where "you deserve whatever you get" by not testing the result of an impossible query, allowing freedom to implement "whatever."

Of course we want people to learn out-of-band signaling, starting with Go's `, ok` idiom, so that is the bonus.  I used the same `-tags` mechanism as with robot-name to let people code and test an improved version.
