### PR TITLE
Comparing structs should use reflect.DeepEqual

### DIFF
--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -1,6 +1,9 @@
 package clock
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 var newTests = []struct {
 	h, m int
@@ -53,13 +56,14 @@ func TestClock(t *testing.T) {
 	clock1 := New(15, 37)
 	clock2 := New(15, 36)
 	clock3 := New(14, 37)
-	if clock0 != clock1 {
+	if !reflect.DeepEqual(clock0, clock1) {
 		t.Fatal(clock0, "!=", clock1, "want ==")
 	}
-	if clock2 == clock1 {
+	if reflect.DeepEqual(clock1, clock2) {
 		t.Fatal(clock2, "==", clock1, "want !=")
 	}
-	if clock3 == clock1 {
+	if reflect.DeepEqual(clock1, clock3) {
 		t.Fatal(clock3, "==", clock1, "want !=")
 	}
+
 }


### PR DESCRIPTION
This test fails with the current code, as it checks if two structs are equal by using the comparison operator == instead of using reflect's DeepEqual().

"DeepEqual tests for deep equality. It uses normal == equality where possible but will scan elements of arrays, slices, maps, and fields of structs. In maps, keys are compared with == but elements use deep equality. DeepEqual correctly handles recursive types. Functions are equal only if they are both nil. An empty slice is not equal to a nil slice."
http://golang.org/pkg/reflect/#DeepEqual
