### PR TITLE
Fix bug when generating test cases with multi-line commits

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -242,5 +243,6 @@ func getRemoteCommit(exercise string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s %s", c[0].Sha[0:7], c[0].Commit.Message), nil
+	messageFirstLine := strings.Split(c[0].Commit.Message, "\n")[0]
+	return fmt.Sprintf("%s %s", c[0].Sha[0:7], messageFirstLine), nil
 }


### PR DESCRIPTION
Generator would add multiple lines of the last remote commit to the
header of a generated `cases_test.go` file. As only the first line is
commented out any extra lines break the file. This fix limits the
remote caller commit lines to one: the summary line.

Resolves #874
