### PR TITLE
Change some exercises to be 'bonus' exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,42 @@
   "blurb": "Go is a compiled, open source programming language with a small, consistent syntax, a powerful standard library, and fantastic tooling. It's a great fit for web backends and command-line tools.",
   "exercises": [
     {
+      "core": false,
+      "difficulty": 1,
+      "slug": "raindrops",
+      "topics": [
+        "control-flow-(conditionals)",
+        "filtering",
+        "strings"
+      ],
+      "unlocked_by": null,
+      "uuid": "2f51e32a-9b1f-4100-9eec-517115c858e9"
+    },
+    {
+      "core": false,
+      "difficulty": 1,
+      "slug": "leap",
+      "topics": [
+        "booleans",
+        "control-flow-(conditionals)",
+        "integers",
+        "logic"
+      ],
+      "unlocked_by": null,
+      "uuid": "fee57b09-2b67-4483-a2e5-3dfec0568b15"
+    },
+    {
+      "core": false,
+      "difficulty": 2,
+      "slug": "bob",
+      "topics": [
+        "control-flow-(conditionals)",
+        "strings"
+      ],
+      "unlocked_by": null,
+      "uuid": "efdf07a1-e329-4d0f-90a1-374b9b8af748"
+    },
+    {
       "core": true,
       "difficulty": 1,
       "slug": "hello-world",
@@ -34,18 +70,6 @@
       ],
       "unlocked_by": null,
       "uuid": "52582415-8f7f-4ac5-857f-5c160ec48134"
-    },
-    {
-      "core": true,
-      "difficulty": 1,
-      "slug": "raindrops",
-      "topics": [
-        "control-flow-(conditionals)",
-        "filtering",
-        "strings"
-      ],
-      "unlocked_by": null,
-      "uuid": "2f51e32a-9b1f-4100-9eec-517115c858e9"
     },
     {
       "core": true,
@@ -220,17 +244,6 @@
       "uuid": "62aa3d20-65d8-440f-9d08-48bbc823f4fe"
     },
     {
-      "core": false,
-      "difficulty": 4,
-      "slug": "pascals-triangle",
-      "topics": [
-        "arrays",
-        "mathematics"
-      ],
-      "unlocked_by": "series",
-      "uuid": "92e2a192-5ee9-422a-8699-c231a7136b10"
-    },
-    {
       "core": true,
       "difficulty": 5,
       "slug": "queen-attack",
@@ -245,26 +258,14 @@
     },
     {
       "core": false,
-      "difficulty": 1,
-      "slug": "leap",
+      "difficulty": 4,
+      "slug": "pascals-triangle",
       "topics": [
-        "booleans",
-        "control-flow-(conditionals)",
-        "integers",
-        "logic"
+        "arrays",
+        "mathematics"
       ],
-      "unlocked_by": "hamming",
-      "uuid": "fee57b09-2b67-4483-a2e5-3dfec0568b15"
-    },
-    {
-      "core": false,
-      "difficulty": 1,
-      "slug": "gigasecond",
-      "topics": [
-        "time"
-      ],
-      "unlocked_by": "hamming",
-      "uuid": "ea390e58-6ac5-4219-89bb-648852712a6a"
+      "unlocked_by": "series",
+      "uuid": "92e2a192-5ee9-422a-8699-c231a7136b10"
     },
     {
       "core": false,
@@ -273,8 +274,18 @@
       "topics": [
         "lists"
       ],
-      "unlocked_by": "raindrops",
+      "unlocked_by": "hamming",
       "uuid": "fb03948c-11e8-440d-9a5d-979396451270"
+    },
+    {
+      "core": false,
+      "difficulty": 1,
+      "slug": "gigasecond",
+      "topics": [
+        "time"
+      ],
+      "unlocked_by": "two-fer",
+      "uuid": "ea390e58-6ac5-4219-89bb-648852712a6a"
     },
     {
       "core": false,
@@ -284,19 +295,8 @@
         "control-flow-(loops)",
         "strings"
       ],
-      "unlocked_by": "raindrops",
+      "unlocked_by": "hamming",
       "uuid": "d14c6283-e57c-472c-8181-87f82d9088dd"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "bob",
-      "topics": [
-        "control-flow-(conditionals)",
-        "strings"
-      ],
-      "unlocked_by": "raindrops",
-      "uuid": "efdf07a1-e329-4d0f-90a1-374b9b8af748"
     },
     {
       "core": false,
@@ -462,7 +462,7 @@
         "maps",
         "sequences"
       ],
-      "unlocked_by": "rna-transcription",
+      "unlocked_by": "etl",
       "uuid": "0b9e07de-c8e4-4d28-b589-897a7ef8062a"
     },
     {
@@ -520,7 +520,7 @@
         "maps",
         "transforming"
       ],
-      "unlocked_by": "scrabble-score",
+      "unlocked_by": "two-fer",
       "uuid": "9bef2163-2a24-4d50-9610-e3cac2e7772a"
     },
     {
@@ -737,7 +737,7 @@
         "parsing",
         "strings"
       ],
-      "unlocked_by": "scrabble-score",
+      "unlocked_by": "etl",
       "uuid": "5911d90f-ba2f-482f-8c92-c01c112d6fdd"
     },
     {

--- a/exercises/bob/bob.go
+++ b/exercises/bob/bob.go
@@ -1,3 +1,12 @@
 package bob
 
+// Hey returns Bob's responses to a given dialogue.
+func Hey(dialogue string) string {
+	// Write some code here to pass the test suite.
+	// Then delete this comment stub.
+	return ""
+}
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
 const testVersion = 3

--- a/exercises/bob/bob_test.go
+++ b/exercises/bob/bob_test.go
@@ -2,15 +2,7 @@ package bob
 
 import "testing"
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
-func TestHeyBob(t *testing.T) {
+func TestHey(t *testing.T) {
 	for _, tt := range testCases {
 		actual := Hey(tt.input)
 		if actual != tt.expected {
@@ -24,10 +16,20 @@ func TestHeyBob(t *testing.T) {
 	}
 }
 
-func BenchmarkBob(b *testing.B) {
+func BenchmarkHey(b *testing.B) {
 	for _, tt := range testCases {
 		for i := 0; i < b.N; i++ {
 			Hey(tt.input)
 		}
+	}
+}
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const targetTestVersion = 3
+
+func TestTestVersion(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
 	}
 }

--- a/exercises/bob/cases_test.go
+++ b/exercises/bob/cases_test.go
@@ -1,8 +1,8 @@
 package bob
 
-// Source: exercism/x-common
+// Source: exercism/problem-specifications
 // Commit: 65756b1 bob: Fix canonical-data.json formatting
-// x-common version: 1.0.0
+// Problem Specifications Version: 1.0.0
 
 var testCases = []struct {
 	description string

--- a/exercises/bob/example.go
+++ b/exercises/bob/example.go
@@ -2,29 +2,32 @@ package bob
 
 import "strings"
 
-const testVersion = 3
-
-func Hey(drivel string) string {
-	switch drivel = strings.TrimSpace(drivel); {
-	case silent(drivel):
+// Hey returns Bob's responses to any given dialogue
+func Hey(dialogue string) string {
+	switch dialogue = strings.TrimSpace(dialogue); {
+	case silent(dialogue):
 		return "Fine. Be that way!"
-	case yelling(drivel):
+	case yelling(dialogue):
 		return "Whoa, chill out!"
-	case asking(drivel):
+	case asking(dialogue):
 		return "Sure."
 	default:
 		return "Whatever."
 	}
 }
 
-func yelling(drivel string) bool {
-	return strings.ToUpper(drivel) == drivel && strings.ToLower(drivel) != strings.ToUpper(drivel)
+func yelling(dialogue string) bool {
+	return strings.ToUpper(dialogue) == dialogue && strings.ToLower(dialogue) != strings.ToUpper(dialogue)
 }
 
-func asking(drivel string) bool {
-	return strings.HasSuffix(drivel, "?")
+func asking(dialogue string) bool {
+	return strings.HasSuffix(dialogue, "?")
 }
 
-func silent(drivel string) bool {
-	return drivel == ""
+func silent(dialogue string) bool {
+	return dialogue == ""
 }
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const testVersion = 3

--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -2,8 +2,16 @@ package hamming
 
 import "testing"
 
+// targetTestVersion is used to ensure that a solution is only evaluated
+// against the correct version of the test suite.
 const targetTestVersion = 6
 
+// TestTestVersion compares the targetTestVersion defined above with
+// a testVersion value.
+// This is a common convention throughout the Go Exercism track.  To make a
+// test like this test pass, define the 'testVersion' const in your solution,
+// and give it the same value as `targetTestVersion`.  We've done this for you
+// in the ./hamming.go file provided.
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
 		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
@@ -17,7 +25,7 @@ func TestHamming(t *testing.T) {
 			// check if err is of error type
 			var _ error = err
 
-			// we expect error
+			// we expect an error
 			if err == nil {
 				t.Fatalf("Distance(%q, %q). error is nil.",
 					tc.s1, tc.s2)
@@ -28,7 +36,7 @@ func TestHamming(t *testing.T) {
 					tc.s1, tc.s2, got, tc.want)
 			}
 
-			// we do not expect error
+			// we do not expect an error
 			if err != nil {
 				t.Fatalf("Distance(%q, %q) returned error: %v when expecting none.",
 					tc.s1, tc.s2, err)
@@ -38,7 +46,8 @@ func TestHamming(t *testing.T) {
 }
 
 func BenchmarkHamming(b *testing.B) {
-	// bench combined time to run through all test cases
+	// bench the combined time it takes
+	// to run through all test cases
 	for i := 0; i < b.N; i++ {
 		for _, tc := range testCases {
 			Distance(tc.s1, tc.s2)

--- a/exercises/leap/cases_test.go
+++ b/exercises/leap/cases_test.go
@@ -1,8 +1,8 @@
 package leap
 
-// Source: exercism/x-common
+// Source: exercism/problem-specifications
 // Commit: cc65ebe leap: Fix canonical-data.json formatting
-// x-common version: 1.0.0
+// Problem Specifications Version: 1.0.0
 
 var testCases = []struct {
 	year        int

--- a/exercises/leap/example.go
+++ b/exercises/leap/example.go
@@ -1,7 +1,10 @@
 package leap
 
-const testVersion = 3
-
-func IsLeapYear(i int) bool {
-	return i%4 == 0 && i%100 != 0 || i%400 == 0
+// IsLeapYear confirms whether a given year is a leap year.
+func IsLeapYear(year int) bool {
+	return year%4 == 0 && year%100 != 0 || year%400 == 0
 }
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about it now.
+const testVersion = 3

--- a/exercises/leap/leap.go
+++ b/exercises/leap/leap.go
@@ -1,6 +1,12 @@
 package leap
 
-const testVersion = 3
-
-func IsLeapYear(int) bool {
+// IsLeapYear confirms whether a given year is a leap year.
+func IsLeapYear(year int) bool {
+	// Write some code here to pass the test suite.
+	// Then delete this comment stub.
+	return false
 }
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const testVersion = 3

--- a/exercises/leap/leap_test.go
+++ b/exercises/leap/leap_test.go
@@ -2,15 +2,6 @@ package leap
 
 import "testing"
 
-// targetTestVersion is used to ensure that a solution is only evaluated
-// against the correct version of the test suite.
-const targetTestVersion = 3
-
-// TestTestVersion compares the targetTestVersion defined above with
-// a testVersion value.
-// This is a common convention throughout the Go Exercism track.
-// To make a test like this test pass, define 'testVersion' in your solution.
-// We've done this for you in the ./leap.go file provided.
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
 		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
@@ -35,3 +26,7 @@ func Benchmark400(b *testing.B) {
 		}
 	}
 }
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const targetTestVersion = 3

--- a/exercises/raindrops/cases_test.go
+++ b/exercises/raindrops/cases_test.go
@@ -1,8 +1,8 @@
 package raindrops
 
-// Source: exercism/x-common
+// Source: exercism/problem-specifications
 // Commit: 9db5371 raindrops: Fix canonical-data.json formatting
-// x-common version: 1.0.0
+// Problem Specifications Version: 1.0.0
 
 var tests = []struct {
 	input    int

--- a/exercises/raindrops/example.go
+++ b/exercises/raindrops/example.go
@@ -2,8 +2,8 @@ package raindrops
 
 import "strconv"
 
-const testVersion = 3
-
+// Convert converts a number to a string, the contents
+// of which depend on the number's factors.
 func Convert(number int) string {
 	s := ""
 	if number%3 == 0 {
@@ -20,3 +20,7 @@ func Convert(number int) string {
 	}
 	return s
 }
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const testVersion = 3

--- a/exercises/raindrops/raindrops.go
+++ b/exercises/raindrops/raindrops.go
@@ -1,8 +1,16 @@
 package raindrops
 
-const testVersion = 3
-
-func Convert(int) string
+// Convert converts a number to a string, the contents
+// of which depend on the number's factors.
+func Convert(number int) string {
+	// Write some code here to pass the test suite.
+	// Then delete this comment stub.
+	return ""
+}
 
 // Don't forget the test program has a benchmark too.
 // How fast does your Convert convert?
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const testVersion = 3

--- a/exercises/raindrops/raindrops_test.go
+++ b/exercises/raindrops/raindrops_test.go
@@ -2,14 +2,6 @@ package raindrops
 
 import "testing"
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestConvert(t *testing.T) {
 	for _, test := range tests {
 		if actual := Convert(test.input); actual != test.expected {
@@ -24,5 +16,15 @@ func BenchmarkConvert(b *testing.B) {
 		for _, test := range tests {
 			Convert(test.input)
 		}
+	}
+}
+
+// This test versioning is specific to Exercism,
+// you don't need to worry about this now.
+const targetTestVersion = 3
+
+func TestTestVersion(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
 	}
 }


### PR DESCRIPTION
Bonus exercises are those that are not part of the main *core* exercise
structure, they are available as soon as the hello-world exercise is
submitted.

See https://github.com/exercism/go/pull/808#discussion_r134311568

Other exercises have also been moved in response to the above.

The bonus exercises; `bob`, `leap` & `raindrops`, have all been edited
so they are more suitable for someone who has just completed the
`hello-world` exercise. They all have simplified stubs, with the test
versioning (soon to be removed completely) moved and commented on to be
less important before the explanation in `hamming`.