### PR TITLE
run-length-encoding: create test case generator

### DIFF
--- a/exercises/run-length-encoding/.meta/gen.go
+++ b/exercises/run-length-encoding/.meta/gen.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("run-length-encoding", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to umarshal into
+type js struct {
+	Groups []testGroup `json:"Cases"`
+}
+
+type testGroup struct {
+	Description string
+	Cases       []json.RawMessage `property:"RAW"`
+	EncodeCases []struct {
+		Description string
+		Input       string
+		Expected    string
+	} `property:"encode"`
+	DecodeCases []struct {
+		Description string
+		Input       string
+		Expected    string
+	} `property:"decode"`
+	EncodeDecodeCases []struct {
+		Description string
+		Input       string
+		Expected    string
+	} `property:"consistency"`
+}
+
+var tmpl = `package encode
+
+{{.Header}}
+
+{{range .J.Groups}}
+	// {{ .Description }}
+
+	{{- if .EncodeCases }}
+		var encodeTests = []struct {
+			input string
+			expected string
+			description string
+		}{
+			{{- range .EncodeCases }}
+				{ {{.Input | printf "%q"}}, {{.Expected | printf "%q"}}, {{.Description | printf "%q"}} },
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if .DecodeCases }}
+		var decodeTests = []struct {
+			input string
+			expected string
+			description string
+		}{
+			{{- range .DecodeCases }}
+				{ {{.Input | printf "%q"}}, {{.Expected | printf "%q"}}, {{.Description | printf "%q"}} },
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if .EncodeDecodeCases }}
+		var encodeDecodeTests = []struct {
+			input string
+			expected string
+			description string
+		}{
+			{{- range .EncodeDecodeCases }}
+				{ {{.Input | printf "%q"}}, {{.Expected | printf "%q"}}, {{.Description | printf "%q"}} },
+			{{- end }}
+		}
+	{{- end }}
+{{end}}
+`

--- a/exercises/run-length-encoding/cases_test.go
+++ b/exercises/run-length-encoding/cases_test.go
@@ -1,0 +1,42 @@
+package encode
+
+// Source: exercism/problem-specifications
+// Commit: 503a57a run-length-encoding: Fix canonical-data.json formatting
+// Problem Specifications Version: 1.0.0
+
+// run-length encode a string
+var encodeTests = []struct {
+	input       string
+	expected    string
+	description string
+}{
+	{"", "", "empty string"},
+	{"XYZ", "XYZ", "single characters only are encoded without count"},
+	{"AABBBCCCC", "2A3B4C", "string with no single characters"},
+	{"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB", "12WB12W3B24WB", "single characters mixed with repeated characters"},
+	{"  hsqq qww  ", "2 hs2q q2w2 ", "multiple whitespace mixed in string"},
+	{"aabbbcccc", "2a3b4c", "lowercase characters"},
+}
+
+// run-length decode a string
+var decodeTests = []struct {
+	input       string
+	expected    string
+	description string
+}{
+	{"", "", "empty string"},
+	{"XYZ", "XYZ", "single characters only"},
+	{"2A3B4C", "AABBBCCCC", "string with no single characters"},
+	{"12WB12W3B24WB", "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB", "single characters with repeated characters"},
+	{"2 hs2q q2w2 ", "  hsqq qww  ", "multiple whitespace mixed in string"},
+	{"2a3b4c", "aabbbcccc", "lower case string"},
+}
+
+// encode and then decode
+var encodeDecodeTests = []struct {
+	input       string
+	expected    string
+	description string
+}{
+	{"zzz ZZ  zZ", "zzz ZZ  zZ", "encode followed by decode gives original string"},
+}

--- a/exercises/run-length-encoding/run_length_encoding_test.go
+++ b/exercises/run-length-encoding/run_length_encoding_test.go
@@ -2,58 +2,30 @@ package encode
 
 import "testing"
 
-var encodeTests = []struct {
-	input    string
-	expected string
-}{
-	{"", ""},
-	{"XYZ", "XYZ"},
-	{"AABBBCCCC", "2A3B4C"},
-	{"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB", "12WB12W3B24WB"},
-	{"  hsqq qww  ", "2 hs2q q2w2 "},
-	{"aabbbcccc", "2a3b4c"},
-}
-
-var decodeTests = []struct {
-	input    string
-	expected string
-}{
-	{"", ""},
-	{"XYZ", "XYZ"},
-	{"2A3B4C", "AABBBCCCC"},
-	{"12WB12W3B24WB", "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"},
-	{"2 hs2q q2w2 ", "  hsqq qww  "},
-	{"2a3b4c", "aabbbcccc"},
-}
-
-var encodeDecodeTests = []struct {
-	input    string
-	expected string
-}{
-	{"zzz ZZ  zZ", "zzz ZZ  zZ"},
-}
-
 func TestRunLengthEncode(t *testing.T) {
 	for _, test := range encodeTests {
 		if actual := RunLengthEncode(test.input); actual != test.expected {
-			t.Errorf("RunLengthEncode(%s) = %q, expected %q.",
-				test.input, actual, test.expected)
+			t.Errorf("FAIL %s - RunLengthEncode(%s) = %q, expected %q.",
+				test.description, test.input, actual, test.expected)
 		}
+		t.Logf("PASS RunLengthEncode - %s", test.description)
 	}
 }
 func TestRunLengthDecode(t *testing.T) {
 	for _, test := range decodeTests {
 		if actual := RunLengthDecode(test.input); actual != test.expected {
-			t.Errorf("RunLengthDecode(%s) = %q, expected %q.",
-				test.input, actual, test.expected)
+			t.Errorf("FAIL %s - RunLengthDecode(%s) = %q, expected %q.",
+				test.description, test.input, actual, test.expected)
 		}
+		t.Logf("PASS RunLengthDecode - %s", test.description)
 	}
 }
 func TestRunLengthEncodeDecode(t *testing.T) {
 	for _, test := range encodeDecodeTests {
 		if actual := RunLengthDecode(RunLengthEncode(test.input)); actual != test.expected {
-			t.Errorf("RunLengthDecode(RunLengthEncode(%s)) = %q, expected %q.",
-				test.input, actual, test.expected)
+			t.Errorf("FAIL %s - RunLengthDecode(RunLengthEncode(%s)) = %q, expected %q.",
+				test.description, test.input, actual, test.expected)
 		}
+		t.Logf("PASS %s", test.description)
 	}
 }


### PR DESCRIPTION
Add .meta/gen.go to generate cases_test.go.

Update test program to use generated test case arrays.
Put FAIL and PASS in test result output.

For #605.