### PR TITLE
acronym: drop fmt in example

### DIFF
--- a/exercises/acronym/example.go
+++ b/exercises/acronym/example.go
@@ -1,7 +1,6 @@
 package acronym
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -9,11 +8,11 @@ import (
 func Abbreviate(s string) string {
 	regex := regexp.MustCompile("[A-Z]+[a-z]*|[a-z]+")
 	words := regex.FindAllString(s, -1)
-	abbr := []string{}
 
+	var abbr []string
 	for _, word := range words {
 		abbr = append(abbr, string(word[0]))
 	}
 
-	return fmt.Sprintf("%s", strings.ToUpper(strings.Join(abbr, "")))
+	return strings.ToUpper(strings.Join(abbr, ""))
 }


### PR DESCRIPTION
 - because passed argument is already string