### PR TITLE
gen/gen.go: correct location for cases_test.go

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -70,12 +70,6 @@ func init() {
 	if _, path, _, ok := runtime.Caller(0); ok {
 		dirMetadata = filepath.Join(path, "..", "..", "..", "problem-specifications")
 	}
-	if _, path, _, ok := runtime.Caller(2); ok {
-		dirExercise = filepath.Join(path, "..", "..")
-	}
-	if dirExercise == "" {
-		dirExercise = "."
-	}
 }
 
 // outputSource puts the src text into given fileName
@@ -94,6 +88,21 @@ func outputSource(status string, fileName string, src []byte) error {
 func Gen(exercise string, j interface{}, t *template.Template) error {
 	if dirMetadata == "" {
 		return errors.New("unable to determine current path")
+	}
+	// Determine the exercise directory.
+	// Use runtime.Caller to determine path location of the generator main package.
+	// Call frames: 0 is this frame, Gen().
+	//              1 should be a func in <exercise-dir>/.meta/gen.go (generator main package)
+	//                which is calling Gen().
+	//                                  |
+	//                                  V
+	if _, path, _, ok := runtime.Caller(1); ok {
+		// Construct a path 2 directories higher than the path for .meta/gen.go
+		// and it should be exercise directory.
+		dirExercise = filepath.Join(path, "..", "..")
+	}
+	if dirExercise == "" {
+		dirExercise = "."
 	}
 	jFile := filepath.Join("exercises", exercise, "canonical-data.json")
 	// try to find and read the local json source file


### PR DESCRIPTION
Using Go 1.9 with test case generators breaks
the placement of the output file, cases_test.go.
Specifically, on Linux it is output to ../cases_test.go which is
relative to your current directory.

The bug is related to the fact that with Go 1.9, this line

 	if _, path, _, ok := runtime.Caller(2); ok {

when called from init() within a package
has a different result than 1.8.3 and earlier.
Path is returned as ```<autogenerated>``` with 1.9,
and dirExercise ends up being set to "..".

The correct solution for both new and previous Go versions
is to utilize the same technique of runtime.Caller(),
but from a known call stack position apart from the init() function.

The change moves the logic to set dirExercise
from init() into the Gen() function in order to
set a correct value for the exercise directory regardless
of the current working directory when running the generator.

Also, add some commentary explanation of how dirExercise is determined.

Resolves #848