### PR TITLE
clock: test program modified to use common data

### DIFF
--- a/clock/cases_test.go
+++ b/clock/cases_test.go
@@ -1,0 +1,78 @@
+package clock
+
+// Source: exercism/x-common
+// Commit: 6bf749c Merge pull request #32 from soniakeys/test-data
+
+// Test creating a new clock with an initial time.
+var newTests = []struct {
+	h, m int
+	want string
+}{
+	{8, 0, "08:00"},      // on the hour
+	{9, 0, "09:00"},      // on the hour
+	{11, 9, "11:09"},     // past the hour
+	{11, 19, "11:19"},    // past the hour
+	{24, 0, "00:00"},     // midnight is zero hours
+	{25, 0, "01:00"},     // hour rolls over
+	{1, 60, "02:00"},     // sixty minutes is next hour
+	{0, 160, "02:40"},    // minutes roll over
+	{25, 160, "03:40"},   // hour and minutes roll over
+	{-1, 15, "23:15"},    // negative hour
+	{-25, 0, "23:00"},    // negative hour rolls over
+	{1, -40, "00:20"},    // negative minutes
+	{1, -160, "22:20"},   // negative minutes roll over
+	{-25, -160, "20:20"}, // negative hour and minutes both roll over
+}
+
+// Test adding and subtracting minutes.
+var addTests = []struct {
+	h, m, a int
+	want    string
+}{
+	{10, 0, 3, "10:03"},     // add minutes
+	{0, 45, 40, "01:25"},    // add to next hour
+	{10, 0, 61, "11:01"},    // add more than one hour
+	{23, 59, 2, "00:01"},    // add across midnight
+	{5, 32, 1500, "06:32"},  // add more than one day (1500 min = 25 hrs)
+	{0, 45, 160, "03:25"},   // add more than two hours with carry
+	{10, 3, -3, "10:00"},    // subtract minutes
+	{10, 3, -30, "09:33"},   // subtract to previous hour
+	{10, 3, -70, "08:53"},   // subtract more than an hour
+	{0, 3, -4, "23:59"},     // subtract across midnight
+	{0, 0, -160, "21:20"},   // subtract more than two hours
+	{5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
+	{6, 15, -160, "03:35"},  // subtract more than two hours with borrow
+}
+
+// Construct two separate clocks, set times, test if they are equal.
+type hm struct{ h, m int }
+
+var eqTests = []struct {
+	c1, c2 hm
+	want   bool
+}{
+	// clocks with same time
+	{
+		hm{15, 37},
+		hm{15, 37},
+		true,
+	},
+	// clocks a minute apart
+	{
+		hm{15, 36},
+		hm{15, 37},
+		false,
+	},
+	// clocks an hour apart
+	{
+		hm{14, 37},
+		hm{15, 37},
+		false,
+	},
+	// clocks set 24 hours apart
+	{
+		hm{10, 37},
+		hm{34, 37},
+		true,
+	},
+}

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -2,64 +2,44 @@ package clock
 
 import "testing"
 
-var newTests = []struct {
-	h, m int
-	disp string
-}{
-	{8, 0, "08:00"},
-	{9, 0, "09:00"},
-	{11, 9, "11:09"},
-}
+const testVersion = 1
 
-var addTests = []struct {
-	h, m, a int
-	disp    string
-}{
-	{10, 0, 3, "10:03"},   // simple
-	{10, 0, 61, "11:01"},  // add > 1 hour
-	{23, 30, 60, "00:30"}, // add across midnight
-	{10, 0, -90, "08:30"}, // subtract > 1 hour
-	{0, 30, -60, "23:30"}, // subtract across midnight
+// Retired testVersions
+// (none) 79937f6d58e25ebafe12d1cb4a9f88f4de70cfd6
 
-	{0, 45, 40, "01:25"},   // hour carry
-	{1, 25, -40, "00:45"},  // hour borrow
-	{23, 45, 40, "00:25"},  // carry across midnight
-	{0, 25, -40, "23:45"},  // borrow across midnight
-	{0, 0, 160, "02:40"},   // add > 2 hrs
-	{0, 45, 160, "03:25"},  // add > 2 hrs with carry
-	{0, 0, -160, "21:20"},  // subtract > 2 hrs
-	{6, 15, -160, "03:35"}, // subtract > 2 hrs with borrow
-
-	{0, 160, 0, "02:40"},  // initial minutes roll over
-	{25, 0, 0, "01:00"},   // initial hour rolls over
-	{25, 160, 0, "03:40"}, // both rollover
-	{0, -160, 0, "21:20"}, // same cases, negative
-	{-25, 0, 0, "23:00"},
-	{-25, -160, 0, "20:20"},
-}
-
-func TestClock(t *testing.T) {
+func TestNewClock(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, n := range newTests {
-		if c := New(n.h, n.m); c.String() != n.disp {
-			t.Fatalf("New(%d, %d) = %q, want %q", n.h, n.m, c, n.disp)
+		if got := New(n.h, n.m); got.String() != n.want {
+			t.Fatalf("New(%d, %d) = %q, want %q", n.h, n.m, got, n.want)
 		}
 	}
+	t.Log(len(newTests), "test cases")
+}
+
+func TestAddMinutes(t *testing.T) {
 	for _, a := range addTests {
-		if c := New(a.h, a.m).Add(a.a); c.String() != a.disp {
-			t.Fatalf("New(%d, %d).Add(%d) = %q, want %q", a.h, a.m, a.a, c, a.disp)
+		if got := New(a.h, a.m).Add(a.a); got.String() != a.want {
+			t.Fatalf("New(%d, %d).Add(%d) = %q, want %q",
+				a.h, a.m, a.a, got, a.want)
 		}
 	}
-	clock0 := New(15, 37)
-	clock1 := New(15, 37)
-	clock2 := New(15, 36)
-	clock3 := New(14, 37)
-	if clock0 != clock1 {
-		t.Fatal(clock0, "!=", clock1, "want ==")
+	t.Log(len(addTests), "test cases")
+}
+
+func TestCompareClocks(t *testing.T) {
+	for _, e := range eqTests {
+		clock1 := New(e.c1.h, e.c1.m)
+		clock2 := New(e.c2.h, e.c2.m)
+		got := clock1 == clock2
+		if got != e.want {
+			t.Log("Clock1:", clock1)
+			t.Log("Clock2:", clock2)
+			op := map[bool]string{true: "==", false: "!="}
+			t.Fatal("Clock1, clock2 compare", op[got], "want", op[e.want])
+		}
 	}
-	if clock2 == clock1 {
-		t.Fatal(clock2, "==", clock1, "want !=")
-	}
-	if clock3 == clock1 {
-		t.Fatal(clock3, "==", clock1, "want !=")
-	}
+	t.Log(len(eqTests), "test cases")
 }

--- a/clock/example.go
+++ b/clock/example.go
@@ -2,6 +2,8 @@ package clock
 
 import "fmt"
 
+const TestVersion = 1
+
 type Clock int
 
 func New(h, m int) Clock {

--- a/clock/example_gen.go
+++ b/clock/example_gen.go
@@ -1,0 +1,177 @@
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func getPath() (jPath, jOri, jCommit string) {
+	// Ideally draw from a .json which is pulled from the official x-common
+	// repository.  For development however, accept a file in current directory
+	// if there is no .json in source control.  Also allow an override in any
+	// case by environment variable.
+	if jPath = os.Getenv("EXTEST"); jPath > "" {
+		return jPath, "local file", "" // override
+	}
+	c := exec.Command("git", "show", "--oneline", "HEAD")
+	c.Dir = "../../../exercism/x-common"
+	ori, err := c.Output()
+	if err != nil {
+		return "", "local file", "" // not in source control
+	}
+	// good.  return source control dir and commit.
+	return c.Dir, "exercism/x-common", string(bytes.TrimSpace(ori))
+}
+
+func main() {
+	jPath, jOri, jCommit := getPath()
+	d, err := ioutil.ReadFile(filepath.Join(jPath, "clock.json"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	j := &js{}
+	if err = json.Unmarshal(d, j); err != nil {
+		// This error message is usually enough if the problem is a wrong
+		// data structure defined here. Sadly it doesn't locate the error well
+		// in the case of invalid JSON.  Use a real validator tool if you can't
+		// spot the problem right away.
+		log.Print(`unexpected data structure`)
+		log.Fatal(err)
+	}
+	gen(j, jPath, jOri, jCommit)
+}
+
+// The JSON structure we expect to be able to umarshal into
+type js struct {
+	Create struct {
+		Description []string
+		Cases       []newCase
+	}
+	Add struct {
+		Description []string
+		Cases       []addCase
+	}
+	Equal struct {
+		Description []string
+		Cases       []eqCase
+	}
+}
+
+// Handle the three tests similarly
+
+type newCase struct {
+	Description  string
+	Hour, Minute int
+	Expected     string
+}
+
+func genNewTests(f *os.File, j *js) {
+	// json.Unmarshal will happily skip parts of the data structure that
+	// don't match.  Check here that we really got some data.
+	if len(j.Create.Cases) == 0 {
+		log.Fatal(`Missing "Create" test cases`)
+	}
+	genCmts(f, j.Create.Description)
+	fmt.Fprintln(f, `var newTests = []struct {
+	h, m int
+	want string
+}{`)
+	for i := range j.Create.Cases {
+		tc := &j.Create.Cases[i]
+		fmt.Fprintf(f, "{%d, %d, %q}, // %s\n",
+			tc.Hour, tc.Minute, tc.Expected, tc.Description)
+	}
+	fmt.Fprint(f, "}\n\n")
+}
+
+type addCase struct {
+	Description       string
+	Hour, Minute, Add int
+	Expected          string
+}
+
+func genAddTests(f *os.File, j *js) {
+	// generate addTests
+	if len(j.Add.Cases) == 0 {
+		log.Fatal(`Missing "Add" test cases`)
+	}
+	genCmts(f, j.Add.Description)
+	fmt.Fprintln(f, `var addTests = []struct {
+	h, m, a int
+	want    string
+}{`)
+	for i := range j.Add.Cases {
+		tc := &j.Add.Cases[i]
+		fmt.Fprintf(f, "{%d, %d, %d, %q}, // %s\n",
+			tc.Hour, tc.Minute, tc.Add, tc.Expected, tc.Description)
+	}
+	fmt.Fprint(f, "}\n\n")
+}
+
+type eqCase struct {
+	Description    string
+	Clock1, Clock2 struct{ Hour, Minute int }
+	Expected       bool
+}
+
+func genEqTests(f *os.File, j *js) {
+	if len(j.Equal.Cases) == 0 {
+		log.Fatal(`Missing "Equal" test cases`)
+	}
+	genCmts(f, j.Equal.Description)
+	fmt.Fprintln(f, `type hm struct{ h, m int }
+
+var eqTests = []struct {
+	c1, c2 hm
+	want   bool
+}{`)
+	for i := range j.Equal.Cases {
+		tc := &j.Equal.Cases[i]
+		fmt.Fprintf(f, `// %s
+{
+	hm{%d, %d},
+	hm{%d, %d},
+	%t,
+},
+`, tc.Description,
+			tc.Clock1.Hour, tc.Clock1.Minute,
+			tc.Clock2.Hour, tc.Clock2.Minute,
+			tc.Expected)
+	}
+	fmt.Fprintln(f, "}")
+}
+
+func gen(j *js, jPath, jOri, jCommit string) {
+	f, err := os.Create("cases_test.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	fmt.Fprintln(f, "package clock\n")
+
+	fmt.Fprintln(f, "// Source:", jOri)
+	if jCommit > "" {
+		fmt.Fprintf(f, "// Commit: %s\n\n", jCommit)
+	}
+
+	genNewTests(f, j)
+	genAddTests(f, j)
+	genEqTests(f, j)
+
+	exec.Command("go", "fmt", "cases_test.go").Run()
+}
+
+func genCmts(f *os.File, cmts []string) {
+	for _, c := range cmts {
+		fmt.Fprintln(f, "//", c)
+	}
+}


### PR DESCRIPTION
Generates test data from JSON in x-common.  This brings some minor changes to the test cases as a result of looking through other languages and collecting a common core of test cases.  I don't expect it to break existing Go solutions though except for the addition of TestVersion.

The new file `cases_test.go` should get fetched by the client.  The new file `example_gen.go` should not get fetched.
