### PR TITLE
pangram: Remove non-ASCII compatible test cases

### DIFF
--- a/exercises/pangram/example.go
+++ b/exercises/pangram/example.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-const testVersion = 1
+const testVersion = 2
 
 func IsPangram(s string) bool {
 	lowerString := strings.ToLower(s)

--- a/exercises/pangram/pangram.go
+++ b/exercises/pangram/pangram.go
@@ -1,5 +1,5 @@
 package pangram
 
-const testVersion = 1
+const testVersion = 2
 
 func IsPangram(string) bool

--- a/exercises/pangram/pangram_test.go
+++ b/exercises/pangram/pangram_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
+const targetTestVersion = 2
 
 type testCase struct {
 	input         string
@@ -20,8 +20,6 @@ var testCases = []testCase{
 	{"the 1 quick brown fox jumps over the 2 lazy dogs", true, ""},
 	{"7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog", false, "missing letters replaced by numbers"},
 	{"\"Five quacking Zephyrs jolt my wax bed.\"", true, ""},
-	{"Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.", true, ""},
-	{"Широкая электрификация южных губерний даст мощный толчок подъёму сельского хозяйства.", false, "Panagram in alphabet other than ASCII"},
 }
 
 func TestTestVersion(t *testing.T) {


### PR DESCRIPTION
This brings the tests into consistency with the README.

Resolves #801, also see #802