### PR TITLE
Fixed perfect_number false positive and equaling types. Closes #712

### DIFF
--- a/exercises/perfect-numbers/perfect_numbers_test.go
+++ b/exercises/perfect-numbers/perfect_numbers_test.go
@@ -40,3 +40,25 @@ func TestClassifiesCorrectly(t *testing.T) {
 		}
 	}
 }
+
+// Test that the classifications are not equal to each other.
+// If they are equal, then the tests will return false positives.
+func TestClassificationsNotEqual(t *testing.T) {
+	classifications := []struct {
+		class Classification
+		name  string
+	}{
+		{ClassificationAbundant, "ClassificationAbundant"},
+		{ClassificationDeficient, "ClassificationDeficient"},
+		{ClassificationPerfect, "ClassificationPerfect"},
+	}
+
+	for i, pair1 := range classifications {
+		for j := i + 1; j < len(classifications); j++ {
+			pair2 := classifications[j]
+			if pair1.class == pair2.class {
+				t.Fatalf("%s should not be equal to %s", pair1.name, pair2.name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
As issue #712 lays out, this test makes sure that the constants created from the Classification interface, will not equal each other providing a false positive for `go test`.