### PR TITLE
roman-numerals: remove non-canonical test data

### DIFF
--- a/exercises/roman-numerals/example.go
+++ b/exercises/roman-numerals/example.go
@@ -15,7 +15,7 @@ type arabicToRoman struct {
 func ToRomanNumeral(input int) (string, error) {
 	buffer := bytes.NewBufferString("")
 
-	if input <= 0 || input >= 4000 {
+	if input <= 0 || input >= 3001 {
 		return "", fmt.Errorf("the number %d is undefined in the roman numeral system", input)
 	}
 

--- a/exercises/roman-numerals/example.go
+++ b/exercises/roman-numerals/example.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const testVersion = 3
+const testVersion = 4
 
 type arabicToRoman struct {
 	arabic int

--- a/exercises/roman-numerals/roman_numerals_test.go
+++ b/exercises/roman-numerals/roman_numerals_test.go
@@ -2,7 +2,7 @@ package romannumerals
 
 import "testing"
 
-const targetTestVersion = 3
+const targetTestVersion = 4
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
@@ -11,13 +11,7 @@ func TestTestVersion(t *testing.T) {
 }
 
 func TestRomanNumerals(t *testing.T) {
-	tc := append(romanNumeralTests, []romanNumeralTest{
-		{0, "", true},
-		{-1, "", true},
-		{4000, "", true},
-		{3999, "MMMCMXCIX", false},
-	}...)
-	for _, test := range tc {
+	for _, test := range romanNumeralTests {
 		actual, err := ToRomanNumeral(test.arabic)
 		if err == nil && test.hasError {
 			t.Errorf("ToRomanNumeral(%d) should return an error.", test.arabic)

--- a/exercises/roman-numerals/roman_numerals_test.go
+++ b/exercises/roman-numerals/roman_numerals_test.go
@@ -11,7 +11,13 @@ func TestTestVersion(t *testing.T) {
 }
 
 func TestRomanNumerals(t *testing.T) {
-	for _, test := range romanNumeralTests {
+	tc := append(romanNumeralTests, []romanNumeralTest{
+		{0, "", true},
+		{-1, "", true},
+		{3001, "", true},
+	}...)
+
+	for _, test := range tc {
 		actual, err := ToRomanNumeral(test.arabic)
 		if err == nil && test.hasError {
 			t.Errorf("ToRomanNumeral(%d) should return an error.", test.arabic)


### PR DESCRIPTION
Removed extra test cases to bring the roman-numeral exercise into
consistency with the problem-specifications description. Bumped test
version accordingly.

Resolves #836