### PR TITLE
collatz-conjecture: add generator

### DIFF
--- a/exercises/collatz-conjecture/.meta/gen.go
+++ b/exercises/collatz-conjecture/.meta/gen.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("collatz-conjecture", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type OneCase struct {
+	Description string
+	Number      int
+	Expected    interface{}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []OneCase
+}
+
+func (c OneCase) Valid() bool {
+	valid, _ := determineExpected(c.Expected)
+	return valid
+}
+
+func (c OneCase) Answer() int {
+	_, answer := determineExpected(c.Expected)
+	return answer
+}
+
+// determineExpected examines an .Expected interface{} object and determines
+// whether a test case is valid(bool) and has an answer or expects an error.
+// returning valid and answer.
+func determineExpected(expected interface{}) (bool, int) {
+	ans, ok := expected.(float64)
+	if ok {
+		return ok, int(ans)
+	}
+	return false, 0
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package collatzconjecture
+
+{{.Header}}
+
+var testCases = []struct {
+	description string
+	input       int
+	expectError bool
+	expected    int
+}{
+{{range .J.Cases}}{
+	description:	"{{.Description}}",
+	input:		{{.Number}},
+{{if .Valid}} expected:	{{.Answer}},
+{{- else}} expectError: true,
+{{- end}}
+},
+{{end}}}
+`

--- a/exercises/collatz-conjecture/cases_test.go
+++ b/exercises/collatz-conjecture/cases_test.go
@@ -1,0 +1,43 @@
+package collatzconjecture
+
+// Source: exercism/problem-specifications
+// Commit: 25c4479 Collatz-conjecture: remove trailing space in test name (#839)
+// Problem Specifications Version: 1.1.1
+
+var testCases = []struct {
+	description string
+	input       int
+	expectError bool
+	expected    int
+}{
+	{
+		description: "zero steps for one",
+		input:       1,
+		expected:    0,
+	},
+	{
+		description: "divide if even",
+		input:       16,
+		expected:    4,
+	},
+	{
+		description: "even and odd steps",
+		input:       12,
+		expected:    9,
+	},
+	{
+		description: "Large number of even and odd steps",
+		input:       1000000,
+		expected:    152,
+	},
+	{
+		description: "zero is an error",
+		input:       0,
+		expectError: true,
+	},
+	{
+		description: "negative value is an error",
+		input:       -15,
+		expectError: true,
+	},
+}

--- a/exercises/collatz-conjecture/collatz_conjecture_test.go
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.go
@@ -4,48 +4,6 @@ import (
 	"testing"
 )
 
-var testCases = []struct {
-	description string
-	input       int
-	expectError bool
-	expected    int
-}{
-	{
-		description: "zero steps for one",
-		input:       1,
-		expectError: false,
-		expected:    0,
-	},
-	{
-		description: "divide if even",
-		input:       16,
-		expectError: false,
-		expected:    4,
-	},
-	{
-		description: "even and old steps",
-		input:       12,
-		expectError: false,
-		expected:    9,
-	},
-	{
-		description: "large number of even and odd steps",
-		input:       1000000,
-		expectError: false,
-		expected:    152,
-	},
-	{
-		description: "zero is an error",
-		input:       0,
-		expectError: true,
-	},
-	{
-		description: "negative value is an error",
-		input:       -15,
-		expectError: true,
-	},
-}
-
 func TestCollatzConjecture(t *testing.T) {
 	for _, testCase := range testCases {
 		steps, err := CollatzConjecture(testCase.input)


### PR DESCRIPTION
Add .meta/gen.go to generate cases_test.go.
Make use of zero-value of expectError bool.

Update test program to use generated test case array.

For #605.