### PR TITLE
series: Move bonus instructions to README

### DIFF
--- a/exercises/series/.meta/hints.md
+++ b/exercises/series/.meta/hints.md
@@ -1,25 +1,3 @@
-# Series
-
-Given a string of digits, output all the contiguous substrings of length `n` in
-that string.
-
-For example, the string "49142" has the following 3-digit series:
-
-- 491
-- 914
-- 142
-
-And the following 4-digit series:
-
-- 4914
-- 9142
-
-And if you ask for a 6-digit series from a 5-digit string, you deserve
-whatever you get.
-
-Note that these series are only required to occupy *adjacent positions*
-in the input; the digits need not be *numerically consecutive*.
-
 ## Implementation
 
 Define two functions: (Two? Yes, sometimes we ask more out of Go.)
@@ -62,28 +40,3 @@ The `ok bool` second return argument is a common and idiomatic pattern
 in Go. For example you see it in
 [Map lookups](https://blog.golang.org/go-maps-in-action) and
 [type assertions](https://tour.golang.org/methods/15).
-
-
-## Running the tests
-
-To run the tests run the command `go test` from within the exercise directory.
-
-If the test suite contains benchmarks, you can run these with the `-bench`
-flag:
-
-    go test -bench .
-
-Keep in mind that each reviewer will run benchmarks on a different machine, with
-different specs, so the results from these benchmark tests may vary.
-
-## Further information
-
-For more detailed information about the Go track, including how to get help if
-you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/about).
-
-## Source
-
-A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
-
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Moved information on bonus exercise and build tags from the main test file
to the README. Also added info about the `ok bool` pattern.

Resolves #804