### PR TITLE
maintainers: add my bio as an alumnus

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -18,14 +18,10 @@
       "name": "Katrina Owen"
     },
     {
-      "alumnus": false,
-      "avatar_url": null,
-      "bio": null,
+      "alumnus": true,
+      "bio": "I write a lot of Go for my day job, building platforms for other software engineers to use. The Exercism Go track was the first open-source project I joined; I'm grateful for all I've learned through this experience.",
       "github_username": "petertseng",
-      "link_text": null,
-      "link_url": null,
-      "name": null,
-      "show_on_website": false
+      "show_on_website": true
     },
     {
       "alumnus": false,


### PR DESCRIPTION
As noted in https://github.com/exercism/go/issues/719 I cannot currently
fulfill my duties as a maintainer of this track, so it is right and
proper to mark myself as an alumnus as a result.

I will do as Katrina did in https://github.com/exercism/go/pull/797 and
submit a bio for myself. I think this is suitable for showing on the
website (by the way, Katrina's currently isn't being shown).