### PR TITLE
add exercise circular buffer

### DIFF
--- a/circular-buffer/circular_buffer_test.go
+++ b/circular-buffer/circular_buffer_test.go
@@ -1,0 +1,177 @@
+package circular
+
+// Implement a circular buffer of bytes supporting both overflow-checked writes
+// and unconditional, possibly overwriting, writes.
+//
+//   type Buffer
+//   func NewBuffer(size int) *Buffer
+//   func (*Buffer) Read() (c byte, ok bool)
+//   func (*Buffer) Write(c byte) (ok bool)
+//   func (*Buffer) Overwrite(c byte)
+//   func (*Buffer) Clear() // clear entire buffer so that it is empty
+
+import "testing"
+
+// testBuffer and methods support the tests, providing log and fail messages.
+
+type testBuffer struct {
+	*testing.T
+	b *Buffer
+}
+
+func nb(size int, t *testing.T) testBuffer {
+	t.Logf("NewBuffer(%d)", size)
+	return testBuffer{t, NewBuffer(size)}
+}
+
+func (tb testBuffer) read(want byte) {
+	switch c, ok := tb.b.Read(); {
+	case !ok:
+		tb.Fatal("Read() returned ok = false, want true.")
+	case c != want:
+		tb.Fatalf("Read() = %c, want %c.", c, want)
+	}
+	tb.Logf("Read %c", want)
+}
+
+func (tb testBuffer) readFail() {
+	if c, ok := tb.b.Read(); ok {
+		tb.Fatalf("Read() = %c, ok want !ok", c)
+	}
+	tb.Log("Read() fail")
+}
+
+func (tb testBuffer) write(c byte) {
+	if !tb.b.Write(c) {
+		tb.Fatalf("Write(%c) returned !ok, want ok.", c)
+	}
+	tb.Logf("Write(%c)", c)
+}
+
+func (tb testBuffer) writeFail(c byte) {
+	if tb.b.Write(c) {
+		tb.Fatalf("Write(%c) returned ok, want !ok.", c)
+	}
+	tb.Logf("Write(%c) fail", c)
+}
+
+func (tb testBuffer) clear() {
+	tb.b.Clear()
+	tb.Log("Clear()")
+}
+
+func (tb testBuffer) overwrite(c byte) {
+	tb.b.Overwrite(c)
+	tb.Logf("Overwrite(%c)", c)
+}
+
+// tests.  separate functions so log will have descriptive test name.
+
+func TestReadEmptyBuffer(t *testing.T) {
+	tb := nb(1, t)
+	tb.readFail()
+}
+
+func TestWriteAndReadOneItem(t *testing.T) {
+	tb := nb(1, t)
+	tb.write('1')
+	tb.read('1')
+	tb.readFail()
+}
+
+func TestWriteAndReadMultipleItems(t *testing.T) {
+	tb := nb(2, t)
+	tb.write('1')
+	tb.write('2')
+	tb.read('1')
+	tb.read('2')
+	tb.readFail()
+}
+
+func TestClear(t *testing.T) {
+	tb := nb(3, t)
+	tb.write('1')
+	tb.write('2')
+	tb.write('3')
+	tb.clear()
+	tb.write('1')
+	tb.write('2')
+	tb.read('1')
+	tb.write('3')
+	tb.read('2')
+}
+
+func TestAlternateWriteAndRead(t *testing.T) {
+	tb := nb(2, t)
+	tb.write('1')
+	tb.read('1')
+	tb.write('2')
+	tb.read('2')
+}
+
+func TestReadOldestItem(t *testing.T) {
+	tb := nb(3, t)
+	tb.write('1')
+	tb.write('2')
+	tb.read('1')
+	tb.write('3')
+	tb.read('2')
+	tb.read('3')
+}
+
+func TestWriteFullBuffer(t *testing.T) {
+	tb := nb(2, t)
+	tb.write('1')
+	tb.write('2')
+	tb.writeFail('A')
+}
+
+func TestOverwrite(t *testing.T) {
+	tb := nb(2, t)
+	tb.write('1')
+	tb.write('2')
+	tb.overwrite('A')
+	tb.read('2')
+	tb.read('A')
+	tb.readFail()
+}
+
+func TestAlternateReadAndOverwrite(t *testing.T) {
+	tb := nb(5, t)
+	tb.write('1')
+	tb.write('2')
+	tb.write('3')
+	tb.read('1')
+	tb.read('2')
+	tb.write('4')
+	tb.read('3')
+	tb.write('5')
+	tb.write('6')
+	tb.write('7')
+	tb.write('8')
+	tb.overwrite('A')
+	tb.overwrite('B')
+	tb.read('6')
+	tb.read('7')
+	tb.read('8')
+	tb.read('A')
+	tb.read('B')
+	tb.readFail()
+}
+
+func BenchmarkOverwrite(b *testing.B) {
+	c := NewBuffer(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Overwrite(0)
+	}
+}
+
+func BenchmarkWriteRead(b *testing.B) {
+	c := NewBuffer(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Write(0)
+		c.Read()
+	}
+}

--- a/circular-buffer/example.go
+++ b/circular-buffer/example.go
@@ -1,0 +1,55 @@
+package circular
+
+// standard library container/ring package and "one slot open" technique
+// as described at WP.
+
+import "container/ring"
+
+// Buffer implements a circular buffer supporting both overflow-checked writes
+// and unconditional, possibly overwriting, writes.
+type Buffer struct {
+	start, end *ring.Ring
+}
+
+// NewBuffer constructs a new empty circular buffer.
+func NewBuffer(size int) *Buffer {
+	r := ring.New(size + 1)
+	return &Buffer{r, r}
+}
+
+// Read removes one byte from the buffer and returns it.
+// Read returns ok = false if the buffer is empty.
+func (b *Buffer) Read() (c byte, ok bool) {
+	if b.start == b.end {
+		return 0, false
+	}
+	c = b.start.Value.(byte)
+	b.start = b.start.Next()
+	return c, true
+}
+
+// Write puts byte c in the buffer and returns true as long as there is room
+// in the buffer.  Write returns false if the buffer is full.
+func (b *Buffer) Write(c byte) bool {
+	if b.end.Next() == b.start {
+		return false
+	}
+	b.end.Value = c
+	b.end = b.end.Next()
+	return true
+}
+
+// Overwrite unconditionally puts byte c in the buffer.  If the buffer was
+// already full, c overwrites the oldest byte in the buffer.
+func (b *Buffer) Overwrite(c byte) {
+	b.end.Value = c
+	b.end = b.end.Next()
+	if b.end == b.start {
+		b.start = b.start.Next()
+	}
+}
+
+// Clear clears the buffer, leaving it empty.
+func (b *Buffer) Clear() {
+	b.start = b.end
+}

--- a/config.json
+++ b/config.json
@@ -36,6 +36,7 @@
     "rna-transcription",
     "roman-numerals",
     "say",
+    "circular-buffer",
     "robot-name",
     "custom-set",
     "atbash-cipher",


### PR DESCRIPTION
Test program is pretty close to the Ruby and Javascript programs, but it tests a buffer of bytes rather than arbitrary types.  A fixed type seemed more Go-like.  Given this, the rule of ignoring nil makes no sense so I skipped that.

The example uses the container/ring type from the standard library.  This has some inefficiencies compared a slice-based algorithm like in the Ruby or JS examples or like others described on WP, but it's slightly easier.
