### PR TITLE
generator: handle multi-line commit - issue #874

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -242,5 +243,7 @@ func getRemoteCommit(exercise string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s %s", c[0].Sha[0:7], c[0].Commit.Message), nil
+	// Use only 1st line of the commit message
+	lines := strings.SplitN(c[0].Commit.Message, "\n", 2)
+	return fmt.Sprintf("%s %s", c[0].Sha[0:7], lines[0]), nil
 }


### PR DESCRIPTION
When remote problem-specifications repository is used
as the source of the canonical-data.json, and the commit entry
retrieved has a multi-line message, the generator
uses the entire multi-line message in the source comment output;
this causes a compile error in the generated cases_test.go.

Correct bug by using only the first line of the commit message
in returned string from getRemoteCommit.

Closes #874 