### PR TITLE
Add two-fer exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -20,6 +20,17 @@
       ]
     },
     {
+      "uuid": "dc4ad67d-0fe4-0880-5a13-3aebb8759bcc3095de1",
+      "slug": "two-fer",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "Control-flow (conditionals)",
+        "Strings"
+      ]
+    },
+    {
       "uuid": "52582415-8f7f-4ac5-857f-5c160ec48134",
       "slug": "hamming",
       "core": true,

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -1,0 +1,66 @@
+# Two Fer
+
+`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+
+```
+"One for X, one for me."
+```
+
+When X is a name or "you".
+
+If the given name is "Alice", the result should be "One for Alice, one for me."
+If no name is given, the result should be "One for you, one for me."
+
+
+## Test-Driven Development
+
+As programmers mature, they eventually want to test their code.
+
+Here at Exercism we simulate [Test-Driven
+Development](http://en.wikipedia.org/wiki/Test-driven_development) (TDD), where
+you write your tests before writing any functionality. The simulation comes in
+the form of a pre-written test suite, which will signal that you have solved
+the problem.
+
+It will also provide you with a safety net to explore other solutions without
+breaking the functionality.
+
+### A typical TDD workflow on Exercism:
+
+1. Run the test file and pick one test that's failing.
+2. Write some code to fix the test you picked.
+3. Re-run the tests to confirm the test is now passing.
+4. Repeat from step 1.
+5. Submit your solution (`exercism submit /path/to/file`)
+
+## Instructions
+
+Submissions are encouraged to be general, within reason. Having said that, it's
+also important not to over-engineer a solution.
+
+It's important to remember that the goal is to make code as expressive and
+readable as we can.
+
+## Running the tests
+
+To run the tests run the command `go test` from within the exercise directory.
+
+If the test suite contains benchmarks, you can run these with the `-bench`
+flag:
+
+    go test -bench .
+
+Keep in mind that each reviewer will run benchmarks on a different machine, with
+different specs, so the results from these benchmark tests may vary.
+
+## Further information
+
+For more detailed information about the Go track, including how to get help if
+you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/about).
+
+## Source
+
+This is an exercise to introduce users to basic programming constructs, just after hello World. [https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-fer/example.go
+++ b/exercises/two-fer/example.go
@@ -1,0 +1,9 @@
+package twofer
+
+// ShareWith apportions the goods between two people.
+func ShareWith(name string) string {
+	if name == "" {
+		name = "you"
+	}
+	return "One for " + name + ", one for me."
+}

--- a/exercises/two-fer/example_two_fer_test.go
+++ b/exercises/two-fer/example_two_fer_test.go
@@ -1,0 +1,20 @@
+package twofer
+
+import "fmt"
+
+// ExampleShareWith() is an Example function. Examples are testable snippets of
+// Go code that are used for documenting and verifying the package API.
+// They may be present in some exercises to demonstrate the expected use of the
+// exercise API and can be run as part of a package's test suite.
+//
+// When an Example test is run the data that is written to standard output is
+// compared to the data that comes after the "Output: " comment.
+//
+// Below the result of ShareWith() is passed to standard output
+// using fmt.Println, and this is compared against the expected output.
+// If they are equal, the test passes.
+func ExampleShareWith() {
+	h := ShareWith("")
+	fmt.Println(h)
+	// Output: One for you, one for me.
+}

--- a/exercises/two-fer/two_fer.go
+++ b/exercises/two-fer/two_fer.go
@@ -1,0 +1,15 @@
+// This is a "stub" file.  It's a little start on your solution.
+// It's not a complete solution though; you have to write some code.
+
+// Package twofer should have a package comment that summarizes what it's about.
+// https://golang.org/doc/effective_go.html#commentary
+package twofer
+
+// ShareWith needs a comment documenting it.
+func ShareWith(string) string {
+	// Write some code here to pass the test suite.
+	// Then remove all the stock comments.
+	// They're here to help you get started but they only clutter a finished solution.
+	// If you leave them in, reviewers will protest!
+	return ""
+}

--- a/exercises/two-fer/two_fer_test.go
+++ b/exercises/two-fer/two_fer_test.go
@@ -1,0 +1,20 @@
+package twofer
+
+import "testing"
+
+// Define a function ShareWith(string) string.
+
+func TestShareWith(t *testing.T) {
+	tests := []struct {
+		name, expected string
+	}{
+		{"", "One for you, one for me."},
+		{"Alice", "One for Alice, one for me."},
+		{"Bob", "One for Bob, one for me."},
+	}
+	for _, test := range tests {
+		if observed := ShareWith(test.name); observed != test.expected {
+			t.Fatalf("ShareWith(%s) = %v, want %v", test.name, observed, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
This adds the exercise that replaced the old conditional version of Hello World.

I also added the Example Test here. I considered using _only_ an example test, but figured I'd play it safe and go with what we used to have for Hello World.

I did not add the testVersion–we're going to be able to get rid of this book-keeping in the near future, and my fingers are crossed hoping that we won't need to update two-fer in the meantime.

This gives us a fairly gentle ramp-up:

- `hello-world`:, just wire everything together and get a test passing
- `two-fer`: some more explanatory comments in in the stub file and an example test
- `leap`: introduce `testVersion`