### PR TITLE
acronym: Remove duplicated function definition

### DIFF
--- a/exercises/acronym/acronym.go
+++ b/exercises/acronym/acronym.go
@@ -5,8 +5,6 @@
 // https://golang.org/doc/effective_go.html#commentary
 package acronym
 
-func Abbreviate(string) string
-
 // Abbreviate should have a comment documenting it.
 func Abbreviate(s string) string {
 	// Write some code here to pass the test suite.


### PR DESCRIPTION
A previous PR (#860) introduced a duplicated definition for the Abbreviate function in the acronym exercise.