### PR TITLE
prime-factors: improve test formatting

### DIFF
--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -28,7 +28,7 @@ func TestPrimeFactors(t *testing.T) {
 	for _, test := range tests {
 		actual := Factors(test.input)
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("prime.Factors(%d) = %v; expected %v",
+			t.Errorf("prime.Factors(%d) = %#v; expected %#v",
 				test.input, actual, test.expected)
 		}
 	}


### PR DESCRIPTION
See #866 

This improves the test formatting in the case where an empty slice is wanted but a nil slice is given.

From:

```
--- FAIL: TestPrimeFactors (0.00s)
	prime_factors_test.go:31: prime.Factors(1) = []; expected []

```

To:

```
--- FAIL: TestPrimeFactors (0.00s)
	prime_factors_test.go:31: prime.Factors(1) = []int64(nil); expected []int64{}
```