### PR TITLE
space-age: do not force rounding of solutions

### DIFF
--- a/exercises/space-age/space_age_test.go
+++ b/exercises/space-age/space_age_test.go
@@ -1,12 +1,14 @@
 package space
 
 import (
+	"math"
 	"testing"
 )
 
 func TestAge(t *testing.T) {
+	const precision = 0.01
 	for _, tc := range testCases {
-		if actual := Age(tc.seconds, tc.planet); actual != tc.expected {
+		if actual := Age(tc.seconds, tc.planet); math.Abs(actual-tc.expected)>precision {
 			t.Fatalf("FAIL: %s\nExpected: %#v\nActual: %#v", tc.description, tc.expected, actual)
 		}
 		t.Logf("PASS: %s", tc.description)

--- a/exercises/space-age/space_age_test.go
+++ b/exercises/space-age/space_age_test.go
@@ -8,7 +8,7 @@ import (
 func TestAge(t *testing.T) {
 	const precision = 0.01
 	for _, tc := range testCases {
-		if actual := Age(tc.seconds, tc.planet); math.Abs(actual-tc.expected)>precision {
+		if actual := Age(tc.seconds, tc.planet); math.Abs(actual-tc.expected) > precision {
 			t.Fatalf("FAIL: %s\nExpected: %#v\nActual: %#v", tc.description, tc.expected, actual)
 		}
 		t.Logf("PASS: %s", tc.description)


### PR DESCRIPTION
The expected age values are specified (in respective canonical-data.json) with 2-digit precision (e.g., 31.69), while the actual result is a float.
Instead of forcing the solution to perform an arbitrary rounding, the test code verifies the result with certain precision (currently same 2-digit, for compatibility - can be eventually added to canonical-data.json itself).
Aligned with the conclusion of the discussion in exercism/problem-specifications#880