### PR TITLE
README: remove configlet metadata coupling requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ So let's quickly run through each file and briefly describe it:
 
 * **.meta/metadata.yml** - Like the `meta/*.md` files, this will
   override the exercise metadata from the problem-specifications
-  repository. For now **the metadata file must be present** for the
-  `description.md` file to be used: see exercism/configlet#65.
+  repository.
 
 In some exercises there can be extra files, for instance the
 [series](exercises/series/) exercise contains extra test files.


### PR DESCRIPTION
confliglet has been updated to no longer require the `metadata.yml` and
`description.md` file to both be present for either to work. Removed the
blurb describing this requirement from our README.

See: https://github.com/exercism/configlet/pull/84