### PR TITLE
travis: upgrade Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ sudo: false
 # but since Travis only runs five jobs at a time throughout all of Exercism,
 # it is better citizenship to not test the additional versions.
 go:
-  - 1.7.5
-  - 1.8
+  - 1.8.3
+  - 1.9
   - tip
 
 # Travis runs in a 64 bit environment but beginning with Go 1.5, building a


### PR DESCRIPTION
1.9 was released on 24 August 2017:
https://golang.org/doc/go1.9

1.8.3 was released on 24 May 2017:
https://golang.org/doc/devel/release.html#go1.8.minor

This keeps up with the policy of only testing the
current & previous release.