### PR TITLE
prime-factors: add generator

### DIFF
--- a/exercises/prime-factors/.meta/gen.go
+++ b/exercises/prime-factors/.meta/gen.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("prime-factors", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Groups []TestGroup `json:"cases"`
+}
+
+type TestGroup struct {
+	Description string
+	Cases       []OneCase
+}
+
+type OneCase struct {
+	Description string
+	Input       int64
+	Expected    []int64
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package prime
+
+{{.Header}}
+
+var tests = []struct {
+	description string
+	input int64
+	expected []int64
+}{
+{{range .J.Groups}}
+{{range .Cases}} {
+	"{{.Description}}",
+	{{.Input}},
+	{{printf "%#v" .Expected}},
+},
+{{end}}{{end}}}
+`

--- a/exercises/prime-factors/cases_test.go
+++ b/exercises/prime-factors/cases_test.go
@@ -1,0 +1,48 @@
+package prime
+
+// Source: exercism/problem-specifications
+// Commit: bf5bb2b prime-factors: Fix canonical-data.json formatting
+// Problem Specifications Version: 1.0.0
+
+var tests = []struct {
+	description string
+	input       int64
+	expected    []int64
+}{
+
+	{
+		"no factors",
+		1,
+		[]int64{},
+	},
+	{
+		"prime number",
+		2,
+		[]int64{2},
+	},
+	{
+		"square of a prime",
+		9,
+		[]int64{3, 3},
+	},
+	{
+		"cube of a prime",
+		8,
+		[]int64{2, 2, 2},
+	},
+	{
+		"product of primes and non-primes",
+		12,
+		[]int64{2, 2, 3},
+	},
+	{
+		"product of primes",
+		901255,
+		[]int64{5, 17, 23, 461},
+	},
+	{
+		"factors include a large prime",
+		93819012551,
+		[]int64{11, 9539, 894119},
+	},
+}

--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -7,30 +7,15 @@ import (
 	"testing"
 )
 
-var tests = []struct {
-	input    int64
-	expected []int64
-}{
-	{1, []int64{}},
-	{2, []int64{2}},
-	{3, []int64{3}},
-	{4, []int64{2, 2}},
-	{6, []int64{2, 3}},
-	{8, []int64{2, 2, 2}},
-	{9, []int64{3, 3}},
-	{27, []int64{3, 3, 3}},
-	{625, []int64{5, 5, 5, 5}},
-	{901255, []int64{5, 17, 23, 461}},
-	{93819012551, []int64{11, 9539, 894119}},
-}
-
 func TestPrimeFactors(t *testing.T) {
 	for _, test := range tests {
 		actual := Factors(test.input)
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("prime.Factors(%d) = %#v; expected %#v",
-				test.input, actual, test.expected)
+			t.Fatalf("FAIL %s\nFactors(%d) = %#v;\nexpected %#v",
+				test.description, test.input,
+				actual, test.expected)
 		}
+		t.Logf("PASS %s", test.description)
 	}
 }
 


### PR DESCRIPTION
Add .meta/gen.go to generate cases_test.go.

Update test program to use generated test case array.
Output FAIL and PASS in test output.

For #605.