### PR TITLE
gigasecond: test prog rewrite

### DIFF
--- a/gigasecond/cases_test.go
+++ b/gigasecond/cases_test.go
@@ -1,0 +1,23 @@
+package gigasecond
+
+// Source: exercism/x-common
+// Commit: f362340 Merge pull request #36 from soniakeys/gigasecond-test-data
+
+// Add one gigasecond to the input.
+var addCases = []struct {
+	in   string
+	want string
+}{
+	{
+		"2011-04-25",
+		"2043-01-01T01:46:40",
+	},
+	{
+		"1977-06-13",
+		"2009-02-19T01:46:40",
+	},
+	{
+		"1959-07-19",
+		"1991-03-27T01:46:40",
+	},
+}

--- a/gigasecond/example.go
+++ b/gigasecond/example.go
@@ -2,10 +2,11 @@ package gigasecond
 
 import "time"
 
-// A gigasecond is 10^9 seconds.
-const Gigasecond time.Duration = 1e9 * time.Second
+const TestVersion = 1
 
-// AddGigasecond returns the time t + Gigasecond.
+// AddGigasecond returns time t plus one gigasecond.
 func AddGigasecond(t time.Time) time.Time {
-	return t.Add(Gigasecond)
+	return t.Add(1e9 * time.Second)
 }
+
+var Birthday = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/gigasecond/example_gen.go
+++ b/gigasecond/example_gen.go
@@ -1,0 +1,114 @@
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
+)
+
+// Code at the beginning here is not specific to gigasecond.
+// It could be used for other problems.
+
+func getPath() (jPath, jOri, jCommit string) {
+	// Ideally draw from a .json which is pulled from the official x-common
+	// repository.  For development however, accept a file in current directory
+	// if there is no .json in source control.  Also allow an override in any
+	// case by environment variable.
+	if jPath = os.Getenv("EXTEST"); jPath > "" {
+		return jPath, "local file", "" // override
+	}
+	c := exec.Command("git", "show", "--oneline", "HEAD")
+	c.Dir = "../../../exercism/x-common"
+	ori, err := c.Output()
+	if err != nil {
+		return "", "local file", "" // no source control
+	}
+	if _, err = os.Stat(filepath.Join(c.Dir, jFile)); err != nil {
+		return "", "local file", "" // not in source control
+	}
+	// good.  return source control dir and commit.
+	return c.Dir, "exercism/x-common", string(bytes.TrimSpace(ori))
+}
+
+func main() {
+	jPath, jOri, jCommit := getPath()
+	d, err := ioutil.ReadFile(filepath.Join(jPath, jFile))
+	if err != nil {
+		log.Fatal(err)
+	}
+	j := &js{}
+	if err = json.Unmarshal(d, j); err != nil {
+		// This error message is usually enough if the problem is a wrong
+		// data structure defined here. Sadly it doesn't locate the error well
+		// in the case of invalid JSON.  Use a real validator tool if you can't
+		// spot the problem right away.
+		log.Print(`unexpected data structure`)
+		log.Fatal(err)
+	}
+	gen(j, jPath, jOri, jCommit)
+}
+
+func gen(j *js, jPath, jOri, jCommit string) {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	f, err := os.Create("cases_test.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	d := struct {
+		Ori    string
+		Commit string
+		J      *js
+	}{jOri, jCommit, j}
+	if err = t.Execute(f, &d); err != nil {
+		log.Print(err)
+		return
+	}
+	if exec.Command("go", "fmt", "cases_test.go").Run(); err != nil {
+		log.Print(err)
+		return
+	}
+}
+
+// Code from here on is gigasecond-specific definitions.
+
+const jFile = "gigasecond.json"
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Add struct {
+		Description []string
+		Cases       []struct {
+			Input    string
+			Expected string
+		}
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package gigasecond
+
+// Source: {{.Ori}}
+{{if .Commit}}// Commit: {{.Commit}}
+{{end}}
+{{range .J.Add.Description}}// {{.}}
+{{end}}var addCases = []struct {
+	in   string
+	want string
+}{
+{{range .J.Add.Cases}}{
+	{{printf "%q" .Input}},
+	{{printf "%q" .Expected}},
+},
+{{end}}}
+`

--- a/gigasecond/gigasecond_test.go
+++ b/gigasecond/gigasecond_test.go
@@ -1,32 +1,69 @@
 package gigasecond
 
+// Write a function AddGigasecond that works with time.Time.
+// Also define a variable Birthday set to your (or someone else's) birthday.
+// Run go test -v to see your gigasecond anniversary.
+
 import (
-	"math/rand"
+	"os"
 	"testing"
 	"time"
 )
 
-func TestGigasecond(t *testing.T) {
-	if Gigasecond != 1e18 {
-		t.Fatalf("Gigasecond is incorrectly defined.")
-	}
-}
+const testVersion = 1
+
+// Retired testVersions
+// (none) 98807b314216ff27492378a00df60410cc971d32
+
+// date formats used in test data
+const (
+	fmtD  = "2006-01-02"
+	fmtDT = "2006-01-02T15:04:05"
+)
 
 func TestAddGigasecond(t *testing.T) {
-	for i := 0; i < 100; i++ {
-		ns := rand.Int63()
-		input := time.Unix(0, ns)
-		expect := time.Unix(1e9, ns)
-		output := AddGigasecond(input)
-		if !output.Equal(expect) {
-			t.Fatalf("AddGigasecond(%v): got %v; want %v", input, output, expect)
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v.", TestVersion, testVersion)
+	}
+	for _, tc := range addCases {
+		in := parse(tc.in, fmtD, t)
+		want := parse(tc.want, fmtDT, t)
+		got := AddGigasecond(in)
+		if !got.Equal(want) {
+			t.Fatalf(`AddGigasecond(%s)
+   = %s
+want %s`, in, got, want)
 		}
 	}
+	t.Log("Tested", len(addCases), "cases.")
+}
+
+func TestYourAnniversary(t *testing.T) {
+	t.Logf(`
+Your birthday:               %s
+Your gigasecond anniversary: %s`, Birthday, AddGigasecond(Birthday))
+}
+
+func parse(s string, f string, t *testing.T) time.Time {
+	tt, err := time.Parse(f, s)
+	if err != nil {
+		// can't run tests if input won't parse.  if this seems to be a
+		// development or ci environment, raise an error.  if this condition
+		// makes it to the solver though, ask for a bug report.
+		_, statErr := os.Stat("example_gen.go")
+		if statErr == nil || os.Getenv("TRAVIS_GO_VERSION") > "" {
+			t.Fatal(err)
+		} else {
+			t.Log(err)
+			t.Skip("(Not your problem.  " +
+				"please file issue at https://github.com/exercism/xgo.)")
+		}
+	}
+	return tt
 }
 
 func BenchmarkAddGigasecond(b *testing.B) {
-	t := time.Unix(123456789, 123456789)
 	for i := 0; i < b.N; i++ {
-		AddGigasecond(t)
+		AddGigasecond(time.Time{})
 	}
 }


### PR DESCRIPTION
This addresses the first point of https://github.com/exercism/xgo/issues/110 by removing the requirement to define a Gigasecond value.  The second point of https://github.com/exercism/xgo/issues/110 doesn't seem called for by either the problem or the Go documentation of the time.Time type.  The Go documentation says "[Changing the location] changes only the presentation; it does not change the instant in time being denoted and therefore does not affect the computations...."  I see location as a non-issue for this problem.

For the exercise to "enter your birthday," the solver must now define a variable in the submitted program.  This allows discussion on various ways to initialize a time.Time.  Also TestVersion is added.  These are the API changes.

The test program now uses common test data from x-common.  Example_gen.go generates this.  Example_gen.go has a different structure than the one for clock.  This one uses Go text/templates as a step toward reuse of generation code in the future.
