### PR TITLE
Improve Handshake Benchmark Test

### DIFF
--- a/exercises/secret-handshake/secret_handshake_test.go
+++ b/exercises/secret-handshake/secret_handshake_test.go
@@ -28,7 +28,10 @@ func TestHandshake(t *testing.T) {
 }
 
 func BenchmarkHandshake(b *testing.B) {
+	var j uint
 	for i := 0; i < b.N; i++ {
-		Handshake(31)
+		for j = 0; j < 32; j++ {
+			Handshake(j)
+		}
 	}
 }

--- a/exercises/secret-handshake/secret_handshake_test.go
+++ b/exercises/secret-handshake/secret_handshake_test.go
@@ -28,9 +28,8 @@ func TestHandshake(t *testing.T) {
 }
 
 func BenchmarkHandshake(b *testing.B) {
-	var j uint
 	for i := 0; i < b.N; i++ {
-		for j = 0; j < 32; j++ {
+		for j := uint(0); j < 32; j++ {
 			Handshake(j)
 		}
 	}


### PR DESCRIPTION
It would seem to be a better speed analysis of the routine if we try more than just `Handshake(31)`

This is especially true when you consider there could be two code paths, or significant overhead depending on how the reverse functionality is handled.

I suspect do not need to bump the `targetTestVersion` since the test cases remain the same.