### PR TITLE
perfect-numbers: add hints.md

### DIFF
--- a/exercises/perfect-numbers/.meta/hints.md
+++ b/exercises/perfect-numbers/.meta/hints.md
@@ -1,0 +1,19 @@
+## Implementation
+
+Define
+```type Classification```
+for containing the classification values for natural numbers.
+You may choose any representation for this type.
+
+Define three Classification constants named
+```
+	ClassificationDeficient
+	ClassificationPerfect
+	ClassificationAbundant
+```
+
+Implement a function named Classify which accepts
+an int64 input and returns a Classification and an error value.
+
+Create an error named ErrOnlyPositive
+which is returned when the input is not a positive integer.

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -5,7 +5,7 @@ Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
 
 The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
-- **Perfect**: aliquot sum = number 
+- **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6
   - 28 is a perfect number because (1 + 2 + 4 + 7 + 14) = 28
 - **Abundant**: aliquot sum > number
@@ -14,8 +14,29 @@ The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) d
 - **Deficient**: aliquot sum < number
   - 8 is a deficient number because (1 + 2 + 4) = 7
   - Prime numbers are deficient
-  
+
 Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
+
+## Implementation
+
+Define
+```type Classification```
+for containing the classification values for natural numbers.
+You may choose any representation for this type.
+
+Define three Classification constants named
+```
+	ClassificationDeficient
+	ClassificationPerfect
+	ClassificationAbundant
+```
+
+Implement a function named Classify which accepts
+an int64 input and returns a Classification and an error value.
+
+Create an error named ErrOnlyPositive
+which is returned when the input is not a positive integer.
+
 
 ## Running the tests
 


### PR DESCRIPTION
The README fo perfect-numbers is lacking in
specific instructions regarding the required elements
needed to be compliant with the test program.

Add a .meta/hints.md which more clearly states
the expected elements of the perfect-numbers exercise.

Best if merged after #952 since it reflects a related change to int64.