### PR TITLE
Fix reset test, because currently passed with an empty 'Reset()' functio...

### DIFF
--- a/circular-buffer/circular_buffer_test.go
+++ b/circular-buffer/circular_buffer_test.go
@@ -119,10 +119,10 @@ func TestReset(t *testing.T) {
 	tb.write('3')
 	tb.reset()
 	tb.write('1')
-	tb.write('2')
-	tb.read('1')
 	tb.write('3')
-	tb.read('2')
+	tb.read('1')
+	tb.write('4')
+	tb.read('3')
 }
 
 func TestAlternateWriteAndRead(t *testing.T) {


### PR DESCRIPTION
Hi,

Fixed 'TestReset()' function in circular-buffer, it passed with an empty 'Reset()' function too, because the same values were add before and after reset as well.

Cheers,
Norbert
