### PR TITLE
error-handling: move detailed exercise description to README

### DIFF
--- a/exercises/error-handling/.meta/description.md
+++ b/exercises/error-handling/.meta/description.md
@@ -1,19 +1,39 @@
 Implement various kinds of error handling and resource management.
 
-An important point of programming is how to handle errors and close resources even if errors occur.
+An important point of programming is how to handle errors and close resources
+even if errors occur.
 
-If you are new to Go errors or panics we recommend reading [the documentation on these topics](https://blog.golang.org/defer-panic-and-recover) first for context.
+If you are new to Go errors or panics we recommend reading
+[the documentation on these topics](https://blog.golang.org/defer-panic-and-recover)
+first for context.
 
-In this exercise you will be required to define a function `Use(o ResourceOpener, input string) error` that opens a resource, calls Frob(input) on the result resource and then closes that resource (in all cases). Your function should properly handle errors and panics.
+In this exercise you will be required to define a function `Use(o
+ResourceOpener, input string) error` that opens a resource, calls Frob(input) on
+the result resource and then closes that resource (in all cases). Your function
+should properly handle errors and panics.
 
-`ResourceOpener o` will be a function you may invoke directly `o()` in an attempt to "open" the resource. It returns a Resource and error value in the [idiomatic Go fashion](https://blog.golang.org/error-handling-and-go):
+`ResourceOpener o` will be a function you may invoke directly `o()` in an
+attempt to "open" the resource. It returns a Resource and error value in the
+[idiomatic Go fashion](https://blog.golang.org/error-handling-and-go):
 
-See the [common.go](./common.go) file for the definitions of Resource, ResourceOpener, FrobError and TransientError. You will define your solution to be in the same package as [common.go](./common.go) and [error\_handling\_test.go](./error_handling_test.go): "erratum". This will make those types available for use in your solution.
+See the [common.go](./common.go) file for the definitions of Resource,
+ResourceOpener, FrobError and TransientError. You will define your solution to
+be in the same package as [common.go](./common.go) and
+[error\_handling\_test.go](./error_handling_test.go): "erratum". This will make
+those types available for use in your solution.
 
 There will be a few places in your Use function where errors may occur:
 
-* Invoking the ResourceOpener function passed into Use as the first parameter, it may fail with an error of type TransientError, if so keep trying to open the resource. If it is some other sort of error, return it from your `Use` function.
+* Invoking the ResourceOpener function passed into Use as the first parameter,
+  it may fail with an error of type TransientError, if so keep trying to open
+  the resource. If it is some other sort of error, return it from your `Use`
+  function.
 
-* Calling the Frob function on the Resource returned from the ResourceOpener function, it may **panic** with a FrobError (or another type of error). If it is indeed a FrobError you will have to call the Resource's `Defrob` function *using the panic FrobError's `.defrobTag` variable as input to the `Defrob` function*. Either way `Use` should return the error.
+* Calling the Frob function on the Resource returned from the ResourceOpener
+  function, it may **panic** with a FrobError (or another type of error). If it
+  is indeed a FrobError you will have to call the Resource's `Defrob` function
+  *using the panic FrobError's `.defrobTag` variable as input to the `Defrob`
+  function*. Either way `Use` should return the error.
 
-* *Also note*: if the Resource was opened successfully make sure to call its Close function no matter what (even if errors have occurred).
+* *Also note*: if the Resource was opened successfully make sure to call its
+  Close function no matter what (even if errors have occurred).

--- a/exercises/error-handling/.meta/description.md
+++ b/exercises/error-handling/.meta/description.md
@@ -1,5 +1,3 @@
-# Error Handling
-
 Implement various kinds of error handling and resource management.
 
 An important point of programming is how to handle errors and close resources even if errors occur.
@@ -19,24 +17,3 @@ There will be a few places in your Use function where errors may occur:
 * Calling the Frob function on the Resource returned from the ResourceOpener function, it may **panic** with a FrobError (or another type of error). If it is indeed a FrobError you will have to call the Resource's `Defrob` function *using the panic FrobError's `.defrobTag` variable as input to the `Defrob` function*. Either way `Use` should return the error.
 
 * *Also note*: if the Resource was opened successfully make sure to call its Close function no matter what (even if errors have occurred).
-
-Testing for specific error types may be performed by [type assertions](https://golang.org/ref/spec#Type_assertions). You may also need to look at [named return values](https://blog.golang.org/error-handling-and-go) as a helpful way to return error information from panic recovery.
-
-
-## Running the tests
-
-To run the tests run the command `go test` from within the exercise directory.
-
-If the test suite contains benchmarks, you can run these with the `-bench` flag:
-
-    go test -bench .
-
-Keep in mind that each reviewer will run benchmarks on a different machine, with different specs, so the results from these benchmark tests may vary.
-
-## Further information
-
-For more detailed information about the Go track, including how to get help if you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/about).
-
-
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/error-handling/.meta/hints.md
+++ b/exercises/error-handling/.meta/hints.md
@@ -1,0 +1,1 @@
+Testing for specific error types may be performed by [type assertions](https://golang.org/ref/spec#Type_assertions). You may also need to look at [named return values](https://blog.golang.org/error-handling-and-go) as a helpful way to return error information from panic recovery.

--- a/exercises/error-handling/.meta/hints.md
+++ b/exercises/error-handling/.meta/hints.md
@@ -1,1 +1,5 @@
-Testing for specific error types may be performed by [type assertions](https://golang.org/ref/spec#Type_assertions). You may also need to look at [named return values](https://blog.golang.org/error-handling-and-go) as a helpful way to return error information from panic recovery.
+Testing for specific error types may be performed by
+[type assertions](https://golang.org/ref/spec#Type_assertions). You may also
+need to look at
+[named return values](https://blog.golang.org/error-handling-and-go) as a
+helpful way to return error information from panic recovery.

--- a/exercises/error-handling/.meta/metadata.yml
+++ b/exercises/error-handling/.meta/metadata.yml
@@ -1,0 +1,2 @@
+---
+blurb: "Implement various kinds of error handling and resource management"

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -2,40 +2,67 @@
 
 Implement various kinds of error handling and resource management.
 
-An important point of programming is how to handle errors and close resources even if errors occur.
+An important point of programming is how to handle errors and close resources
+even if errors occur.
 
-If you are new to Go errors or panics we recommend reading [the documentation on these topics](https://blog.golang.org/defer-panic-and-recover) first for context.
+If you are new to Go errors or panics we recommend reading
+[the documentation on these topics](https://blog.golang.org/defer-panic-and-recover)
+first for context.
 
-In this exercise you will be required to define a function `Use(o ResourceOpener, input string) error` that opens a resource, calls Frob(input) on the result resource and then closes that resource (in all cases). Your function should properly handle errors and panics.
+In this exercise you will be required to define a function `Use(o
+ResourceOpener, input string) error` that opens a resource, calls Frob(input) on
+the result resource and then closes that resource (in all cases). Your function
+should properly handle errors and panics.
 
-`ResourceOpener o` will be a function you may invoke directly `o()` in an attempt to "open" the resource. It returns a Resource and error value in the [idiomatic Go fashion](https://blog.golang.org/error-handling-and-go):
+`ResourceOpener o` will be a function you may invoke directly `o()` in an
+attempt to "open" the resource. It returns a Resource and error value in the
+[idiomatic Go fashion](https://blog.golang.org/error-handling-and-go):
 
-See the [common.go](./common.go) file for the definitions of Resource, ResourceOpener, FrobError and TransientError. You will define your solution to be in the same package as [common.go](./common.go) and [error\_handling\_test.go](./error_handling_test.go): "erratum". This will make those types available for use in your solution.
+See the [common.go](./common.go) file for the definitions of Resource,
+ResourceOpener, FrobError and TransientError. You will define your solution to
+be in the same package as [common.go](./common.go) and
+[error\_handling\_test.go](./error_handling_test.go): "erratum". This will make
+those types available for use in your solution.
 
 There will be a few places in your Use function where errors may occur:
 
-* Invoking the ResourceOpener function passed into Use as the first parameter, it may fail with an error of type TransientError, if so keep trying to open the resource. If it is some other sort of error, return it from your `Use` function.
+* Invoking the ResourceOpener function passed into Use as the first parameter,
+  it may fail with an error of type TransientError, if so keep trying to open
+  the resource. If it is some other sort of error, return it from your `Use`
+  function.
 
-* Calling the Frob function on the Resource returned from the ResourceOpener function, it may **panic** with a FrobError (or another type of error). If it is indeed a FrobError you will have to call the Resource's `Defrob` function *using the panic FrobError's `.defrobTag` variable as input to the `Defrob` function*. Either way `Use` should return the error.
+* Calling the Frob function on the Resource returned from the ResourceOpener
+  function, it may **panic** with a FrobError (or another type of error). If it
+  is indeed a FrobError you will have to call the Resource's `Defrob` function
+  *using the panic FrobError's `.defrobTag` variable as input to the `Defrob`
+  function*. Either way `Use` should return the error.
 
-* *Also note*: if the Resource was opened successfully make sure to call its Close function no matter what (even if errors have occurred).
+* *Also note*: if the Resource was opened successfully make sure to call its
+  Close function no matter what (even if errors have occurred).
 
-Testing for specific error types may be performed by [type assertions](https://golang.org/ref/spec#Type_assertions). You may also need to look at [named return values](https://blog.golang.org/error-handling-and-go) as a helpful way to return error information from panic recovery.
+Testing for specific error types may be performed by
+[type assertions](https://golang.org/ref/spec#Type_assertions). You may also
+need to look at
+[named return values](https://blog.golang.org/error-handling-and-go) as a
+helpful way to return error information from panic recovery.
 
 
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.
 
-If the test suite contains benchmarks, you can run these with the `-bench` flag:
+If the test suite contains benchmarks, you can run these with the `-bench`
+flag:
 
     go test -bench .
 
-Keep in mind that each reviewer will run benchmarks on a different machine, with different specs, so the results from these benchmark tests may vary.
+Keep in mind that each reviewer will run benchmarks on a different machine, with
+different specs, so the results from these benchmark tests may vary.
 
 ## Further information
 
-For more detailed information about the Go track, including how to get help if you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/about).
+For more detailed information about the Go track, including how to get help if
+you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/about).
 
 
 ## Submitting Incomplete Solutions

--- a/exercises/error-handling/common.go
+++ b/exercises/error-handling/common.go
@@ -36,15 +36,16 @@ func (e FrobError) Error() string {
 type Resource interface {
 
 	// Resource is using composition to inherit the requirements of the io.Closer
-	// interface. What this means is that a Resource will have a .Close() method.
+	// interface. What this means is that a Resource implementation will be
+	// expected to have a .Close() method too.
 	io.Closer
 
 	// Frob does something with the input string.
 	// Because this is an incredibly badly designed system if there is an error
 	// it panics.
 	//
-	// The paniced error may be a FrobError in which case Defrob should be called
-	// with the defrobTag string.
+	// The panicked error may be a FrobError in which case Defrob should be
+	// called with the .defrobTag string property of the error.
 	Frob(string)
 
 	Defrob(string)

--- a/exercises/error-handling/error_handling_test.go
+++ b/exercises/error-handling/error_handling_test.go
@@ -5,44 +5,7 @@ import (
 	"testing"
 )
 
-// Because this exercise is generally unique to each language and how it
-// handles errors, most of the definition of your expected solution is provided
-// here instead of the README.
-// You should read this carefully (more than once) before implementation.
-
-// Define a function `Use(o ResourceOpener, input string) error` that opens a
-// resource, calls Frob(input) and closes the resource (in all cases). Your
-// function should properly handle errors, as defined by the expectations of
-// this test suite. ResourceOpener will be a function you may invoke directly
-// `o()` in an attempt to "open" the resource. It returns a Resource and error
-// value in the idiomatic Go fashion:
-// https://blog.golang.org/error-handling-and-go
-//
-// See the ./common.go file for the definitions of Resource, ResourceOpener,
-// FrobError and TransientError.
-//
-// There will be a few places in your Use function where errors may occur:
-//
-// - Invoking the ResourceOpener function passed into Use as the first
-//   parameter, it may fail with a TransientError, if so keep trying to open it.
-//   If it is some other sort of error, return it.
-//
-// - Calling the Frob function on the Resource returned from the ResourceOpener
-//   function, it may panic with a FrobError (or another type of error). If
-//   it is indeed a FrobError you will have to call the Resource's Defrob
-//   function using the FrobError's defrobTag variable as input. Either way
-//   return the error.
-//
-// Also note: if the Resource was opened successfully make sure to call its
-// Close function no matter what (even if errors occur).
-//
-// If you are new to Go errors or panics here is a good place to start:
-// https://blog.golang.org/defer-panic-and-recover
-//
-// You may also need to look at named return values as a helpful way to
-// return error information from panic recovery:
-// https://tour.golang.org/basics/7
-
+// Please review the README for this exercise carefully before implementation.
 const targetTestVersion = 2
 
 // Little helper to let us customize behaviour of the resource on a per-test


### PR DESCRIPTION
Originally added for #703, moved the longer description for the
exercise to the README using the new `.meta/` files enabled via
`configlet` v3+. Links have been moved into markdown format, some
language has been updated as well.

Resolves #833