### PR TITLE
armstrong-numbers: add exercise with generator (#969)

### DIFF
--- a/config.json
+++ b/config.json
@@ -736,6 +736,18 @@
     },
     {
       "core": false,
+      "difficulty": 3,
+      "slug": "armstrong-numbers",
+      "topics": [
+        "algorithms",
+        "integers",
+        "mathematics"
+      ],
+      "unlocked_by": "prime-factors",
+      "uuid": "b3f06c57-c0de-4b8f-bd16-782b2ce3f478"
+    },
+    {
+      "core": false,
       "difficulty": 5,
       "slug": "transpose",
       "topics": [

--- a/exercises/armstrong-numbers/.meta/gen.go
+++ b/exercises/armstrong-numbers/.meta/gen.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("armstrong-numbers", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Exercise string
+	Version  string
+	Cases    []oneCase
+}
+
+// Test cases
+type oneCase struct {
+	Description string
+	Property    string
+	Input       struct {
+		Number int
+	}
+	Expected bool
+}
+
+// Template to generate test cases.
+var tmpl = `package armstrong
+
+{{.Header}}
+
+var testCases = []struct {
+	description	string
+	input		int
+	expected	bool
+}{ {{range .J.Cases}}
+{
+	description:	{{printf "%q"  .Description}},
+	input:		{{printf "%#v"  .Input.Number}},
+	expected:	{{printf "%#v"  .Expected}},
+},{{end}}
+}
+`

--- a/exercises/armstrong-numbers/armstrong_test.go
+++ b/exercises/armstrong-numbers/armstrong_test.go
@@ -1,0 +1,12 @@
+package armstrong
+
+import "testing"
+
+func TestArmstrong(t *testing.T) {
+	for _, tc := range testCases {
+		if actual := IsNumber(tc.input); actual != tc.expected {
+			t.Fatalf("FAIL: %s\nExpected: %v\nActual: %v", tc.description, tc.expected, actual)
+		}
+		t.Logf("PASS: %s", tc.description)
+	}
+}

--- a/exercises/armstrong-numbers/cases_test.go
+++ b/exercises/armstrong-numbers/cases_test.go
@@ -1,0 +1,52 @@
+package armstrong
+
+// Source: exercism/problem-specifications
+// Commit: 5c3baae armstrong-numbers: new exercise (#1018)
+// Problem Specifications Version: 1.0.0
+
+var testCases = []struct {
+	description string
+	input       int
+	expected    bool
+}{
+	{
+		description: "Single digit numbers are Armstrong numbers",
+		input:       5,
+		expected:    true,
+	},
+	{
+		description: "There are no 2 digit Armstrong numbers",
+		input:       10,
+		expected:    false,
+	},
+	{
+		description: "Three digit number that is an Armstrong number",
+		input:       153,
+		expected:    true,
+	},
+	{
+		description: "Three digit number that is not an Armstrong number",
+		input:       100,
+		expected:    false,
+	},
+	{
+		description: "Four digit number that is an Armstrong number",
+		input:       9474,
+		expected:    true,
+	},
+	{
+		description: "Four digit number that is not an Armstrong number",
+		input:       9475,
+		expected:    false,
+	},
+	{
+		description: "Seven digit number that is an Armstrong number",
+		input:       9926315,
+		expected:    true,
+	},
+	{
+		description: "Seven digit number that is not an Armstrong number",
+		input:       9926314,
+		expected:    false,
+	},
+}

--- a/exercises/armstrong-numbers/example.go
+++ b/exercises/armstrong-numbers/example.go
@@ -1,0 +1,24 @@
+package armstrong
+
+import "math"
+
+func order(n int) (result int) {
+	for n != 0 {
+		result++
+		n = n / 10
+	}
+	return
+}
+
+// IsNumber returns true for an armstrong number
+func IsNumber(n int) bool {
+	originalNumber := n
+	pow := order(n)
+	sum := 0
+	for n != 0 {
+		remainder := n % 10
+		sum += int(math.Pow(float64(remainder), float64(pow)))
+		n = n / 10
+	}
+	return originalNumber == sum
+}


### PR DESCRIPTION
implemented exercise about 'armstrong numbers' in go . Fixes issue #969 