### PR TITLE
kindergarten-garden: Use Skipf to display formatting directives

### DIFF
--- a/exercises/kindergarten-garden/kindergarten_garden_test.go
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.go
@@ -181,7 +181,7 @@ RVGCCGCV`
 	tf := func(g *Garden, n int, child string, expPlants []string) {
 		switch plants, ok := g.Plants(child); {
 		case !ok:
-			t.Skip("Garden %d lookup %s returned ok = false, want true.",
+			t.Skipf("Garden %d lookup %s returned ok = false, want true.",
 				n, child)
 		case !reflect.DeepEqual(plants, expPlants):
 			t.Fatalf("Garden %d lookup %s = %q, want %q.",


### PR DESCRIPTION
This commit fixes #975. The original `t.Skip()` call included the use of formatting directives. These were caught in the tests run against Go: tip. It looks like the formatting directives are intended and so the call was updated to use `t.Skipf()` fixing the issue.