### PR TITLE
simple-cipher: update README to reflect exercise implementation 

### DIFF
--- a/exercises/simple-cipher/.meta/description.md
+++ b/exercises/simple-cipher/.meta/description.md
@@ -85,7 +85,7 @@ Shift ciphers work by making the text slightly odd, but are vulnerable
 to frequency analysis. Substitution ciphers help that, but are still
 very vulnerable when the key is short or if spaces are
 preserved. You'll see one solution to this problem in the exercise
-"[crypto-square](exercises/crypto-square/)".
+"[crypto-square](https://github.com/exercism/go/tree/master/exercises/crypto-square)".
 
 If you want to go farther in this field, the questions begin to be
 about how we can exchange keys in a secure way. Take a look at

--- a/exercises/simple-cipher/.meta/description.md
+++ b/exercises/simple-cipher/.meta/description.md
@@ -1,5 +1,3 @@
-# Simple Cipher
-
 Implement a simple shift cipher like Caesar and a more secure
 substitution cipher.
 
@@ -98,64 +96,3 @@ of this scheme.
 [cc]: https://en.wikipedia.org/wiki/Caesar_cipher
 [vc]: https://en.wikipedia.org/wiki/Vigen%C3%A8re_cipher
 [dh]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
-
-## Implementation
-
-The definition of the Cipher interface is located in
-[cipher.go](./cipher.go).
-
-Your implementations should conform to the Cipher interface.
-
-```go
-type Cipher interface {
-    Encode(string) string
-    Decode(string) string
-}
-```
-
-It is expected that `Encode` will ignore all values in the string that
-are not A-Za-z, they will not be represented in the output. The output
-will be also normalized to lowercase.
-
-The functions used to obtain the ciphers are:
-
-```go
-func NewCaesar() Cipher { }
-
-func NewShift(distance int) Cipher { }
-
-func NewVigenere(key string) Cipher { }
-```
-
-Argument for `NewShift` must be in the range 1 to 25 or -1 to -25.
-Zero is disallowed.  For invalid arguments `NewShift` returns nil.
-
-Argument for `NewVigenere` must consist of lower case letters a-z
-only.  Values consisting entirely of the letter 'a' are disallowed.
-For invalid arguments `NewVigenere` returns nil.
-
-
-
-## Running the tests
-
-To run the tests run the command `go test` from within the exercise directory.
-
-If the test suite contains benchmarks, you can run these with the `-bench`
-flag:
-
-    go test -bench .
-
-Keep in mind that each reviewer will run benchmarks on a different machine, with
-different specs, so the results from these benchmark tests may vary.
-
-## Further information
-
-For more detailed information about the Go track, including how to get help if
-you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/about).
-
-## Source
-
-Substitution Cipher at Wikipedia [http://en.wikipedia.org/wiki/Substitution_cipher](http://en.wikipedia.org/wiki/Substitution_cipher)
-
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-cipher/.meta/hints.md
+++ b/exercises/simple-cipher/.meta/hints.md
@@ -1,0 +1,35 @@
+## Implementation
+
+The definition of the Cipher interface is located in
+[cipher.go](./cipher.go).
+
+Your implementations should conform to the Cipher interface.
+
+```go
+type Cipher interface {
+    Encode(string) string
+    Decode(string) string
+}
+```
+
+It is expected that `Encode` will ignore all values in the string that
+are not A-Za-z, they will not be represented in the output. The output
+will be also normalized to lowercase.
+
+The functions used to obtain the ciphers are:
+
+```go
+func NewCaesar() Cipher { }
+
+func NewShift(distance int) Cipher { }
+
+func NewVigenere(key string) Cipher { }
+```
+
+Argument for `NewShift` must be in the range 1 to 25 or -1 to -25.
+Zero is disallowed.  For invalid arguments `NewShift` returns nil.
+
+Argument for `NewVigenere` must consist of lower case letters a-z
+only.  Values consisting entirely of the letter 'a' are disallowed.
+For invalid arguments `NewVigenere` returns nil.
+

--- a/exercises/simple-cipher/.meta/metadata.yml
+++ b/exercises/simple-cipher/.meta/metadata.yml
@@ -1,0 +1,4 @@
+---
+blurb: "Implement a simple shift cipher like Caesar and a more secure substitution cipher"
+source: "Substitution Cipher at Wikipedia"
+source_url: "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -87,7 +87,7 @@ Shift ciphers work by making the text slightly odd, but are vulnerable
 to frequency analysis. Substitution ciphers help that, but are still
 very vulnerable when the key is short or if spaces are
 preserved. You'll see one solution to this problem in the exercise
-"[crypto-square](exercises/crypto-square/)".
+"[crypto-square](https://github.com/exercism/go/tree/master/exercises/crypto-square)".
 
 If you want to go farther in this field, the questions begin to be
 about how we can exchange keys in a secure way. Take a look at

--- a/exercises/simple-cipher/simple_cipher_test.go
+++ b/exercises/simple-cipher/simple_cipher_test.go
@@ -1,33 +1,3 @@
-// For Step 1, implement the Caesar cipher, which seems clear enough except
-// maybe for figuring out whether to add or subtract.
-//
-// For Step 2, implement a shift cipher, like Caesar except the shift amount
-// is specified as an int.  (Each letter of "ddddddddddddddddd", is 'd';
-// 'd'-'a' == 3, so the corresponding shift amount is 3.)
-//
-// Steps 2 and 3 seem to be describing the Vigenère cipher (Google it)
-// so let's do that too.  The random thing, don't worry about.  There is
-// no test for that.
-//
-// API:
-//
-// type Cipher interface {
-//    Encode(string) string
-//    Decode(string) string
-// }
-// NewCaesar() Cipher
-// NewShift(int) Cipher
-// NewVigenere(string) Cipher
-//
-// Interface Cipher is in file cipher.go.
-//
-// Argument for NewShift must be in the range 1 to 25 or -1 to -25.
-// Zero is disallowed.  For invalid arguments NewShift returns nil.
-//
-// Argument for NewVigenere must consist of lower case letters a-z only.
-// Values consisting entirely of the letter 'a' are disallowed.
-// For invalid arguments NewVigenere returns nil.
-
 package cipher
 
 import (


### PR DESCRIPTION
Clear up the expected implementation details for the simple-cipher
exercise in the README. Provide more explanation of the Vigenère
cipher. Moved README updates into .meta/ directory and regenerated the
README.

Resolves #786