### PR TITLE
Explain cases_test.go file where it may first be encountered

### DIFF
--- a/exercises/hamming/.meta/hints.md
+++ b/exercises/hamming/.meta/hints.md
@@ -1,0 +1,4 @@
+You may be wondering about the `cases_test.go` file. We explain it in the
+[leap exercise][leap-exercise-readme].
+
+[leap-exercise-readme]: https://github.com/exercism/go/blob/master/exercises/leap/README.md 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -35,6 +35,12 @@ The Hamming distance is only defined for sequences of equal length. This means
 that based on the definition, each language could deal with getting sequences
 of equal length differently.
 
+You may be wondering about the `cases_test.go` file. We explain it in the
+[leap exercise][leap-exercise-readme].
+
+[leap-exercise-readme]: https://github.com/exercism/go/blob/master/exercises/leap/README.md 
+
+
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.

--- a/exercises/leap/.meta/hints.md
+++ b/exercises/leap/.meta/hints.md
@@ -1,0 +1,14 @@
+You will see a `cases_test.go` file in this exercise. This holds the test
+cases used in the `leap_test.go`. You can mostly ignore this file.
+
+However, if you are interested... we sometimes generate the test data from a
+[cross language repository][problem-specifications-leap]. In that repo
+exercises may have a [.json file][problem-specifications-leap-json] that
+contains common test data. Some of our local exercises have an
+[intermediary program][local-leap-gen] that takes the problem specification
+JSON and turns in into Go structs that are fed into the `<exercise>_test.go`
+file. The Go specific transformation of that data lives in the `cases_test.go` file.
+
+[problem-specifications-leap]: https://github.com/exercism/problem-specifications/tree/master/exercises/leap
+[problem-specifications-leap-json]: https://github.com/exercism/problem-specifications/blob/master/exercises/leap/canonical-data.json
+[local-leap-gen]: https://github.com/exercism/go/blob/master/exercises/leap/.meta/gen.go

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -26,6 +26,22 @@ phenomenon, go watch [this youtube video][video].
 
 [video]: http://www.youtube.com/watch?v=xX96xng7sAE
 
+You will see a `cases_test.go` file in this exercise. This holds the test
+cases used in the `leap_test.go`. You can mostly ignore this file.
+
+However, if you are interested... we sometimes generate the test data from a
+[cross language repository][problem-specifications-leap]. In that repo
+exercises may have a [.json file][problem-specifications-leap-json] that
+contains common test data. Some of our local exercises have an
+[intermediary program][local-leap-gen] that takes the problem specification
+JSON and turns in into Go structs that are fed into the `<exercise>_test.go`
+file. The Go specific transformation of that data lives in the `cases_test.go` file.
+
+[problem-specifications-leap]: https://github.com/exercism/problem-specifications/tree/master/exercises/leap
+[problem-specifications-leap-json]: https://github.com/exercism/problem-specifications/blob/master/exercises/leap/canonical-data.json
+[local-leap-gen]: https://github.com/exercism/go/blob/master/exercises/leap/.meta/gen.go
+
+
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.


### PR DESCRIPTION
The user may encounter the `cases_test.go` first in `leap` as an
unlock or in `hamming` in core. We add a explanation of the file's
purpose in the `hamming` README and link to it in the `leap` README.

Resolves #824
