### PR TITLE
anagram: update generator to new input schema

### DIFF
--- a/exercises/anagram/.meta/gen.go
+++ b/exercises/anagram/.meta/gen.go
@@ -29,9 +29,11 @@ type js struct {
 // The JSON structure we expect to be able to unmarshal into
 type OneCase struct {
 	Description string
-	Subject     string
-	Candidates  []string
-	Expected    []string
+	Input       struct {
+		Subject    string
+		Candidates []string
+	}
+	Expected []string
 }
 
 // template applied to above data structure generates the Go test cases
@@ -47,8 +49,8 @@ var testCases = []struct {
 }{ {{range .J.Cases}}
 {
 	description: {{printf "%q"   .Description}},
-	subject: {{printf "%q"   .Subject}},
-	candidates: []string { {{range $line := .Candidates}}{{printf "\n%q," $line}}{{end}}},
+	subject: {{printf "%q"   .Input.Subject}},
+	candidates: []string { {{range $line := .Input.Candidates}}{{printf "\n%q," $line}}{{end}}},
 	expected: []string { {{range $line := .Expected}}{{printf "\n%q," $line}}{{end}}},
 	},{{end}}
 }

--- a/exercises/anagram/cases_test.go
+++ b/exercises/anagram/cases_test.go
@@ -1,8 +1,8 @@
 package anagram
 
 // Source: exercism/problem-specifications
-// Commit: 196fc1a anagram: Rename duplicated test case description (#671)
-// Problem Specifications Version: 1.0.1
+// Commit: a0f7663 anagram: Update json for new "input" policy (#1036)
+// Problem Specifications Version: 1.1.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.