### PR TITLE
add exercise robot-simulator

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,7 +56,8 @@
     "binary-search-tree",
     "kindergarten-garden",
     "simple-cipher",
-    "paasio"
+    "paasio",
+    "robot-simulator"
   ],
   "deprecated": [
     "accumulate",

--- a/robot-simulator/defs.go
+++ b/robot-simulator/defs.go
@@ -1,0 +1,32 @@
+package robot
+
+import "fmt"
+
+// definitions used in step 1
+
+var (
+	X, Y   int
+	Facing Dir
+)
+
+type Dir int
+
+var _ fmt.Stringer = Dir(1729)
+
+// additional definitions used in step 2
+
+type Command byte // valid values are 'R', 'L', 'A'
+type RU int
+type Pos struct{ Easting, Northing RU }
+type Rect struct{ Min, Max Pos }
+type DirAt struct {
+	Dir
+	Pos
+}
+
+// additional definition used in step 3
+
+type Place struct {
+	Name string
+	DirAt
+}

--- a/robot-simulator/example.go
+++ b/robot-simulator/example.go
@@ -1,0 +1,149 @@
+package robot
+
+import "fmt"
+
+// ======= Step 1
+
+const (
+	N = iota
+	E
+	S
+	W
+)
+
+func (d Dir) String() string {
+	return "NESW"[d : d+1]
+}
+
+func Right() { Facing = (Facing + 1) % 4 }
+func Left()  { Facing = (Facing + 3) % 4 }
+func Advance() {
+	if Facing&1 == 1 {
+		X += 1 - int(Facing&2)
+	} else {
+		Y += 1 - int(Facing&2)
+	}
+}
+
+// ======= Step 2
+
+type Action byte
+
+func Robot(cmd chan Command, act chan Action) {
+	for c := range cmd {
+		act <- Action(c)
+	}
+	close(act)
+}
+
+func Room(extent Rect, place DirAt, act chan Action, report chan DirAt) {
+	for a := range act {
+		switch a {
+		case 'R':
+			place.Dir = (place.Dir + 1) % 4
+		case 'L':
+			place.Dir = (place.Dir + 3) % 4
+		case 'A':
+			np := place.Pos
+			if place.Dir&1 == 1 {
+				np.Easting += 1 - RU(place.Dir&2)
+			} else {
+				np.Northing += 1 - RU(place.Dir&2)
+			}
+			if in(np, extent) {
+				place.Pos = np
+			}
+		}
+	}
+	report <- place
+}
+
+func in(p Pos, ext Rect) bool {
+	return p.Easting >= ext.Min.Easting && p.Easting <= ext.Max.Easting &&
+		p.Northing >= ext.Min.Northing && p.Northing <= ext.Max.Northing
+}
+
+// ======= Step 3
+
+type Action3 struct {
+	name   string
+	action byte
+}
+
+const beep = 7 // robots beep to communicate that they are done
+
+func Robot3(name, script string, act chan Action3, log chan string) {
+	for i := 0; i < len(script); i++ {
+		act <- Action3{name, script[i]}
+	}
+	act <- Action3{name, beep}
+}
+
+func Room3(extent Rect, robots []Place, act chan Action3, rep chan []Place, log chan string) {
+	// The function has multiple returns.  No matter what, rep <- is how we
+	// communicate to the test program that the room is terminating.
+	defer func() { rep <- robots }()
+	nx := map[string]int{} // name index back into robots slice
+	px := map[Pos]int{}    // position index back into robots slice
+	for x, r := range robots {
+		if r.Name == "" {
+			log <- "Unnamed robot"
+			return
+		}
+		if _, ok := nx[r.Name]; ok {
+			log <- "Duplicate name"
+			return
+		}
+		nx[r.Name] = x
+
+		if !in(r.DirAt.Pos, extent) {
+			log <- "Robot placed outside room"
+			return
+		}
+		if _, ok := px[r.DirAt.Pos]; ok {
+			log <- "Position occupied"
+			return
+		}
+		px[r.DirAt.Pos] = x
+	}
+	done := 0
+	for a := range act {
+		x, ok := nx[a.name]
+		if !ok {
+			log <- "Action by unknown robot"
+			return
+		}
+		da := &robots[x].DirAt
+		switch a.action {
+		case 'R':
+			da.Dir = (da.Dir + 1) % 4
+		case 'L':
+			da.Dir = (da.Dir + 3) % 4
+		case 'A':
+			np := da.Pos
+			if da.Dir&1 == 1 {
+				np.Easting += 1 - RU(da.Dir&2)
+			} else {
+				np.Northing += 1 - RU(da.Dir&2)
+			}
+			if !in(np, extent) {
+				log <- a.name + " bumps wall!"
+				continue
+			}
+			if y, occupied := px[np]; occupied {
+				log <- fmt.Sprintf("%s bumps %s!", a.name, robots[y].Name)
+				continue
+			}
+			delete(px, da.Pos)
+			px[np] = x
+			da.Pos = np
+		case beep:
+			if done++; done == len(robots) {
+				return
+			}
+		default:
+			log <- "Undefined command"
+			return
+		}
+	}
+}

--- a/robot-simulator/robot_simulator_step2_test.go
+++ b/robot-simulator/robot_simulator_step2_test.go
@@ -1,0 +1,89 @@
+// +build step2 !step1,!step3
+
+package robot
+
+import "testing"
+
+// For step 1 you implement robot movements, but it's not much of a simulation.
+// For example where in the source code is "the robot"?  Where is "the grid"?
+// Where are the computations that turn robot actions into grid positions,
+// in the robot or in the grid?  The physical world is different.
+//
+// Step 2 introduces a "room."  It seems a small addition, but we'll make
+// big changes to clarify the rolls of "room", "robot", and "test program"
+// and begin to clarify the physics of the simulation.  You will define Room
+// and Robot as functions which the test program "brings into existance" by
+// launching them as goroutines.  Information moves between test program,
+// robot, and room over Go channels.
+//
+// Think of Room as a "physics engine," something that models and simulates
+// a physical room with walls and a robot.  It should somehow model the
+// coordinate space of the room, the location of the robot and the walls,
+// and ensure for example that the robot doesn't walk through walls.
+// We want Robot to be an agent that performs actions, but we want Room to
+// maintain a coherrent truth.
+//
+// Step 2 API:
+//
+// Robot(chan Command, chan Action)
+// Room(extent Rect, place DirAt, act chan Action, rep chan DirAt)
+//
+// You get to define Action; see defs.go for other definitions.
+//
+// The test program creates the channels and starts both Room and Robot.
+// The test program then sends commands to Robot.  When it is done sending
+// commands, it closes the command channel.  Robot must accept commands and
+// inform Room of actions it is attempting.  When it senses the command channel
+// closing, it must shut down itself.  The room must interpret the physical
+// consequences of the robot actions.  When it senses the robot shutting down,
+// it sends a final report back to the test program, telling the robot's final
+// position and direction.
+
+var test2 = []struct {
+	Command
+	DirAt
+}{
+	0:  {' ', DirAt{N, Pos{1, 1}}}, // no command, this is the start DirAt
+	1:  {'A', DirAt{N, Pos{1, 2}}},
+	2:  {'R', DirAt{E, Pos{1, 2}}},
+	3:  {'A', DirAt{E, Pos{2, 2}}},
+	4:  {'L', DirAt{N, Pos{2, 2}}},
+	5:  {'L', DirAt{W, Pos{2, 2}}},
+	6:  {'L', DirAt{S, Pos{2, 2}}},
+	7:  {'A', DirAt{S, Pos{2, 1}}},
+	8:  {'R', DirAt{W, Pos{2, 1}}},
+	9:  {'A', DirAt{W, Pos{1, 1}}},
+	10: {'A', DirAt{W, Pos{1, 1}}}, // bump W wall
+	11: {'L', DirAt{S, Pos{1, 1}}},
+	12: {'A', DirAt{S, Pos{1, 1}}}, // bump S wall
+	13: {'L', DirAt{E, Pos{1, 1}}},
+	14: {'A', DirAt{E, Pos{2, 1}}},
+	15: {'A', DirAt{E, Pos{2, 1}}}, // bump E wall
+	16: {'L', DirAt{N, Pos{2, 1}}},
+	17: {'A', DirAt{N, Pos{2, 2}}},
+	18: {'A', DirAt{N, Pos{2, 2}}}, // bump N wall
+}
+
+func TestStep2(t *testing.T) {
+	// run incrementally longer tests
+	for i := 1; i <= len(test2); i++ {
+		cmd := make(chan Command)
+		act := make(chan Action)
+		rep := make(chan DirAt)
+		go Robot(cmd, act)
+		go Room(Rect{Pos{1, 1}, Pos{2, 2}}, test2[0].DirAt, act, rep)
+		for j := 1; j < i; j++ {
+			cmd <- test2[j].Command
+		}
+		close(cmd)
+		da := <-rep
+		last := i - 1
+		want := test2[last].DirAt
+		if da.Pos != want.Pos {
+			t.Fatalf("Command #%d, Pos = %v, want %v", last, da.Pos, want.Pos)
+		}
+		if da.Dir != want.Dir {
+			t.Fatalf("Command #%d, Dir = %v, want %v", last, da.Dir, want.Dir)
+		}
+	}
+}

--- a/robot-simulator/robot_simulator_step3_test.go
+++ b/robot-simulator/robot_simulator_step3_test.go
@@ -1,0 +1,294 @@
+// +build step3 !step1,!step2
+
+package robot
+
+import "testing"
+
+// Step 3 has three major changes:
+//
+// *  Robots run scripts rather than respond to individual commands.
+// *  A log channel allows robots and the room to log messages.
+// *  The room allows multiple robots to exist and operate concurrently.
+//
+// Step 3 API:
+//
+//    Robot3(name, script string, action chan Action3, log chan string)
+//    Room3(extent Rect, robots []Place,
+//       action chan Action3, report chan []Place, log chan string)
+//
+// Again, you define Action3.
+//
+// For the final position report sent from Room3, you can return the same slice
+// recieved from the robots channel, just with updated positions and directions.
+//
+// Messages must be sent on the log channel for
+// *  A robot without a name
+// *  Duplicate robot names
+// *  Robots placed at the same place
+// *  A robot placed outside of the room
+// *  An undefined command in a script
+// *  An action from an unknown robot
+// *  A robot attempting to advance into a wall
+// *  A robot attempting to advance into another robot
+
+var testOneRobot = []struct {
+	cmd byte
+	DirAt
+	nMsg int
+}{
+	// (test2 data with message counts added)
+	{' ', DirAt{N, Pos{1, 1}}, 0},
+	{'A', DirAt{N, Pos{1, 2}}, 0},
+	{'R', DirAt{E, Pos{1, 2}}, 0},
+	{'A', DirAt{E, Pos{2, 2}}, 0},
+	{'L', DirAt{N, Pos{2, 2}}, 0},
+	{'L', DirAt{W, Pos{2, 2}}, 0},
+	{'L', DirAt{S, Pos{2, 2}}, 0},
+	{'A', DirAt{S, Pos{2, 1}}, 0},
+	{'R', DirAt{W, Pos{2, 1}}, 0},
+	{'A', DirAt{W, Pos{1, 1}}, 0},
+	{'A', DirAt{W, Pos{1, 1}}, 1}, // bump W wall
+	{'L', DirAt{S, Pos{1, 1}}, 1},
+	{'A', DirAt{S, Pos{1, 1}}, 2}, // bump S wall
+	{'L', DirAt{E, Pos{1, 1}}, 2},
+	{'A', DirAt{E, Pos{2, 1}}, 2},
+	{'A', DirAt{E, Pos{2, 1}}, 3}, // bump E wall
+	{'L', DirAt{N, Pos{2, 1}}, 3},
+	{'A', DirAt{N, Pos{2, 2}}, 3},
+	{'A', DirAt{N, Pos{2, 2}}, 4}, // bump N wall
+}
+
+func logMon(log chan string, nMsg chan int, t *testing.T) {
+	n := 0
+	for msg := range log {
+		t.Log("Sim:", msg)
+		n++
+	}
+	nMsg <- n
+}
+
+// Same tests as step 2; single robot, but expect log messages on wall bumps.
+func TestOneStep3(t *testing.T) {
+	for i := 1; i <= len(testOneRobot); i++ {
+		log := make(chan string)
+		nMsg := make(chan int)
+		go logMon(log, nMsg, t)
+		act := make(chan Action3)
+		rep := make(chan []Place)
+		go Room3(
+			Rect{Pos{1, 1}, Pos{2, 2}},
+			[]Place{{"Robbie", testOneRobot[0].DirAt}},
+			act, rep, log)
+		scr := ""
+		for j := 1; j < i; j++ {
+			scr += string(testOneRobot[j].cmd)
+		}
+		t.Logf("Script %q", scr)
+		go Robot3("Robbie", scr, act, log)
+		pls := <-rep
+		lastTest := testOneRobot[i-1]
+		if len(pls) != 1 {
+			t.Fatalf("Got report on %d robots, want 1.", len(pls))
+		}
+		pl := pls[0]
+		if pl.Name != "Robbie" {
+			t.Fatalf(`Got report for robot %q, want report for "Robbie".`,
+				pl.Name)
+		}
+		da := pl.DirAt
+		want := lastTest.DirAt
+		if da.Pos != want.Pos {
+			t.Fatalf("Script %q, Pos = %v, want %v", scr, da.Pos, want.Pos)
+		}
+		if da.Dir != want.Dir {
+			t.Fatalf("Script %q, Dir = %v, want %v", scr, da.Dir, want.Dir)
+		}
+		close(log)
+		if n := <-nMsg; n != lastTest.nMsg {
+			t.Errorf("%d sim messages logged, want %d.", n, lastTest.nMsg)
+		}
+	}
+}
+
+func TestNoName(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{1, 1}, Pos{1, 1}},
+		[]Place{{"", DirAt{N, Pos{1, 1}}}},
+		act, rep, log)
+	go Robot3("", "", act, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 1 {
+		t.Fatalf("Got %d messages, want 1.", n)
+	}
+}
+
+func TestSameName(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{1, 1}, Pos{2, 1}},
+		[]Place{
+			{"Daryl", DirAt{N, Pos{1, 1}}},
+			{"Daryl", DirAt{N, Pos{2, 1}}},
+		},
+		act, rep, log)
+	go Robot3("Daryl", "", act, log)
+	go Robot3("Daryl", "", act, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 1 {
+		t.Fatalf("Got %d messages, want 1.", n)
+	}
+}
+
+func TestSamePosition(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{1, 1}, Pos{100, 100}},
+		[]Place{
+			{"Matter", DirAt{N, Pos{23, 47}}},
+			{"Antimatter", DirAt{N, Pos{23, 47}}},
+		},
+		act, rep, log)
+	go Robot3("Matter", "", act, log)
+	go Robot3("Animatter", "", act, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 1 {
+		t.Fatalf("Got %d messages, want 1.", n)
+	}
+}
+
+func TestOutsideRoom(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{1, 1}, Pos{1, 1}},
+		[]Place{{"Elvis", DirAt{N, Pos{2, 3}}}},
+		act, rep, log)
+	go Robot3("Elvis", "", act, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 1 {
+		t.Fatalf("Got %d messages, want 1.", n)
+	}
+}
+
+func TestBadCommand(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{0, 0}, Pos{0, 99}},
+		[]Place{{"Vgr", DirAt{N, Pos{0, 99}}}},
+		act, rep, log)
+	go Robot3("Vgr", "RET", act, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 1 {
+		t.Fatalf("Got %d messages, want 1.", n)
+	}
+}
+
+func TestBadRobot(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{0, 0}, Pos{0, 0}},
+		[]Place{{"Data", DirAt{N, Pos{0, 0}}}},
+		act, rep, log)
+	go Robot3("Lore", "A", act, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 1 {
+		t.Fatalf("Got %d messages, want 1.", n)
+	}
+}
+
+func TestThree(t *testing.T) { // no bumping
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	go Robot3("clutz", "LAAARALA", act, log)
+	go Robot3("sphero", "RRAAAAALA", act, log)
+	go Robot3("roomba", "LAAARRRALLLL", act, log)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{-10, -10}, Pos{15, 10}},
+		[]Place{
+			{"clutz", DirAt{N, Pos{0, 0}}},
+			{"sphero", DirAt{E, Pos{2, -7}}},
+			{"roomba", DirAt{S, Pos{8, 4}}},
+		},
+		act, rep, log)
+	pls := <-rep
+	if len(pls) != 3 {
+		t.Fatalf("Got report on %d robots, want 3.", len(pls))
+	}
+exp:
+	for _, exp := range []Place{
+		{"clutz", DirAt{W, Pos{-4, 1}}},
+		{"sphero", DirAt{S, Pos{-3, -8}}},
+		{"roomba", DirAt{N, Pos{11, 5}}},
+	} {
+		for _, pl := range pls {
+			if pl.Name != exp.Name {
+				continue
+			}
+			if pl.DirAt.Pos != exp.DirAt.Pos {
+				t.Fatalf("%s at %v, want %v",
+					pl.Name, pl.DirAt.Pos, exp.DirAt.Pos)
+			}
+			if pl.DirAt.Dir != exp.DirAt.Dir {
+				t.Fatalf("%s facing %v, want %v",
+					pl.Name, pl.DirAt.Dir, exp.DirAt.Dir)
+			}
+			continue exp
+		}
+		t.Fatalf("Missing %d", exp.Name)
+	}
+}
+
+func TestBattle(t *testing.T) {
+	log := make(chan string)
+	nMsg := make(chan int)
+	go logMon(log, nMsg, t)
+	act := make(chan Action3)
+	go Robot3("Toro", "AAAAAAA", act, log)
+	go Robot3("Phere", "AAAAAAA", act, log)
+	rep := make(chan []Place)
+	go Room3(
+		Rect{Pos{1, 1}, Pos{9, 9}},
+		[]Place{
+			{"Toro", DirAt{E, Pos{1, 5}}},
+			{"Phere", DirAt{W, Pos{9, 5}}},
+		},
+		act, rep, log)
+	<-rep
+	close(log)
+	if n := <-nMsg; n != 7 {
+		t.Fatalf("Got %d messages, want 7.", n)
+	}
+}

--- a/robot-simulator/robot_simulator_test.go
+++ b/robot-simulator/robot_simulator_test.go
@@ -1,0 +1,62 @@
+// +build step1 !step2,!step3
+
+package robot
+
+// Tests are separated into 3 steps.
+//
+// Run all tests with `go test` or run specific tests with the -tags option.
+// Examples,
+//
+//    go test                      # run all tests
+//    go test -tags step1          # run just step 1 tests.
+//    go test -tags 'step1 step2'  # run step1 and step2 tests
+//
+// This source file contains step 1 tests only.  For other tests see
+// robot_simulator_step2_test.go and robot_simulator_step3_test.go.
+//
+// You are given the source file defs.go which defines a number of things
+// the test program requires.  It is organized into three sections by step.
+//
+// To complete step 1 you will define Right, Left, Advance, N, S, E, W,
+// and Dir.String.  Complete step 1 before moving on to step 2.
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestStep1(t *testing.T) {
+	want := func(x, y int, dir Dir) {
+		_, _, line, _ := runtime.Caller(1)
+		if X != x || Y != y {
+			t.Fatalf("(from line %d) robot at = %d, %d.  Want %d, %d.",
+				line, X, Y, x, y)
+		}
+		if Facing != dir {
+			t.Fatalf("(from line %d) robot facing %v, want %v.",
+				line, Facing, dir)
+		}
+	}
+	want(0, 0, N)
+
+	Advance()
+	want(0, 1, N)
+
+	Right()
+	want(0, 1, E)
+
+	Advance()
+	want(1, 1, E)
+
+	Left()
+	want(1, 1, N)
+
+	Left()
+	Left()
+	Advance()
+	want(1, 0, S)
+
+	Right()
+	Advance()
+	want(0, 0, W)
+}


### PR DESCRIPTION
I have reservations about this one.  There's a lot to it and I'm afraid people will find it hard.  And I worry I might have added too many requirements to the readme.  I just didn't like cutting anything out.

There's nothing much unusual in step 1.  Step 2 in the readme mentions room dimensions and I didn't see the point of that unless collisions with walls are detected.  Coordinate space plus collision avoidance is enough physics that I'm not really comfortable unless the model and calculations are encapsulated somehow.  Channels and goroutines work for this and have the advantage that the program architecture is set up for concurrency.  So maybe it's a big step from step 1, but channels and goroutines have been used in a couple other exercises before this one, so it's mostly just some refactoring to take code from step 1 and move it to the right goroutines for step 2.

Step 3 turned out quite a bit more complex.  Now step 3 in the readme really only adds scripts, but the existing test programs in other languages put multiple robots in the same room.  I just couldn't bear doing that without letting the robots run concurrently -- and adding robot-robot collision detection -- and doing error reporting.
