### PR TITLE
use func String() for Clock output

### DIFF
--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -68,7 +68,7 @@ func TestCompareClocks(t *testing.T) {
 		if got != e.want {
 			t.Log("Clock1:", clock1)
 			t.Log("Clock2:", clock2)
-			t.Logf("Clock1 == Clock2 is %t, want %t", got, e.want)
+			t.Logf("Clock1 == Clock2 is %t, want %t", got.String(), e.want)
 			if reflect.DeepEqual(clock1, clock2) {
 				t.Log("(Hint: see comments in clock_test.go.)")
 			}


### PR DESCRIPTION
 Output in error message is not in human-readable format. Now we have:
```
--- FAIL: TestCreateClock (0.00s)
        clock_test.go:41: New(-1, 15) = {'\x15' '\x0f'}, want "23:15"
```
Want to see:
```
--- FAIL: TestCreateClock (0.00s)
        clock_test.go:41: New(-1, 15) = "21:15", want "23:15"
```