### PR TITLE
isbn-verifier: create test case generator

### DIFF
--- a/exercises/isbn-verifier/.meta/gen.go
+++ b/exercises/isbn-verifier/.meta/gen.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("isbn-verifier", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type OneCase struct {
+	Description string
+	Input       string
+	Expected    bool
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []OneCase
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package isbn
+
+{{.Header}}
+
+var testCases = []struct {
+	isbn string
+	expected bool
+	description string
+}{
+{{range .J.Cases}}{ "{{.Input}}", {{.Expected}}, "{{.Description}}"},
+{{end}}}
+`

--- a/exercises/isbn-verifier/cases_test.go
+++ b/exercises/isbn-verifier/cases_test.go
@@ -1,0 +1,25 @@
+package isbn
+
+// Source: exercism/problem-specifications
+// Commit: 3251fa6 Rename property for isbn-verifier exercise
+// Problem Specifications Version: 2.0.0
+
+var testCases = []struct {
+	isbn        string
+	expected    bool
+	description string
+}{
+	{"3-598-21508-8", true, "valid isbn number"},
+	{"3-598-21508-9", false, "invalid isbn check digit"},
+	{"3-598-21507-X", true, "valid isbn number with a check digit of 10"},
+	{"3-598-21507-A", false, "check digit is a character other than X"},
+	{"3-598-2K507-0", false, "invalid character in isbn"},
+	{"3-598-2X507-9", false, "X is only valid as a check digit"},
+	{"3598215088", true, "valid isbn without separating dashes"},
+	{"359821507X", true, "isbn without separating dashes and X as check digit"},
+	{"359821507", false, "isbn without check digit and dashes"},
+	{"3598215078X", false, "too long isbn and no dashes"},
+	{"3-598-21507", false, "isbn without check digit"},
+	{"3-598-21507-XX", false, "too long isbn"},
+	{"3-598-21515-X", false, "check digit of X should not be used for 0"},
+}

--- a/exercises/isbn-verifier/example.go
+++ b/exercises/isbn-verifier/example.go
@@ -32,8 +32,8 @@ func dropHyphen(isbn string) string {
 
 func strToSlice(isbn string) (result []int, err error) {
 
-	for _, char := range isbn {
-		if unicode.IsLetter(char) && char != 'X' {
+	for pos, char := range isbn {
+		if unicode.IsLetter(char) && (char != 'X' || pos != 9) {
 			err = errors.New("invalid character")
 			return
 		} else if char == 'X' {

--- a/exercises/isbn-verifier/isbn_verifier_test.go
+++ b/exercises/isbn-verifier/isbn_verifier_test.go
@@ -4,32 +4,13 @@ import (
 	"testing"
 )
 
-var testCases = []struct {
-	isbn        string
-	expected    bool
-	description string
-}{
-	{"3-598-21508-8", true, "valid isbn number"},
-	{"3-598-21508-9", false, "invalid isbn check digit"},
-	{"3-598-21507-X", true, "valid isbn number with a check digit of 10"},
-	{"3-598-21507-A", false, "check digit is a character other than X"},
-	{"3-598-2K507-0", false, "invalid character in isbn"},
-	{"3-598-2X507-0", false, "X is only valid as a check digit"},
-	{"3598215088", true, "valid isbn without separating dashes"},
-	{"359821507X", true, "isbn without separating dashes and X as check digit"},
-	{"359821507", false, "isbn without check digit and dashes"},
-	{"3598215078X", false, "too long isbn and no dashes"},
-	{"3-598-21507", false, "isbn without check digit"},
-	{"3-598-21507-XA", false, "too long isbn"},
-	{"3-598-21515-X", false, "check digit of X should not be used for 0"},
-}
-
 func TestIsValidISBN(t *testing.T) {
 	for _, test := range testCases {
 		observed := IsValidISBN(test.isbn)
 		if observed != test.expected {
-			t.Fatalf("got %t, want %t, %s (%s)",
-				observed, test.expected, test.description, test.isbn)
+			t.Errorf("FAIL: %s\nIsValidISBN(%q)\nExpected: %t, Actual: %t",
+				test.description, test.isbn, test.expected, observed)
 		}
+		t.Logf("PASS: %s", test.description)
 	}
 }


### PR DESCRIPTION
Add .meta/gen.go to generate cases_test.go.

Update test program to use generated test case array.
Make one correction to pass the 'X is only valid as a check digit'
test case from canonical-data.json.
Output FAIL and PASS in test output.

For #605.