### PR TITLE
Rename `Sing()` to `Song()` in beer-song

### DIFF
--- a/beer-song/beer_test.go
+++ b/beer-song/beer_test.go
@@ -109,12 +109,12 @@ func BenchmarkSeveralVerses(b *testing.B) {
 	}
 }
 
-func TestSingAllVerses(t *testing.T) {
+func TestEntireSong(t *testing.T) {
 	expected, err := Verses(99, 0)
 	if err != nil {
 		t.Fatalf("unexpected error calling Verses(99,0)")
 	}
-	actual := Sing()
+	actual := Song()
 
 	if expected != actual {
 		msg := `
@@ -132,8 +132,8 @@ func TestSingAllVerses(t *testing.T) {
 	}
 }
 
-func BenchmarkSingAllVerses(b *testing.B) {
+func BenchmarkEntireSong(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		Sing()
+		Song()
 	}
 }

--- a/beer-song/example.go
+++ b/beer-song/example.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 )
 
-// Sing returns the full lyrics for 99 bottles of beer
-func Sing() (result string) {
+// Song returns the full lyrics for 99 bottles of beer
+func Song() (result string) {
 	result, _ = Verses(99, 0)
 	return
 }


### PR DESCRIPTION
The names `Verse`, `Verses`, and `Sing` were not at the same level of
abstraction. `Song` fixes this.
