### PR TITLE
[nextercism] Remove all exercise test versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ sudo: false
 # but since Travis only runs five jobs at a time throughout all of Exercism,
 # it is better citizenship to not test the additional versions.
 go:
-  - 1.7.5
-  - 1.8
+  - 1.8.3
+  - 1.9
   - tip
 
 # Travis runs in a 64 bit environment but beginning with Go 1.5, building a

--- a/README.md
+++ b/README.md
@@ -199,21 +199,6 @@ create their own solutions from scratch. Some of the later exercises may have st
 files if the author thinks there may be implementation confusion, a particularly
 difficult concept, or boilerplate code needed.
 
-### Problem Versioning
-
-Each problem defines a `const targetTestVersion` in the test file, and validates
-that the solution has defined a matching value `testVersion`. Any Go track developer
-that changes the test file or test data must increment `targetTestVersion`.
-
-The benefit of all this is that reviewers can see which test version a posted
-solution was written for and be spared confusion over why an old posted solution
-might not pass current tests.
-
-Notice that neither the `testVersion` nor the `targetTestVersion` is exported.
-This is so that golint will not complain about a missing comment. In general,
-adding tests for unexported names is considered an anti-pattern, but in this
-case the trade-off seems acceptable.
-
 ### Errors
 
 We like errors in Go. It's not idiomatic Go to ignore invalid data or have undefined

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -9,21 +9,6 @@ $ go test
 
 Most exercises contain benchmarks, that you can use to determine how changes to your solution affect its performance. To run the benchmarks for an exercise use the command `go test -bench .` inside the exercise directory.
 
-### The `testVersion` constant
-
-Some exercises require you to define a testVersion constant in your package.
-There are sometimes problems where tests change and solutions which worked for
-the old version no longer work. The testVersion system makes it obvious when
-this happens.
-
-To avoid compilation warnings due to testVersion not being defined
-just add `const testVersion = VERSION` (where VERSION should be replaced by the
-value of `targetTestVersion` in the test file) to your submission file.
-
-Should the tests change in a way that old submissions will or could no longer
-work the test writer should increase the `targetTestVersion` value which will cause
-the tests to fail with a clear message when an old submission is run with them.
-
 ### Testable examples
 
 [Example tests](https://blog.golang.org/examples) are used in some exercises and

--- a/exercises/accumulate/accumulate.go
+++ b/exercises/accumulate/accumulate.go
@@ -1,5 +1,3 @@
 package accumulate
 
-const testVersion = 1
-
 func Accumulate([]string, func(string) string) []string

--- a/exercises/accumulate/accumulate_test.go
+++ b/exercises/accumulate/accumulate_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 func echo(c string) string {
 	return c
 }
@@ -26,12 +24,6 @@ var tests = []struct {
 	{[]string{"echo", "echo", "echo", "echo"}, []string{"echo", "echo", "echo", "echo"}, echo, "echo"},
 	{[]string{"First", "Letter", "Only"}, []string{"first", "letter", "only"}, capitalize, "capitalize"},
 	{[]string{"HELLO", "WORLD"}, []string{"hello", "world"}, strings.ToUpper, "strings.ToUpper"},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestAccumulate(t *testing.T) {

--- a/exercises/accumulate/example.go
+++ b/exercises/accumulate/example.go
@@ -1,7 +1,5 @@
 package accumulate
 
-const testVersion = 1
-
 func Accumulate(s []string, f func(st string) string) (result []string) {
 	for _, v := range s {
 		result = append(result, []string{f(v)}...)

--- a/exercises/acronym/acronym.go
+++ b/exercises/acronym/acronym.go
@@ -1,5 +1,3 @@
 package acronym
 
-const testVersion = 3
-
 func Abbreviate(string) string

--- a/exercises/acronym/acronym_test.go
+++ b/exercises/acronym/acronym_test.go
@@ -4,14 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
-
 func TestAcronym(t *testing.T) {
 	for _, test := range stringTestCases {
 		actual := Abbreviate(test.input)

--- a/exercises/acronym/example.go
+++ b/exercises/acronym/example.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const testVersion = 3
-
 func Abbreviate(s string) string {
 	regex := regexp.MustCompile("[A-Z]+[a-z]*|[a-z]+")
 	words := regex.FindAllString(s, -1)

--- a/exercises/all-your-base/all_your_base_test.go
+++ b/exercises/all-your-base/all_your_base_test.go
@@ -2,8 +2,6 @@ package allyourbase
 
 import "testing"
 
-const targetTestVersion = 1
-
 // Note: ConvertToBase should accept leading zeroes in its input,
 // but never emit leading zeroes in its output.
 // Exception: If the value of the output is zero, represent it with a single zero.
@@ -154,12 +152,6 @@ func digitsEqual(a, b []uint64) bool {
 	}
 
 	return true
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestConvertToBase(t *testing.T) {

--- a/exercises/all-your-base/example.go
+++ b/exercises/all-your-base/example.go
@@ -5,8 +5,6 @@ import (
 	"math"
 )
 
-const testVersion = 1
-
 var (
 	ErrInvalidBase  = errors.New("invalid base given")
 	ErrInvalidDigit = errors.New("invalid digit given")

--- a/exercises/allergies/allergies_test.go
+++ b/exercises/allergies/allergies_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var allergiesTests = []struct {
 	expected []string
 	input    uint
@@ -21,12 +19,6 @@ var allergiesTests = []struct {
 	{[]string{"strawberries", "tomatoes", "chocolate", "pollen", "cats"}, 248},
 	{[]string{"eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"}, 255},
 	{[]string{"eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"}, 509},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestAllergies(t *testing.T) {

--- a/exercises/allergies/example.go
+++ b/exercises/allergies/example.go
@@ -2,8 +2,6 @@ package allergies
 
 import "math"
 
-const testVersion = 1
-
 var allergens = []string{"eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"}
 
 func Allergies(i uint) (result []string) {

--- a/exercises/anagram/anagram_test.go
+++ b/exercises/anagram/anagram_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
 var testCases = []struct {
 	subject     string
 	candidates  []string
@@ -138,12 +136,6 @@ func equal(a []string, b []string) bool {
 	sort.Strings(a)
 	sort.Strings(b)
 	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestDetectAnagrams(t *testing.T) {

--- a/exercises/anagram/example.go
+++ b/exercises/anagram/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 2
-
 func Detect(subject string, candidates []string) []string {
 	subject = strings.ToLower(subject)
 	var matches []string

--- a/exercises/atbash-cipher/atbash_cipher_test.go
+++ b/exercises/atbash-cipher/atbash_cipher_test.go
@@ -2,14 +2,6 @@ package atbash
 
 import "testing"
 
-const targetTestVersion = 2
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestAtbash(t *testing.T) {
 	for _, test := range tests {
 		actual := Atbash(test.s)

--- a/exercises/atbash-cipher/example.go
+++ b/exercises/atbash-cipher/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 2
-
 var alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 func Atbash(s string) string {

--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -34,14 +34,6 @@ import (
 	"time"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestSeqOpenBalanceClose(t *testing.T) {
 	// open account
 	const amt = 10

--- a/exercises/bank-account/example.go
+++ b/exercises/bank-account/example.go
@@ -2,8 +2,6 @@ package account
 
 import "sync"
 
-const testVersion = 1
-
 type Account struct {
 	sync.RWMutex
 	open    bool

--- a/exercises/beer-song/beer_test.go
+++ b/exercises/beer-song/beer_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 const verse8 = "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n"
 const verse3 = "3 bottles of beer on the wall, 3 bottles of beer.\nTake one down and pass it around, 2 bottles of beer on the wall.\n"
 const verse2 = "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n"
@@ -46,12 +44,6 @@ var verseTestCases = []struct {
 	{"verse 1", 1, verse1, false},
 	{"verse 0", 0, verse0, false},
 	{"invalid verse", 104, "", true},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestBottlesVerse(t *testing.T) {

--- a/exercises/beer-song/example.go
+++ b/exercises/beer-song/example.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 1
-
 // Song returns the full lyrics for 99 bottles of beer
 func Song() (result string) {
 	result, _ = Verses(99, 0)

--- a/exercises/binary-search-tree/binary_search_tree_test.go
+++ b/exercises/binary-search-tree/binary_search_tree_test.go
@@ -19,14 +19,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestDataIsRetained(t *testing.T) {
 	actual := Bst(4).data
 	expected := 4

--- a/exercises/binary-search-tree/example.go
+++ b/exercises/binary-search-tree/example.go
@@ -1,7 +1,5 @@
 package binarysearchtree
 
-const testVersion = 1
-
 type SearchTreeData struct {
 	left  *SearchTreeData
 	data  int

--- a/exercises/binary-search/binary_search_test.go
+++ b/exercises/binary-search/binary_search_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var testData = []struct {
 	ref   string
 	slice []int
@@ -84,12 +82,6 @@ var testData = []struct {
 		0, 5},
 	{"slice has no values",
 		nil, 0, 0},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestSearchInts(t *testing.T) {

--- a/exercises/binary-search/example.go
+++ b/exercises/binary-search/example.go
@@ -2,8 +2,6 @@ package binarysearch
 
 import "fmt"
 
-const testVersion = 1
-
 func SearchInts(s []int, k int) (i int) {
 	for j := len(s); i < j; {
 		if h := (i + j) / 2; s[h] < k {

--- a/exercises/binary/binary_test.go
+++ b/exercises/binary/binary_test.go
@@ -13,11 +13,6 @@ import (
 // For invalid inputs, return an error that signals to the user why the error happened.
 // The test cases can only check that you return *some* error,
 // but it's still good practice to return useful errors.
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
-
-const targetTestVersion = 2
 
 var testCases = []struct {
 	binary   string
@@ -36,12 +31,6 @@ var testCases = []struct {
 	{"101bar", 0, false},
 	{"101baz010", 0, false},
 	{"22", 0, false},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestParseBinary(t *testing.T) {

--- a/exercises/binary/example.go
+++ b/exercises/binary/example.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 2
-
 // ParseBinary converts a binary string to an integer value
 func ParseBinary(bin string) (int, error) {
 	val := 0

--- a/exercises/bob/bob.go
+++ b/exercises/bob/bob.go
@@ -1,3 +1,1 @@
 package bob
-
-const testVersion = 3

--- a/exercises/bob/bob_test.go
+++ b/exercises/bob/bob_test.go
@@ -9,7 +9,6 @@ func TestHey(t *testing.T) {
 			msg := `
 	ALICE (%s): %q
 	BOB: %s
-
 	Expected Bob to respond: %s`
 			t.Fatalf(msg, tt.description, tt.input, actual, tt.expected)
 		}

--- a/exercises/bob/bob_test.go
+++ b/exercises/bob/bob_test.go
@@ -2,14 +2,6 @@ package bob
 
 import "testing"
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestHey(t *testing.T) {
 	for _, tt := range testCases {
 		actual := Hey(tt.input)

--- a/exercises/bob/example.go
+++ b/exercises/bob/example.go
@@ -2,8 +2,6 @@ package bob
 
 import "strings"
 
-const testVersion = 3
-
 // Hey returns Bob's responses to a given remark.
 func Hey(remark string) string {
 	switch remark = strings.TrimSpace(remark); {

--- a/exercises/bowling/bowling_test.go
+++ b/exercises/bowling/bowling_test.go
@@ -2,19 +2,11 @@ package bowling
 
 import "testing"
 
-const targetTestVersion = 1
-
 const previousRollErrorMessage = `FAIL: %s
 	Unexpected error occurred: %q
 	while applying the previous rolls for the
 	test case: %v
 	The error was returned from Roll(%d) for previousRolls[%d].`
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func applyPreviousRolls(g *Game, rolls []int) (int, int, error) {
 	for index, pins := range rolls {

--- a/exercises/bowling/example.go
+++ b/exercises/bowling/example.go
@@ -3,8 +3,6 @@ package bowling
 
 import "errors"
 
-const testVersion = 1
-
 var (
 	ErrNegativeRollIsInvalid        = errors.New("Negative roll is invalid")
 	ErrPinCountExceedsPinsOnTheLane = errors.New("Pin count exceeds pins on the lane")

--- a/exercises/bracket-push/bracket_push_test.go
+++ b/exercises/bracket-push/bracket_push_test.go
@@ -4,14 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 5
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestBracket(t *testing.T) {
 	for _, tt := range testCases {
 		actual, err := Bracket(tt.input)

--- a/exercises/bracket-push/example.go
+++ b/exercises/bracket-push/example.go
@@ -1,8 +1,5 @@
 package brackets
 
-// testVersion shows the version of the exercise.
-const testVersion = 5
-
 type bracketKind int
 
 const (

--- a/exercises/change/change_test.go
+++ b/exercises/change/change_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestChange(t *testing.T) {
 	for _, tc := range testCases {
 		actual, err := Change(tc.coins, tc.target)

--- a/exercises/change/example.go
+++ b/exercises/change/example.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 )
 
-const testVersion = 1
-
 var (
 	ErrNoSolutionFound = errors.New("No solution")
 	ErrNegativeTarget  = errors.New("Negative Target")

--- a/exercises/circular-buffer/circular_buffer_test.go
+++ b/exercises/circular-buffer/circular_buffer_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 4
-
 // Here is one way you can have a test case verify that the expected
 // interfaces are implemented.
 
@@ -87,12 +85,6 @@ func (tb testBuffer) overwrite(c byte) {
 }
 
 // tests.  separate functions so log will have descriptive test name.
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
 
 func TestReadEmptyBuffer(t *testing.T) {
 	tb := nb(1, t)

--- a/exercises/circular-buffer/example.go
+++ b/exercises/circular-buffer/example.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 )
 
-const testVersion = 4
-
 // Buffer implements a circular buffer supporting both overflow-checked writes
 // and unconditional, possibly overwriting, writes.
 type Buffer struct {

--- a/exercises/clock/clock.go
+++ b/exercises/clock/clock.go
@@ -1,6 +1,5 @@
 package clock
 
-const testVersion = 4
 
 // You can find more details and hints in the test file.
 

--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -27,14 +27,6 @@ import (
 // For some useful guidelines on when to use a value receiver or a pointer
 // receiver see: https://github.com/golang/go/wiki/CodeReviewComments#receiver-type
 
-const targetTestVersion = 4
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestCreateClock(t *testing.T) {
 	for _, n := range timeTests {
 		if got := New(n.h, n.m); got.String() != n.want {

--- a/exercises/clock/example.go
+++ b/exercises/clock/example.go
@@ -2,8 +2,6 @@ package clock
 
 import "fmt"
 
-const testVersion = 4
-
 type Clock int
 
 func New(h, m int) Clock {

--- a/exercises/connect/connect_test.go
+++ b/exercises/connect/connect_test.go
@@ -15,14 +15,6 @@ func prepare(lines []string) []string {
 	return newLines
 }
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestResultOf(t *testing.T) {
 	for _, tt := range testCases {
 		actual, err := ResultOf(prepare(tt.board))

--- a/exercises/connect/example.go
+++ b/exercises/connect/example.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const testVersion = 3
-
 const (
 	white = 1 << iota
 	black

--- a/exercises/crypto-square/crypto_square_test.go
+++ b/exercises/crypto-square/crypto_square_test.go
@@ -2,8 +2,6 @@ package cryptosquare
 
 import "testing"
 
-const targetTestVersion = 2
-
 var tests = []struct {
 	pt string // plain text
 	ct string // cipher text
@@ -84,12 +82,6 @@ var tests = []struct {
 		"Have a nice day. Feed the dog & chill out!",
 		"hifei acedl veeol eddgo aatcu nyhht",
 	},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestEncode(t *testing.T) {

--- a/exercises/crypto-square/example.go
+++ b/exercises/crypto-square/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 2
-
 func norm(r rune) rune {
 	switch {
 	case r >= 'a' && r <= 'z' || r >= '0' && r <= '9':

--- a/exercises/custom-set/custom_set_test.go
+++ b/exercises/custom-set/custom_set_test.go
@@ -28,14 +28,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 4
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 // A first set of tests uses Set.String() to judge correctness.
 
 func TestNew(t *testing.T) {

--- a/exercises/custom-set/example.go
+++ b/exercises/custom-set/example.go
@@ -4,8 +4,6 @@ package stringset
 
 import "fmt"
 
-const testVersion = 4
-
 // Set represents some properties of a mathematical set.
 // Sets are finite and all elements are unique string values.
 type Set map[string]bool

--- a/exercises/custom-set/example_slice.go
+++ b/exercises/custom-set/example_slice.go
@@ -10,8 +10,6 @@ package stringset
 
 import "fmt"
 
-const testVersion = 4
-
 // Set represents some properties of a mathematical set.
 // Sets are finite and all elements are unique string values.
 type Set struct {

--- a/exercises/diamond/diamond_test.go
+++ b/exercises/diamond/diamond_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-const targetTestVersion = 1
-
 var config = &quick.Config{Rand: rand.New(rand.NewSource(time.Now().UnixNano()))}
 
 type correctChar byte
@@ -37,12 +35,6 @@ func checkCorrect(requirement func(byte, []string) bool, keepSeparator bool, t *
 	}
 	if err := quick.Check(assertion, config); err != nil {
 		t.Error(err)
-	}
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
 	}
 }
 

--- a/exercises/diamond/example.go
+++ b/exercises/diamond/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 1
-
 const startIndex = 'A'
 
 // Gen builds a diamond

--- a/exercises/difference-of-squares/difference_of_squares_test.go
+++ b/exercises/difference-of-squares/difference_of_squares_test.go
@@ -2,18 +2,10 @@ package diffsquares
 
 import "testing"
 
-const targetTestVersion = 1
-
 var tests = []struct{ n, sqOfSums, sumOfSq int }{
 	{5, 225, 55},
 	{10, 3025, 385},
 	{100, 25502500, 338350},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestSquareOfSums(t *testing.T) {

--- a/exercises/difference-of-squares/example.go
+++ b/exercises/difference-of-squares/example.go
@@ -1,7 +1,5 @@
 package diffsquares
 
-const testVersion = 1
-
 func SquareOfSums(n int) int {
 	s := 0
 	for i := 0; i <= n; i++ {

--- a/exercises/diffie-hellman/diffie_hellman_test.go
+++ b/exercises/diffie-hellman/diffie_hellman_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 type testCase struct {
 	g    int64    // prime, generator
 	p    *big.Int // prime, modulus
@@ -79,12 +77,6 @@ var tests = []testCase{
 }
 
 var _one = big.NewInt(1)
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 // test that PrivateKey returns numbers in range, returns different numbers.
 func TestPrivateKey(t *testing.T) {

--- a/exercises/diffie-hellman/example.go
+++ b/exercises/diffie-hellman/example.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-const testVersion = 1
-
 var r = rand.New(rand.NewSource(time.Now().Unix()))
 var two = big.NewInt(2)
 

--- a/exercises/error-handling/error_handling_test.go
+++ b/exercises/error-handling/error_handling_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 // Please review the README for this exercise carefully before implementation.
-const targetTestVersion = 2
 
 // Little helper to let us customize behaviour of the resource on a per-test
 // basis.
@@ -19,12 +18,6 @@ type mockResource struct {
 func (mr mockResource) Close() error      { return mr.close() }
 func (mr mockResource) Frob(input string) { mr.frob(input) }
 func (mr mockResource) Defrob(tag string) { mr.defrob(tag) }
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 // Use should not return an error on the "happy" path.
 func TestNoErrors(t *testing.T) {

--- a/exercises/error-handling/example.go
+++ b/exercises/error-handling/example.go
@@ -1,7 +1,5 @@
 package erratum
 
-const testVersion = 2
-
 func Use(opener ResourceOpener, input string) (err error) {
 	var r Resource
 	for {

--- a/exercises/etl/etl_test.go
+++ b/exercises/etl/etl_test.go
@@ -2,8 +2,6 @@ package etl
 
 import "testing"
 
-const targetTestVersion = 1
-
 type given map[int][]string
 type expectation map[string]int
 
@@ -67,12 +65,6 @@ func equal(actual map[string]int, expectation map[string]int) bool {
 	}
 
 	return true
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestTransform(t *testing.T) {

--- a/exercises/etl/example.go
+++ b/exercises/etl/example.go
@@ -2,8 +2,6 @@ package etl
 
 import "strings"
 
-const testVersion = 1
-
 type legacy map[int][]string
 
 func Transform(in legacy) (out map[string]int) {

--- a/exercises/food-chain/example.go
+++ b/exercises/food-chain/example.go
@@ -1,7 +1,5 @@
 package foodchain
 
-const testVersion = 3
-
 var verse = []struct{ eaten, comment string }{
 	{"", ""},
 	{"fly", "I don't know why she swallowed the fly. Perhaps she'll die."},

--- a/exercises/food-chain/food_chain_test.go
+++ b/exercises/food-chain/food_chain_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
-
 var ref = []string{``,
 
 	`I know an old lady who swallowed a fly.
@@ -83,12 +81,6 @@ func diff(got, want string) string {
 		default:
 			return "no differences found"
 		}
-	}
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
 	}
 }
 

--- a/exercises/forth/example.go
+++ b/exercises/forth/example.go
@@ -233,5 +233,3 @@ var errNotEnoughOperands = errors.New("not enough operands")
 var errDivideByZero = errors.New("attempt to divide by zero")
 var errEmptyUserDef = errors.New("empty user definition")
 var errInvalidUserDef = errors.New("invalid user def word")
-
-const testVersion = 2

--- a/exercises/forth/forth_test.go
+++ b/exercises/forth/forth_test.go
@@ -9,14 +9,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestForth(t *testing.T) {
 	for _, tg := range testGroups {
 		for _, tc := range tg.tests {

--- a/exercises/gigasecond/example.go
+++ b/exercises/gigasecond/example.go
@@ -2,8 +2,6 @@ package gigasecond
 
 import "time"
 
-const testVersion = 4
-
 // AddGigasecond returns time t plus one gigasecond.
 func AddGigasecond(t time.Time) time.Time {
 	return t.Add(1e9 * time.Second)

--- a/exercises/gigasecond/gigasecond.go
+++ b/exercises/gigasecond/gigasecond.go
@@ -3,6 +3,4 @@ package gigasecond
 // import path for the time package from the standard library
 import "time"
 
-const testVersion = 4
-
 func AddGigasecond(time.Time) time.Time

--- a/exercises/gigasecond/gigasecond_test.go
+++ b/exercises/gigasecond/gigasecond_test.go
@@ -8,19 +8,11 @@ import (
 	"time"
 )
 
-const targetTestVersion = 4
-
 // date formats used in test data
 const (
 	fmtD  = "2006-01-02"
 	fmtDT = "2006-01-02T15:04:05"
 )
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func TestAddGigasecond(t *testing.T) {
 	for _, tc := range addCases {

--- a/exercises/grade-school/example.go
+++ b/exercises/grade-school/example.go
@@ -2,7 +2,6 @@ package school
 
 import "sort"
 
-const testVersion = 1
 
 type School map[int][]string
 

--- a/exercises/grade-school/example.go
+++ b/exercises/grade-school/example.go
@@ -2,7 +2,6 @@ package school
 
 import "sort"
 
-
 type School map[int][]string
 
 func New() *School {

--- a/exercises/grade-school/grade_school_test.go
+++ b/exercises/grade-school/grade_school_test.go
@@ -19,14 +19,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestNewSchoolIsEmpty(t *testing.T) {
 	if len(New().Enrollment()) != 0 {
 		t.Error("New school not empty")

--- a/exercises/grains/example.go
+++ b/exercises/grains/example.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 1
-
 // Square returns the number of grains on a square on a chess board where the
 // first square has 1 and every subsequent square doubles the number.
 func Square(num int) (uint64, error) {

--- a/exercises/grains/grains_test.go
+++ b/exercises/grains/grains_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var squareTests = []struct {
 	input       int
 	expectedVal uint64
@@ -21,12 +19,6 @@ var squareTests = []struct {
 	{65, 0, true},
 	{0, 0, true},
 	{-1, 0, true},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestSquare(t *testing.T) {

--- a/exercises/hamming/example.go
+++ b/exercises/hamming/example.go
@@ -2,8 +2,6 @@ package hamming
 
 import "errors"
 
-const testVersion = 6
-
 func Distance(a, b string) (d int, err error) {
 	if len(b) != len(a) {
 		return 0, errors.New("strings of unequal length")

--- a/exercises/hamming/hamming.go
+++ b/exercises/hamming/hamming.go
@@ -1,6 +1,4 @@
 package hamming
 
-const testVersion = 6
-
 func Distance(a, b string) (int, error) {
 }

--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -2,14 +2,6 @@ package hamming
 
 import "testing"
 
-const targetTestVersion = 6
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
-
 func TestHamming(t *testing.T) {
 	for _, tc := range testCases {
 		got, err := Distance(tc.s1, tc.s2)

--- a/exercises/hexadecimal/example.go
+++ b/exercises/hexadecimal/example.go
@@ -8,8 +8,6 @@ import (
 	"math"
 )
 
-const testVersion = 1
-
 // ErrRange indicates that a value is out of range for the target type.
 var ErrRange = errors.New("value out of range")
 

--- a/exercises/hexadecimal/hexadecimal_test.go
+++ b/exercises/hexadecimal/hexadecimal_test.go
@@ -15,8 +15,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var testCases = []struct {
 	in      string
 	out     int64
@@ -33,12 +31,6 @@ var testCases = []struct {
 	{"2cg134", 0, "syntax"},
 	{"8000000000000000", 0, "range"},
 	{"9223372036854775809", 0, "range"},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestParseHex(t *testing.T) {

--- a/exercises/house/example.go
+++ b/exercises/house/example.go
@@ -1,7 +1,5 @@
 package house
 
-const testVersion = 1
-
 var songLines = []string{
 	"the horse and the hound and the horn\nthat belonged to",
 	"the farmer sowing his corn\nthat kept",

--- a/exercises/house/house_test.go
+++ b/exercises/house/house_test.go
@@ -15,8 +15,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var (
 	// song copied from README
 	expectedSong = `This is the house that Jack built.
@@ -111,12 +109,6 @@ that lay in the house that Jack built.`
 
 	expectedVerses = strings.Split(expectedSong, "\n\n")
 )
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func TestVerse(t *testing.T) {
 	for v := 0; v < len(expectedVerses); v++ {

--- a/exercises/isogram/example.go
+++ b/exercises/isogram/example.go
@@ -2,8 +2,6 @@ package isogram
 
 import "strings"
 
-const testVersion = 1
-
 func IsIsogram(word string) bool {
 	for i, r := range strings.ToLower(word) {
 		if r != ' ' && r != '-' && i < strings.LastIndex(word, string(r)) {

--- a/exercises/isogram/isogram_test.go
+++ b/exercises/isogram/isogram_test.go
@@ -2,8 +2,6 @@ package isogram
 
 import "testing"
 
-const targetTestVersion = 1
-
 var testCases = []struct {
 	word     string
 	expected bool
@@ -18,12 +16,6 @@ var testCases = []struct {
 	{"the quick brown fox", false},
 	{"Emily Jung Schwartzkopf", true},
 	{"éléphant", false},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestIsIsogram(t *testing.T) {

--- a/exercises/kindergarten-garden/example.go
+++ b/exercises/kindergarten-garden/example.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const testVersion = 1
-
 type Garden map[string][]string
 
 func (g *Garden) Plants(child string) ([]string, bool) {

--- a/exercises/kindergarten-garden/kindergarten_garden_test.go
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 type lookup struct {
 	child  string
 	plants []string
@@ -118,12 +116,6 @@ RVGCCGCV`, append([]string{}, test6names...), true, []lookup{
 		{"Xander", []string{"radishes", "grass", "clover", "violets"}, true},
 	}}
 )
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
 
 func TestGarden(t *testing.T) {
 	for _, test := range tests {

--- a/exercises/largest-series-product/example.go
+++ b/exercises/largest-series-product/example.go
@@ -2,8 +2,6 @@ package lsproduct
 
 import "fmt"
 
-const testVersion = 5
-
 func LargestSeriesProduct(digits string, span int) (int64, error) {
 	if span < 0 {
 		return 0, fmt.Errorf("span is negative: %d", span)

--- a/exercises/largest-series-product/largest_series_product_test.go
+++ b/exercises/largest-series-product/largest_series_product_test.go
@@ -2,14 +2,6 @@ package lsproduct
 
 import "testing"
 
-const targetTestVersion = 5
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestLargestSeriesProduct(t *testing.T) {
 	for _, test := range tests {
 		p, err := LargestSeriesProduct(test.digits, test.span)

--- a/exercises/leap/example.go
+++ b/exercises/leap/example.go
@@ -1,7 +1,5 @@
 package leap
 
-const testVersion = 3
-
 func IsLeapYear(i int) bool {
 	return i%4 == 0 && i%100 != 0 || i%400 == 0
 }

--- a/exercises/leap/leap.go
+++ b/exercises/leap/leap.go
@@ -1,6 +1,4 @@
 package leap
 
-const testVersion = 3
-
 func IsLeapYear(int) bool {
 }

--- a/exercises/leap/leap_test.go
+++ b/exercises/leap/leap_test.go
@@ -2,21 +2,6 @@ package leap
 
 import "testing"
 
-// targetTestVersion is used to ensure that a solution is only evaluated
-// against the correct version of the test suite.
-const targetTestVersion = 3
-
-// TestTestVersion compares the targetTestVersion defined above with
-// a testVersion value.
-// This is a common convention throughout the Go Exercism track.
-// To make a test like this test pass, define 'testVersion' in your solution.
-// We've done this for you in the ./leap.go file provided.
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestLeapYears(t *testing.T) {
 	for _, test := range testCases {
 		observed := IsLeapYear(test.year)

--- a/exercises/ledger/example.go
+++ b/exercises/ledger/example.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const testVersion = 4
-
 type Entry struct {
 	Date        string // "Y-m-d"
 	Description string

--- a/exercises/ledger/ledger.go
+++ b/exercises/ledger/ledger.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const testVersion = 4
-
 type Entry struct {
 	Date        string // "Y-m-d"
 	Description string

--- a/exercises/ledger/ledger_test.go
+++ b/exercises/ledger/ledger_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 4
-
 var successTestCases = []struct {
 	name     string
 	currency string
@@ -248,12 +246,6 @@ var failureTestCases = []struct {
 			},
 		},
 	},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestFormatLedgerSuccess(t *testing.T) {

--- a/exercises/luhn/example.go
+++ b/exercises/luhn/example.go
@@ -2,8 +2,6 @@ package luhn
 
 import "strings"
 
-const testVersion = 2
-
 func Valid(id string) bool {
 
 	if len(strings.TrimSpace(id)) == 1 {

--- a/exercises/luhn/luhn_test.go
+++ b/exercises/luhn/luhn_test.go
@@ -2,14 +2,6 @@ package luhn
 
 import "testing"
 
-const targetTestVersion = 2
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Errorf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestValid(t *testing.T) {
 	for _, test := range testCases {
 		if ok := Valid(test.input); ok != test.ok {

--- a/exercises/matrix/example.go
+++ b/exercises/matrix/example.go
@@ -9,8 +9,6 @@ import (
 // Maintenance note:  This file exists as both matrix/example.go and
 // saddle-points/matrix_example.go.  When changing one file, copy to the other.
 
-const testVersion = 1
-
 type Matrix [][]int
 
 func New(s string) (*Matrix, error) {

--- a/exercises/matrix/matrix_test.go
+++ b/exercises/matrix/matrix_test.go
@@ -18,8 +18,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	in   string
 	ok   bool
@@ -140,12 +138,6 @@ var tests = []struct {
 	// undefined
 	// {"\n\n", // valid?, 3 rows, 0 columns
 	// {"",     // valid?, 0 rows, 0 columns
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestNew(t *testing.T) {

--- a/exercises/meetup/example.go
+++ b/exercises/meetup/example.go
@@ -2,8 +2,6 @@ package meetup
 
 import "time"
 
-const testVersion = 3
-
 type WeekSchedule int
 
 const (

--- a/exercises/meetup/meetup_test.go
+++ b/exercises/meetup/meetup_test.go
@@ -14,8 +14,6 @@ WeekSchedule Teenth
 func Day(WeekSchedule, time.Weekday, time.Month, int) int
 */
 
-const targetTestVersion = 3
-
 var weekName = map[WeekSchedule]string{
 	First:  "first",
 	Second: "second",
@@ -23,12 +21,6 @@ var weekName = map[WeekSchedule]string{
 	Fourth: "fourth",
 	Teenth: "teenth",
 	Last:   "last",
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestDay(t *testing.T) {

--- a/exercises/minesweeper/example.go
+++ b/exercises/minesweeper/example.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 )
 
-const testVersion = 1
-
 func (b Board) Count() error {
 	if len(b) < 2 {
 		return errors.New("need top and bottom border")

--- a/exercises/minesweeper/minesweeper_test.go
+++ b/exercises/minesweeper/minesweeper_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var validBoards = []string{
 	// zero size board
 	`
@@ -149,12 +147,6 @@ func clear(s string) Board {
 		}
 	}
 	return bytes.Split(b, []byte{'\n'})[1:]
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestValid(t *testing.T) {

--- a/exercises/nth-prime/example.go
+++ b/exercises/nth-prime/example.go
@@ -1,7 +1,5 @@
 package prime
 
-const testVersion = 1
-
 func Nth(n int) (p int, ok bool) {
 	switch {
 	case n < 1:

--- a/exercises/nth-prime/nth_prime_test.go
+++ b/exercises/nth-prime/nth_prime_test.go
@@ -2,8 +2,6 @@ package prime
 
 import "testing"
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	n  int
 	p  int
@@ -17,12 +15,6 @@ var tests = []struct {
 	{6, 13, true},
 	{10001, 104743, true},
 	{0, 0, false},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestNth(t *testing.T) {

--- a/exercises/nucleotide-count/example.go
+++ b/exercises/nucleotide-count/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 2
-
 // Histogram is a mapping from nucleotide to its count in given DNA
 type Histogram map[byte]int
 

--- a/exercises/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/nucleotide-count/nucleotide_count_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
 var tallyTests = []struct {
 	strand     DNA
 	nucleotide byte
@@ -16,12 +14,6 @@ var tallyTests = []struct {
 	{"ACT", 'G', 0},
 	{"CCCCC", 'C', 5},
 	{"GGGGGTAACCCGG", 'T', 1},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestNucleotideCounts(t *testing.T) {

--- a/exercises/ocr-numbers/example.go
+++ b/exercises/ocr-numbers/example.go
@@ -2,8 +2,6 @@ package ocr
 
 import "strings"
 
-const testVersion = 1
-
 var digit = map[string]byte{
 	" _ | ||_|   ": '0',
 	"     |  |   ": '1',

--- a/exercises/ocr-numbers/ocr_numbers_test.go
+++ b/exercises/ocr-numbers/ocr_numbers_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	in  string
 	out []string
@@ -122,12 +120,6 @@ var tests = []struct {
 }
 
 var _ = recognizeDigit // step 1.
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func TestRecognize(t *testing.T) {
 	for _, test := range tests {

--- a/exercises/octal/example.go
+++ b/exercises/octal/example.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 1
-
 func ParseOctal(octal string) (int64, error) {
 	num := int64(0)
 	for _, digit := range octal {

--- a/exercises/octal/octal_test.go
+++ b/exercises/octal/octal_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var testCases = []struct {
 	input       string
 	expectedNum int64
@@ -16,12 +14,6 @@ var testCases = []struct {
 	{"1234567", 342391, false},
 	{"carrot", 0, true},
 	{"35682", 0, true},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestParseOctal(t *testing.T) {

--- a/exercises/paasio/example.go
+++ b/exercises/paasio/example.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 )
 
-const testVersion = 3
-
 // NewWriteCounter returns an implementation of WriteCounter.  Calls to
 // w.Write() are not guaranteed to be synchronized.
 func NewWriteCounter(w io.Writer) WriteCounter {

--- a/exercises/paasio/paasio_test.go
+++ b/exercises/paasio/paasio_test.go
@@ -11,14 +11,6 @@ import (
 	"time"
 )
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestMultiThreaded(t *testing.T) {
 	mincpu := 2
 	minproc := 2

--- a/exercises/palindrome-products/example.go
+++ b/exercises/palindrome-products/example.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 )
 
-const testVersion = 1
-
 func isPal(x int) bool {
 	s := strconv.Itoa(x)
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {

--- a/exercises/palindrome-products/palindrome_products_test.go
+++ b/exercises/palindrome-products/palindrome_products_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 /* API to implement:
 
 type Product struct {
@@ -73,12 +71,6 @@ var bonusData = []struct {
 		Product{-4, [][2]int{{-2, 2}}},
 		Product{4, [][2]int{{-2, -2}, {2, 2}}},
 		""},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestPalindromeProducts(t *testing.T) {

--- a/exercises/pangram/example.go
+++ b/exercises/pangram/example.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 )
 
-
 func IsPangram(s string) bool {
 	lowerString := strings.ToLower(s)
 	var check [26]bool

--- a/exercises/pangram/example.go
+++ b/exercises/pangram/example.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 )
 
-const testVersion = 2
 
 func IsPangram(s string) bool {
 	lowerString := strings.ToLower(s)

--- a/exercises/pangram/pangram.go
+++ b/exercises/pangram/pangram.go
@@ -1,5 +1,3 @@
 package pangram
 
-const testVersion = 2
-
 func IsPangram(string) bool

--- a/exercises/pangram/pangram_test.go
+++ b/exercises/pangram/pangram_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
 type testCase struct {
 	input         string
 	expected      bool
@@ -20,12 +18,6 @@ var testCases = []testCase{
 	{"the 1 quick brown fox jumps over the 2 lazy dogs", true, ""},
 	{"7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog", false, "missing letters replaced by numbers"},
 	{"\"Five quacking Zephyrs jolt my wax bed.\"", true, ""},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestPangram(t *testing.T) {

--- a/exercises/parallel-letter-frequency/example.go
+++ b/exercises/parallel-letter-frequency/example.go
@@ -1,7 +1,5 @@
 package letter
 
-const testVersion = 1
-
 func ConcurrentFrequency(l []string) FreqMap {
 	switch len(l) {
 	case 0:

--- a/exercises/parallel-letter-frequency/parallel_letter_frequency_test.go
+++ b/exercises/parallel-letter-frequency/parallel_letter_frequency_test.go
@@ -40,14 +40,6 @@ O say does that star-spangled banner yet wave,
 O'er the land of the free and the home of the brave?`
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestConcurrentFrequency(t *testing.T) {
 	seq := Frequency(euro + dutch + us)
 	con := ConcurrentFrequency([]string{euro, dutch, us})

--- a/exercises/pascals-triangle/example.go
+++ b/exercises/pascals-triangle/example.go
@@ -1,7 +1,5 @@
 package pascal
 
-const testVersion = 1
-
 func Triangle(n int) (t [][]int) {
 	if n < 1 {
 		return

--- a/exercises/pascals-triangle/pascals_triangle_test.go
+++ b/exercises/pascals-triangle/pascals_triangle_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var triangleTestCases = [][]int{
 	{1},
 	{1, 1},
@@ -32,12 +30,6 @@ var triangleTestCases = [][]int{
 }
 
 var testSize = len(triangleTestCases)
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func TestTriangle(t *testing.T) {
 	for n := 1; n <= testSize; n++ {

--- a/exercises/perfect-numbers/example.go
+++ b/exercises/perfect-numbers/example.go
@@ -2,8 +2,6 @@ package perfect
 
 import "errors"
 
-const testVersion = 1
-
 // Classification is the category devised by Greek Mathematician Nicomachus
 type Classification string
 

--- a/exercises/perfect-numbers/perfect_numbers_test.go
+++ b/exercises/perfect-numbers/perfect_numbers_test.go
@@ -17,14 +17,6 @@ var classificationTestCases = []struct {
 	{8128, ClassificationPerfect},
 }
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
-
 func TestGivesPositiveRequiredError(t *testing.T) {
 	if _, err := Classify(0); err != ErrOnlyPositive {
 		t.Errorf("Expected error %q but got %q", ErrOnlyPositive, err)

--- a/exercises/phone-number/example.go
+++ b/exercises/phone-number/example.go
@@ -5,8 +5,6 @@ import (
 	"unicode"
 )
 
-const testVersion = 3
-
 // Number takes in a potential phone number string and returns the number
 // without any formatting if it's valid.
 //

--- a/exercises/phone-number/phone_number_test.go
+++ b/exercises/phone-number/phone_number_test.go
@@ -4,14 +4,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestNumber(t *testing.T) {
 	for _, test := range numberTests {
 		actual, actualErr := Number(test.input)

--- a/exercises/pig-latin/example.go
+++ b/exercises/pig-latin/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 1
-
 var vowel = regexp.MustCompile(`^([aeiou]|y[^aeiou]|xr)[a-z]*`)
 var cons = regexp.MustCompile(`^([^aeiou]?qu|[^aeiou]+)([a-z]*)`)
 

--- a/exercises/pig-latin/pig_latin_test.go
+++ b/exercises/pig-latin/pig_latin_test.go
@@ -2,8 +2,6 @@ package igpay
 
 import "testing"
 
-const targetTestVersion = 1
-
 var tests = []struct{ pl, in string }{
 	{"appleay", "apple"},
 	{"earay", "ear"},
@@ -20,12 +18,6 @@ var tests = []struct{ pl, in string }{
 	{"yttriaay", "yttria"},
 	{"enonxay", "xenon"},
 	{"xrayay", "xray"},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestPigLatin(t *testing.T) {

--- a/exercises/poker/example.go
+++ b/exercises/poker/example.go
@@ -7,8 +7,6 @@ import (
 	"unicode/utf8"
 )
 
-const testVersion = 5
-
 const (
 	Jack  = 11
 	Queen = 12

--- a/exercises/poker/poker_test.go
+++ b/exercises/poker/poker_test.go
@@ -6,11 +6,6 @@ import (
 )
 
 // Define a function BestHand([]string) ([]string, error).
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
-
-const targetTestVersion = 5
 
 var invalidTestCases = []struct {
 	name string
@@ -56,12 +51,6 @@ var invalidTestCases = []struct {
 		name: "double suits after rank",
 		hand: "2♡ 3♡ 5♡♡ 8♡ 9♡",
 	},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestBestHandValid(t *testing.T) {

--- a/exercises/pov/example.go
+++ b/exercises/pov/example.go
@@ -5,8 +5,6 @@ import (
 	"log"
 )
 
-const testVersion = 2
-
 type Graph struct {
 	arcs   [][]int
 	labels []string

--- a/exercises/pov/pov_test.go
+++ b/exercises/pov/pov_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
 // POV / reparent / change root of a tree
 //
 // API:
@@ -257,12 +255,6 @@ func (tc testCase) testResult(got, want []string, msg string, t *testing.T) {
 		t.Log(" ", s)
 	}
 	t.FailNow()
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestConstruction(t *testing.T) {

--- a/exercises/prime-factors/example.go
+++ b/exercises/prime-factors/example.go
@@ -1,7 +1,5 @@
 package prime
 
-const testVersion = 2
-
 func Factors(n int64) []int64 {
 	factors := []int64{}
 	possibleFactor := int64(2)

--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
 var tests = []struct {
 	input    int64
 	expected []int64
@@ -24,12 +22,6 @@ var tests = []struct {
 	{625, []int64{5, 5, 5, 5}},
 	{901255, []int64{5, 17, 23, 461}},
 	{93819012551, []int64{11, 9539, 894119}},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestPrimeFactors(t *testing.T) {

--- a/exercises/protein-translation/example.go
+++ b/exercises/protein-translation/example.go
@@ -1,7 +1,5 @@
 package protein
 
-const testVersion = 1
-
 func FromCodon(codon string) string {
 	switch codon {
 	case

--- a/exercises/protein-translation/protein_translation_test.go
+++ b/exercises/protein-translation/protein_translation_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 type codonCase struct {
 	input    string
 	expected string
@@ -42,12 +40,6 @@ var proteinTestCases = []rnaCase{
 	{"AUGUUUUGG", []string{"Methionine", "Phenylalanine", "Tryptophan"}},
 	{"AUGUUUUAA", []string{"Methionine", "Phenylalanine"}},
 	{"UGGUGUUAUUAAUGGUUU", []string{"Tryptophan", "Cysteine", "Tyrosine"}},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestCodon(t *testing.T) {

--- a/exercises/pythagorean-triplet/example.go
+++ b/exercises/pythagorean-triplet/example.go
@@ -1,7 +1,5 @@
 package pythagorean
 
-const testVersion = 1
-
 type Triplet [3]int
 
 func pyth(a, b, c int) bool {

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.go
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.go
@@ -24,14 +24,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 var rangeTests = []struct {
 	min, max int
 	ts       []Triplet

--- a/exercises/queen-attack/example.go
+++ b/exercises/queen-attack/example.go
@@ -2,8 +2,6 @@ package queenattack
 
 import "fmt"
 
-const testVersion = 2
-
 func CanQueenAttack(w, b string) (attack bool, err error) {
 	if err = valSq(w); err != nil {
 		return false, err

--- a/exercises/queen-attack/queen_attack_test.go
+++ b/exercises/queen-attack/queen_attack_test.go
@@ -5,8 +5,6 @@ import "testing"
 // Arguments to CanQueenAttack are in algebraic notation.
 // See http://en.wikipedia.org/wiki/Algebraic_notation_(chess)
 
-const targetTestVersion = 2
-
 var tests = []struct {
 	w, b   string
 	attack bool
@@ -29,12 +27,6 @@ var tests = []struct {
 	{"f1", "a6", true, true},
 	{"a1", "h8", true, true},
 	{"a8", "h1", true, true},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestCanQueenAttack(t *testing.T) {

--- a/exercises/raindrops/example.go
+++ b/exercises/raindrops/example.go
@@ -2,8 +2,6 @@ package raindrops
 
 import "strconv"
 
-const testVersion = 3
-
 func Convert(number int) string {
 	s := ""
 	if number%3 == 0 {

--- a/exercises/raindrops/raindrops.go
+++ b/exercises/raindrops/raindrops.go
@@ -1,7 +1,5 @@
 package raindrops
 
-const testVersion = 3
-
 func Convert(int) string
 
 // Don't forget the test program has a benchmark too.

--- a/exercises/raindrops/raindrops_test.go
+++ b/exercises/raindrops/raindrops_test.go
@@ -2,14 +2,6 @@ package raindrops
 
 import "testing"
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestConvert(t *testing.T) {
 	for _, test := range tests {
 		if actual := Convert(test.input); actual != test.expected {

--- a/exercises/react/example.go
+++ b/exercises/react/example.go
@@ -1,7 +1,5 @@
 package react
 
-const testVersion = 5
-
 type reactor struct {
 	cells []*cell
 }

--- a/exercises/react/react_test.go
+++ b/exercises/react/react_test.go
@@ -7,11 +7,6 @@ import (
 
 // Define a function New() Reactor and the stuff that follows from
 // implementing Reactor.
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
-
-const targetTestVersion = 5
 
 // This is a compile time check to see if you've properly implemented New().
 var _ Reactor = New()
@@ -21,12 +16,6 @@ func assertCellValue(t *testing.T, c Cell, expected int, explanation string) {
 	_, _, line, _ := runtime.Caller(1)
 	if observed != expected {
 		t.Fatalf("(from line %d) %s: expected %d, got %d", line, explanation, expected, observed)
-	}
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
 	}
 }
 

--- a/exercises/rna-transcription/example.go
+++ b/exercises/rna-transcription/example.go
@@ -2,8 +2,6 @@ package strand
 
 import "strings"
 
-const testVersion = 3
-
 func ToRNA(dna string) string {
 	dna = strings.Replace(dna, "A", "u", -1)
 	dna = strings.Replace(dna, "T", "a", -1)

--- a/exercises/rna-transcription/rna_transcription_test.go
+++ b/exercises/rna-transcription/rna_transcription_test.go
@@ -2,14 +2,6 @@ package strand
 
 import "testing"
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestRNATranscription(t *testing.T) {
 	for _, test := range rnaTests {
 		if actual := ToRNA(test.input); actual != test.expected {

--- a/exercises/robot-name/example.go
+++ b/exercises/robot-name/example.go
@@ -7,8 +7,6 @@ import (
 	"math/rand"
 )
 
-const testVersion = 1
-
 type Robot struct {
 	name string
 }

--- a/exercises/robot-name/robot_name_test.go
+++ b/exercises/robot-name/robot_name_test.go
@@ -5,17 +5,9 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var namePat = regexp.MustCompile(`^[A-Z]{2}\d{3}$`)
 
 func New() *Robot { return new(Robot) }
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func TestNameValid(t *testing.T) {
 	n := New().Name()

--- a/exercises/robot-simulator/example.go
+++ b/exercises/robot-simulator/example.go
@@ -3,7 +3,6 @@ package robot
 import "fmt"
 
 // ======= Step 1
-const testVersion = 3
 const (
 	N Dir = iota
 	E

--- a/exercises/robot-simulator/robot_simulator_test.go
+++ b/exercises/robot-simulator/robot_simulator_test.go
@@ -25,14 +25,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestStep1(t *testing.T) {
 
 	want := func(x, y int, dir Dir) {

--- a/exercises/roman-numerals/example.go
+++ b/exercises/roman-numerals/example.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 4
-
 type arabicToRoman struct {
 	arabic int
 	roman  string

--- a/exercises/roman-numerals/roman_numerals_test.go
+++ b/exercises/roman-numerals/roman_numerals_test.go
@@ -2,14 +2,6 @@ package romannumerals
 
 import "testing"
 
-const targetTestVersion = 4
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestRomanNumerals(t *testing.T) {
 	tc := append(romanNumeralTests, []romanNumeralTest{
 		{0, "", true},

--- a/exercises/saddle-points/example.go
+++ b/exercises/saddle-points/example.go
@@ -1,7 +1,5 @@
 package matrix
 
-const testVersion = 1
-
 type Pair struct{ r, c int }
 
 func (m *Matrix) Saddle() (p []Pair) {

--- a/exercises/saddle-points/saddle_points_test.go
+++ b/exercises/saddle-points/saddle_points_test.go
@@ -8,8 +8,6 @@ package matrix
 
 import "testing"
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	m  string
 	sp []Pair
@@ -18,12 +16,6 @@ var tests = []struct {
 	{"1 2\n3 4", []Pair{{0, 1}}},
 	{"18 3 39 19 91\n38 10 8 77 320\n3 4 8 6 7", []Pair{{2, 2}}},
 	{"4 5 4\n3 5 5\n1 5 4", []Pair{{0, 1}, {1, 1}, {2, 1}}},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestSaddle(t *testing.T) {

--- a/exercises/say/example.go
+++ b/exercises/say/example.go
@@ -1,7 +1,5 @@
 package say
 
-const testVersion = 1
-
 var small = []string{"zero", "one", "two", "three", "four", "five", "six",
 	"seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen",
 	"fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"}

--- a/exercises/say/say_test.go
+++ b/exercises/say/say_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	uint64
 	string
@@ -38,12 +36,6 @@ var tests = []struct {
 		"seven hundred nine million " +
 		"five hundred fifty-one thousand " +
 		"six hundred fifteen"},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestSay(t *testing.T) {

--- a/exercises/scrabble-score/example.go
+++ b/exercises/scrabble-score/example.go
@@ -4,9 +4,6 @@ import (
 	"strings"
 )
 
-// testVersion tracks the version of the exercise.
-const testVersion = 5
-
 var letterValues = map[rune]int{
 	'a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1,
 	'f': 4, 'g': 2, 'h': 4, 'i': 1, 'j': 8,

--- a/exercises/scrabble-score/scrabble_score_test.go
+++ b/exercises/scrabble-score/scrabble_score_test.go
@@ -2,14 +2,6 @@ package scrabble
 
 import "testing"
 
-const targetTestVersion = 5
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestScore(t *testing.T) {
 	for _, test := range scrabbleScoreTests {
 		if actual := Score(test.input); actual != test.expected {

--- a/exercises/secret-handshake/example.go
+++ b/exercises/secret-handshake/example.go
@@ -1,7 +1,5 @@
 package secret
 
-const testVersion = 2
-
 var signals = []string{"wink", "double blink", "close your eyes", "jump"}
 
 // Handshake returns sequence to perform corresponding to the given code.

--- a/exercises/secret-handshake/secret_handshake_test.go
+++ b/exercises/secret-handshake/secret_handshake_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestHandshake(t *testing.T) {
 	for _, test := range tests {
 		h := Handshake(test.code)

--- a/exercises/series/example.go
+++ b/exercises/series/example.go
@@ -1,7 +1,5 @@
 package series
 
-const testVersion = 2
-
 func All(n int, s string) (r []string) {
 	for i := 0; n <= len(s); i++ {
 		r = append(r, s[i:n])

--- a/exercises/series/series_test.go
+++ b/exercises/series/series_test.go
@@ -34,8 +34,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
 var allTests = []struct {
 	n   int
 	s   string
@@ -70,12 +68,6 @@ var allTests = []struct {
 }
 
 var cx = "01032987583"
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
 
 func TestAll(t *testing.T) {
 	for _, test := range allTests {

--- a/exercises/sieve/example.go
+++ b/exercises/sieve/example.go
@@ -1,7 +1,5 @@
 package sieve
 
-const testVersion = 1
-
 func Sieve(limit int) (primes []int) {
 	c := make([]bool, limit)
 	for p := 2; p < limit; {

--- a/exercises/sieve/sieve_test.go
+++ b/exercises/sieve/sieve_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 var p10 = []int{2, 3, 5, 7}
 var p1000 = []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
 	59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137,
@@ -19,12 +17,6 @@ var p1000 = []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
 	683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787,
 	797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883,
 	887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
 
 func TestSieve(t *testing.T) {
 	p := Sieve(10)

--- a/exercises/simple-cipher/example.go
+++ b/exercises/simple-cipher/example.go
@@ -2,8 +2,6 @@ package cipher
 
 import "strings"
 
-const testVersion = 1
-
 type shift int
 
 func NewCaesar() Cipher { return NewShift(3) }

--- a/exercises/simple-cipher/simple_cipher_test.go
+++ b/exercises/simple-cipher/simple_cipher_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 // type for testing cipher encoding alone, without requiring any text prep.
 type prepped struct {
 	pt string // prepped text == decoded plain text

--- a/exercises/strain/example.go
+++ b/exercises/strain/example.go
@@ -1,7 +1,5 @@
 package strain
 
-const testVersion = 1
-
 type Ints []int
 
 func (s Ints) Keep(f func(int) bool) (r Ints) {

--- a/exercises/strain/strain_test.go
+++ b/exercises/strain/strain_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 func lt10(x int) bool { return x < 10 }
 func gt10(x int) bool { return x > 10 }
 func odd(x int) bool  { return x&1 == 1 }
@@ -62,12 +60,6 @@ var discardTests = []struct {
 	{even,
 		Ints{1, 2, 3, 4, 5},
 		Ints{1, 3, 5}},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestKeepInts(t *testing.T) {

--- a/exercises/sum-of-multiples/example.go
+++ b/exercises/sum-of-multiples/example.go
@@ -1,7 +1,5 @@
 package summultiples
 
-const testVersion = 2
-
 // SumMultiples returns the sum of the multiples of the given divisors
 // up to, but not including, the given limit.
 func SumMultiples(limit int, divisors ...int) (sum int) {

--- a/exercises/sum-of-multiples/sum_of_multiples_test.go
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.go
@@ -2,14 +2,6 @@ package summultiples
 
 import "testing"
 
-const targetTestVersion = 2
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestSumMultiples(t *testing.T) {
 	for _, test := range varTests {
 		s := SumMultiples(test.limit, test.divisors...)

--- a/exercises/tournament/example.go
+++ b/exercises/tournament/example.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 )
 
-const testVersion = 4
-
 type outcome int
 
 const (

--- a/exercises/tournament/tournament_test.go
+++ b/exercises/tournament/tournament_test.go
@@ -11,11 +11,6 @@ import (
 //
 // Note that unlike other tracks the Go version of the tally function
 // should not ignore errors. It's not idiomatic Go to ignore errors.
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
-
-const targetTestVersion = 4
 
 var _ func(io.Reader, io.Writer) error = Tally
 
@@ -108,12 +103,6 @@ var errorTestCases = []string{
 	"Devastating Donkeys_Courageous Californians;draw",
 	"Devastating Donkeys@Courageous Californians;draw",
 	"Devastating Donkeys;Allegoric Alaskians;dra",
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestTallyHappy(t *testing.T) {

--- a/exercises/transpose/example.go
+++ b/exercises/transpose/example.go
@@ -1,7 +1,5 @@
 package transpose
 
-const testVersion = 1
-
 func Transpose(m []string) []string {
 	max := maxLen(m)
 	t := make([]string, max)

--- a/exercises/transpose/transpose_test.go
+++ b/exercises/transpose/transpose_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestTranspose(t *testing.T) {
 	for _, test := range testCases {
 		actual := Transpose(test.input)

--- a/exercises/tree-building/example.go
+++ b/exercises/tree-building/example.go
@@ -5,8 +5,6 @@ import (
 	"sort"
 )
 
-const testVersion = 4
-
 type Record struct {
 	ID, Parent int
 }

--- a/exercises/tree-building/tree_building.go
+++ b/exercises/tree-building/tree_building.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 4
-
 type Record struct {
 	ID, Parent int
 }

--- a/exercises/tree-building/tree_test.go
+++ b/exercises/tree-building/tree_test.go
@@ -10,11 +10,6 @@ import (
 // Define a function Build(records []Record) (*Node, error)
 // where Record is a struct containing int fields ID and Parent
 // and Node is a struct containing int field ID and []*Node field Children.
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
-
-const targetTestVersion = 4
 
 var successTestCases = []struct {
 	name     string
@@ -208,12 +203,6 @@ var failureTestCases = []struct {
 
 func (n Node) String() string {
 	return fmt.Sprintf("%d:%s", n.ID, n.Children)
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestMakeTreeSuccess(t *testing.T) {

--- a/exercises/triangle/example.go
+++ b/exercises/triangle/example.go
@@ -4,8 +4,6 @@ import "math"
 
 type Kind string
 
-const testVersion = 3
-
 const (
 	Equ Kind = "equilateral"
 	Iso      = "isosceles"

--- a/exercises/triangle/triangle.go
+++ b/exercises/triangle/triangle.go
@@ -1,7 +1,5 @@
 package triangle
 
-const testVersion = 3
-
 func KindFromSides(a, b, c float64) Kind
 
 // Notice KindFromSides() returns this type. Pick a suitable data type.

--- a/exercises/triangle/triangle_test.go
+++ b/exercises/triangle/triangle_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
-
 type testCase struct {
 	want    Kind
 	a, b, c float64
@@ -51,12 +49,6 @@ func init() {
 		}
 	}
 	testData = append(testData, nf[1:]...)
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 // Test that the kinds are not equal to each other.

--- a/exercises/trinary/example.go
+++ b/exercises/trinary/example.go
@@ -5,8 +5,6 @@ import (
 	"math"
 )
 
-const testVersion = 1
-
 func ParseTrinary(s string) (int64, error) {
 	const third = math.MaxInt64 / 3
 	overflow := false

--- a/exercises/trinary/trinary_test.go
+++ b/exercises/trinary/trinary_test.go
@@ -2,8 +2,6 @@ package trinary
 
 import "testing"
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	arg  string
 	want int64
@@ -18,12 +16,6 @@ var tests = []struct {
 	{"0000000000000000000000000000000000000000201", 19, true},
 	{"2021110011022210012102010021220101220221", 9223372036854775807, true},
 	{"2021110011022210012102010021220101220222", 0, false},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
 }
 
 func TestParseTrinary(t *testing.T) {

--- a/exercises/twelve-days/example.go
+++ b/exercises/twelve-days/example.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 )
 
-const testVersion = 1
-
 var verse = map[string]string{
 	"first":    "a Partridge in a Pear Tree.",
 	"twelfth":  "twelve Drummers Drumming",

--- a/exercises/twelve-days/twelve_days_test.go
+++ b/exercises/twelve-days/twelve_days_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
-
 type testCase struct {
 	input    int
 	expected string
@@ -49,12 +47,6 @@ func diff(got, want string) string {
 		default:
 			return "no differences found"
 		}
-	}
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
 	}
 }
 

--- a/exercises/variable-length-quantity/example.go
+++ b/exercises/variable-length-quantity/example.go
@@ -2,8 +2,6 @@ package variablelengthquantity
 
 import "errors"
 
-const testVersion = 4
-
 var ErrUnterminatedSequence = errors.New("unterminated sequence")
 
 // encodeInt returns the varint encoding of x.

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 4
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
-	}
-}
-
 func TestDecodeVarint(t *testing.T) {
 	for i, tc := range decodeTestCases {
 		o, err := DecodeVarint(tc.input)

--- a/exercises/word-count/example.go
+++ b/exercises/word-count/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 3
-
 // Frequency is a map of the frequency of occurrence keyed to the unique word.
 type Frequency map[string]int
 

--- a/exercises/word-count/word_count.go
+++ b/exercises/word-count/word_count.go
@@ -1,7 +1,5 @@
 package wordcount
 
-const testVersion = 3
-
 // Use this return type.
 type Frequency map[string]int
 

--- a/exercises/word-count/word_count_test.go
+++ b/exercises/word-count/word_count_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
-}
-
 func TestWordCount(t *testing.T) {
 	for _, tt := range testCases {
 		expected := tt.output

--- a/exercises/word-search/example.go
+++ b/exercises/word-search/example.go
@@ -2,8 +2,6 @@ package wordsearch
 
 import "fmt"
 
-const testVersion = 3
-
 func Solve(words []string, puzzle []string) (map[string][2][2]int, error) {
 	positions := make(map[string][2][2]int, len(words))
 	for _, word := range words {

--- a/exercises/word-search/word_search_test.go
+++ b/exercises/word-search/word_search_test.go
@@ -6,11 +6,6 @@ import (
 )
 
 // Define a function Solve(words []string, puzzle []string) (map[string][2][2]int, error).
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
-
-const targetTestVersion = 3
 
 var words = []string{
 	"clojure", "ecmascript", "elixir", "go", "java", "lisp",
@@ -43,12 +38,6 @@ var positions = map[string][2][2]int{
 	"ruby":       {{5, 7}, {8, 7}},
 	"rust":       {{8, 0}, {8, 3}},
 	"scheme":     {{0, 6}, {5, 6}},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestSolve(t *testing.T) {

--- a/exercises/wordy/example.go
+++ b/exercises/wordy/example.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const testVersion = 1
-
 func Answer(q string) (a int, ok bool) {
 	w := strings.Fields(q)
 	if len(w) < 3 { // length check for first two words and last word

--- a/exercises/wordy/wordy_test.go
+++ b/exercises/wordy/wordy_test.go
@@ -2,8 +2,6 @@ package wordy
 
 import "testing"
 
-const targetTestVersion = 1
-
 var tests = []struct {
 	q  string
 	a  int
@@ -25,12 +23,6 @@ var tests = []struct {
 	{"What is -12 divided by 2 divided by -3?", 2, true},
 	{"What is 53 cubed?", 0, false},
 	{"Who is the president of the United States?", 0, false},
-}
-
-func TestTestVersion(t *testing.T) {
-	if testVersion != targetTestVersion {
-		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
-	}
 }
 
 func TestAnswer(t *testing.T) {


### PR DESCRIPTION
This PR is to solve the issue #857 . It removes all the test versioning from all the tests, stubs and examples. I also removed the related comments (when present) and mentions from `README `and `doc/TESTS.md` .
😃 