### PR TITLE
robot-simulator: Update grammar and wording

### DIFF
--- a/exercises/robot-simulator/robot_simulator_step2_test.go
+++ b/exercises/robot-simulator/robot_simulator_step2_test.go
@@ -4,13 +4,13 @@ package robot
 
 import "testing"
 
-// For step 1 you implement robot movements, but it's not much of a simulation.
+// For step 1 you implemented robot movements, but it's not much of a simulation.
 // For example where in the source code is "the robot"?  Where is "the grid"?
 // Where are the computations that turn robot actions into grid positions,
-// in the robot or in the grid?  The physical world is different.
+// in the robot, or in the grid?  The physical world is different.
 //
 // Step 2 introduces a "room."  It seems a small addition, but we'll make
-// big changes to clarify the rolls of "room", "robot", and "test program"
+// big changes to clarify the roles of "room", "robot", and "test program"
 // and begin to clarify the physics of the simulation.  You will define Room
 // and Robot as functions which the test program "brings into existence" by
 // launching them as goroutines.  Information moves between test program,
@@ -34,7 +34,7 @@ import "testing"
 // The test program then sends commands to Robot.  When it is done sending
 // commands, it closes the command channel.  Robot must accept commands and
 // inform Room of actions it is attempting.  When it senses the command channel
-// closing, it must shut down itself.  The room must interpret the physical
+// closing, it must shut itself down.  The room must interpret the physical
 // consequences of the robot actions.  When it senses the robot shutting down,
 // it sends a final report back to the test program, telling the robot's final
 // position and direction.


### PR DESCRIPTION
The big glaring fix is the change `s/rolls/roles/`. But also, be consistent in use of the Oxford comma and tense.