### PR TITLE
change: improve error formatting

### DIFF
--- a/exercises/change/change_test.go
+++ b/exercises/change/change_test.go
@@ -14,7 +14,7 @@ func TestChange(t *testing.T) {
 					tc.description, tc.coins, tc.target, tc.expectedChange, err.Error())
 			} else {
 				if !reflect.DeepEqual(actual, tc.expectedChange) {
-					t.Fatalf("%s : Change(%v, %d): expected %v, actual %v",
+					t.Fatalf("%s : Change(%v, %d): expected %#v, actual %#v",
 						tc.description, tc.coins, tc.target, tc.expectedChange, actual)
 				} else {
 					t.Logf("PASS: %s", tc.description)


### PR DESCRIPTION
See #866

This improves the test formatting in the case where an empty slice is wanted but a nil slice is given.

From:

```
--- FAIL: TestChange (0.00s)
	change_test.go:17: no coins make 0 change : Change([1 5 10 21 25], 0): expected [], actual []
```

To:

```
--- FAIL: TestChange (0.00s)
	change_test.go:17: no coins make 0 change : Change([1 5 10 21 25], 0): expected []int{}, actual []int(nil)
```