### PR TITLE
allergies: update generator to new input schema

### DIFF
--- a/exercises/allergies/.meta/gen.go
+++ b/exercises/allergies/.meta/gen.go
@@ -31,16 +31,20 @@ type testGroup struct {
 	Cases           []json.RawMessage `property:"RAW"`
 	AllergicToCases []struct {
 		Description string
-		Score       uint
-		Expected    []struct {
+		Input       struct {
+			Score uint
+		}
+		Expected []struct {
 			Substance string
 			Result    bool
 		}
 	} `property:"allergicTo"`
 	ListCases []struct {
 		Description string
-		Score       uint
-		Expected    []string
+		Input       struct {
+			Score uint
+		}
+		Expected []string
 	} `property:"list"`
 }
 
@@ -64,7 +68,7 @@ var tmpl = `package allergies
 			{{- range .AllergicToCases }}
 				{
 					description: {{.Description | printf "%q"}},
-					score: {{.Score}},
+					score: {{.Input.Score}},
 					expected: []allergicResult{ {{range .Expected}}
 					  { {{.Substance | printf "%q"}}, {{.Result}} },{{end}}
 					},
@@ -80,7 +84,7 @@ var tmpl = `package allergies
 			expected []string
 		}{
 			{{- range .ListCases }}
-				{ {{.Description | printf "%q"}}, {{.Score}}, {{.Expected | printf "%#v"}}},
+				{ {{.Description | printf "%q"}}, {{.Input.Score}}, {{.Expected | printf "%#v"}}},
 			{{- end }}
 		}
 	{{- end }}

--- a/exercises/allergies/cases_test.go
+++ b/exercises/allergies/cases_test.go
@@ -1,8 +1,8 @@
 package allergies
 
 // Source: exercism/problem-specifications
-// Commit: 879bc89 allergies: Fix canonical-data.json formatting
-// Problem Specifications Version: 1.0.0
+// Commit: 85dcb59 allergies: Update json for new "input" policy (#1033)
+// Problem Specifications Version: 1.1.0
 
 // allergicTo
 type allergicResult struct {


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.