### PR TITLE
accumulate: remove Lisp-specific portion

### DIFF
--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -25,9 +25,6 @@ Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
 
-Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
-as this is idiomatic Lisp, not a library function.
-
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.


### PR DESCRIPTION
Elixir-specific portion added:
https://github.com/exercism/exercism.io/pull/1136

Lisp-specific portion added:
https://github.com/exercism/problem-specifications/pull/98

Elixir-specific portion removed because the `Enum.reduce` was not
necessary:
https://github.com/exercism/problem-specifications/pull/274

It doesn't seem to make much sense to include this Lisp-specific
sentence in non-Lisp tracks.

https://github.com/exercism/problem-specifications/pull/871