### PR TITLE
clock: restore type-safety for different types of cases

### DIFF
--- a/exercises/clock/.meta/gen.go
+++ b/exercises/clock/.meta/gen.go
@@ -70,8 +70,10 @@ var tmpl = `package clock
 	h, m int
 	want string
 }{ {{range .J.Groups}} {{range .Cases}}
-{{if .IsTimeCase}}{ {{.Hour}}, {{.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
-{{- end}}{{end}}{{end}} }
+{{- if .IsTimeCase}}
+	{ {{.Hour}}, {{.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+{{- end}}{{end}}{{end}}
+}
 
 {{with .J.Groups}}
     // {{ .GroupComment "add"}}
@@ -79,8 +81,10 @@ var tmpl = `package clock
 	h, m, a int
 	want string
 }{ {{range .J.Groups}} {{range .Cases}}
-{{if .IsAddCase}}{ {{.Hour}}, {{.Minute}}, {{.Add}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
-{{- end}}{{end}}{{end}} }
+{{- if .IsAddCase}}
+	{ {{.Hour}}, {{.Minute}}, {{.Add}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+{{- end}}{{end}}{{end}}
+}
 
 {{with .J.Groups}}
     // {{ .GroupComment "equal"}}
@@ -90,7 +94,8 @@ var eqTests = []struct {
 	c1, c2 hm
 	want   bool
 }{ {{range .J.Groups}} {{range .Cases}}
-{{if .IsEqualCase}} // {{.Description}}
+{{- if .IsEqualCase}}
+// {{.Description}}
 {
 	hm{ {{.Clock1.Hour}}, {{.Clock1.Minute}}},
 	hm{ {{.Clock2.Hour}}, {{.Clock2.Minute}}},

--- a/exercises/clock/.meta/gen.go
+++ b/exercises/clock/.meta/gen.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 	"text/template"
 
@@ -20,86 +21,73 @@ func main() {
 
 // The JSON structure we expect to be able to umarshal into
 type js struct {
-	Groups TestGroups `json:"Cases"`
+	Groups []testGroup `json:"Cases"`
 }
 
-type TestGroups []struct {
+type testGroup struct {
 	Description string
-	Cases       []OneCase
-}
-
-type OneCase struct {
-	Description string
-	Property    string
-	Hour        int // "create"/"add" cases
-	Minute      int // "create"/"add" cases
-	Add         int // "add" cases only
-
-	Clock1   struct{ Hour, Minute int } // "equal" cases only
-	Clock2   struct{ Hour, Minute int } // "equal" cases only
-	Expected interface{}                // string or bool
-}
-
-func (c OneCase) IsTimeCase() bool  { return c.Property == "create" }
-func (c OneCase) IsAddCase() bool   { return c.Property == "add" }
-func (c OneCase) IsEqualCase() bool { return c.Property == "equal" }
-
-func (groups TestGroups) GroupComment(property string) string {
-	for _, group := range groups {
-		propertyGroupMatch := true
-		for _, testcase := range group.Cases {
-			if testcase.Property != property {
-				propertyGroupMatch = false
-				break
-			}
-		}
-		if propertyGroupMatch {
-			return group.Description
-		}
-	}
-	return "Note: Apparent inconsistent use of \"property\": \"" + property + "\" within test case group!"
+	Cases       []json.RawMessage `property:"RAW"`
+	CreateCases []struct {
+		Description  string
+		Hour, Minute int
+		Expected     string
+	} `property:"create"`
+	AddCases []struct {
+		Description       string
+		Hour, Minute, Add int
+		Expected          string
+	} `property:"add"`
+	EqCases []struct {
+		Description    string
+		Clock1, Clock2 struct{ Hour, Minute int }
+		Expected       bool
+	} `property:"equal"`
 }
 
 var tmpl = `package clock
 
 {{.Header}}
 
-{{with .J.Groups}}
-    // {{ .GroupComment "create"}}
-{{end}} var timeTests = []struct {
-	h, m int
-	want string
-}{ {{range .J.Groups}} {{range .Cases}}
-{{- if .IsTimeCase}}
-	{ {{.Hour}}, {{.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
-{{- end}}{{end}}{{end}}
-}
+{{range .J.Groups}}
+	// {{ .Description }}
 
-{{with .J.Groups}}
-    // {{ .GroupComment "add"}}
-{{end}} var addTests = []struct {
-	h, m, a int
-	want string
-}{ {{range .J.Groups}} {{range .Cases}}
-{{- if .IsAddCase}}
-	{ {{.Hour}}, {{.Minute}}, {{.Add}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
-{{- end}}{{end}}{{end}}
-}
+	{{- if .CreateCases }}
+		var timeTests = []struct {
+			h, m int
+			want string
+		}{
+			{{- range .CreateCases }}
+				{ {{.Hour}}, {{.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+			{{- end }}
+		}
+	{{- end }}
 
-{{with .J.Groups}}
-    // {{ .GroupComment "equal"}}
-{{end}} type hm struct{ h, m int }
+	{{- if .AddCases }}
+		var addTests = []struct {
+			h, m, a int
+			want string
+		}{
+			{{- range .AddCases }}
+				{ {{.Hour}}, {{.Minute}}, {{.Add}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+			{{- end }}
+		}
+	{{- end }}
 
-var eqTests = []struct {
-	c1, c2 hm
-	want   bool
-}{ {{range .J.Groups}} {{range .Cases}}
-{{- if .IsEqualCase}}
-// {{.Description}}
-{
-	hm{ {{.Clock1.Hour}}, {{.Clock1.Minute}}},
-	hm{ {{.Clock2.Hour}}, {{.Clock2.Minute}}},
-	{{.Expected}},
-}, {{- end}}{{end}}{{end}}
-}
+	{{- if .EqCases }}
+		type hm struct{ h, m int }
+		var eqTests = []struct {
+			c1, c2 hm
+			want   bool
+		}{
+			{{- range .EqCases }}
+				// {{.Description}}
+				{
+					hm{ {{.Clock1.Hour}}, {{.Clock1.Minute}}},
+					hm{ {{.Clock2.Hour}}, {{.Clock2.Minute}}},
+					{{.Expected}},
+				},
+			{{- end }}
+		}
+	{{- end }}
+{{end}}
 `

--- a/exercises/clock/cases_test.go
+++ b/exercises/clock/cases_test.go
@@ -28,7 +28,6 @@ var timeTests = []struct {
 	{1, -4820, "16:40"},    // negative minutes roll over continuously
 	{-25, -160, "20:20"},   // negative hour and minutes both roll over
 	{-121, -5810, "22:10"}, // negative hour and minutes both roll over continuously
-
 }
 
 // Test adding and subtracting minutes.
@@ -36,7 +35,6 @@ var addTests = []struct {
 	h, m, a int
 	want    string
 }{
-
 	{10, 0, 3, "10:03"},     // add minutes
 	{6, 41, 0, "06:41"},     // add no minutes
 	{0, 45, 40, "01:25"},    // add to next hour
@@ -53,7 +51,6 @@ var addTests = []struct {
 	{6, 15, -160, "03:35"},  // subtract more than two hours with borrow
 	{5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
 	{2, 20, -3000, "00:20"}, // subtract more than two days
-
 }
 
 // Construct two separate clocks, set times, test if they are equal.
@@ -63,7 +60,6 @@ var eqTests = []struct {
 	c1, c2 hm
 	want   bool
 }{
-
 	// clocks with same time
 	{
 		hm{15, 37},

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -130,6 +130,10 @@ func Gen(exercise string, j interface{}, t *template.Template) error {
 		return fmt.Errorf(`didn't contain version: %v`, err)
 	}
 
+	if err := classifyByProperty(j); err != nil {
+		return fmt.Errorf("couldn't auto-classify based on property: %v", err)
+	}
+
 	// package up a little meta data
 	d := struct {
 		Header

--- a/gen/property.go
+++ b/gen/property.go
@@ -1,0 +1,70 @@
+package gen
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+const tagName = "property"
+
+func classifyByProperty(group interface{}) error {
+	v := reflect.ValueOf(group)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("Can only classify pointers, not %s (%v)", v.Kind(), v)
+	}
+
+	e := v.Elem()
+	t := e.Type()
+
+	var raws []json.RawMessage
+	properties := make(map[string]reflect.Value)
+
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get(tagName)
+		field := e.Field(i)
+		if tag == "RAW" {
+			raws = field.Interface().([]json.RawMessage)
+		} else if tag != "" {
+			properties[tag] = field
+		} else {
+			switch field.Kind() {
+			case reflect.Slice:
+				elem := field.Type().Elem()
+				if elem.Kind() == reflect.Struct {
+					for j := 0; j < field.Len(); j++ {
+						err := classifyByProperty(field.Index(j).Addr().Interface())
+						if err != nil {
+							return fmt.Errorf("Couldn't classify %s element %d: %s", t.Field(i).Name, j, err)
+						}
+					}
+				}
+			case reflect.Struct:
+				err := classifyByProperty(field.Addr().Interface())
+				if err != nil {
+					return fmt.Errorf("Couldn't classify %s: %s", t.Field(i).Name, err)
+				}
+			}
+		}
+	}
+
+	for _, raw := range raws {
+		var prop struct {
+			Property string
+		}
+		if err := json.Unmarshal(raw, &prop); err != nil {
+			return err
+		}
+		caseSlice, ok := properties[prop.Property]
+		if !ok {
+			return fmt.Errorf("Found property %s but no element tagged with that property", prop.Property)
+		}
+		oneCase := reflect.New(caseSlice.Type().Elem()).Interface()
+		if err := json.Unmarshal(raw, &oneCase); err != nil {
+			return err
+		}
+		caseSlice.Set(reflect.Append(caseSlice, reflect.ValueOf(oneCase).Elem()))
+	}
+
+	return nil
+}


### PR DESCRIPTION
~~This PR should not be merged yet... but it should still be reviewed, to see how close to being mergeable it is.~~

This PR is probably ready to merge, but I'll clean up some commits and move the history to a different branch.

The question to ask is: "Would I rather write a generator using this interface than the existing one?"

---

Seeing how this looks. I'm not convinced it's better, but maybe it can be used as a starting point to make things better. That is why I say do not merge, but if we get a good idea out of it it could be.

Clock updated to 1.0.1 and I have code that works for it too, but I want to compare clock 1.0.0 code vs clock 1.0.0 code, so I reverted the 1.0.1 changes (they can be applied later)