### PR TITLE
binary-search: update generator to new input schema

### DIFF
--- a/exercises/binary-search/.meta/gen.go
+++ b/exercises/binary-search/.meta/gen.go
@@ -29,9 +29,11 @@ type js struct {
 type oneCase struct {
 	Description string
 	Property    string
-	Array       []int
-	Value       int
-	Expected    int
+	Input       struct {
+		Array []int
+		Value int
+	}
+	Expected int
 }
 
 // Template to generate test cases.
@@ -47,8 +49,8 @@ var testCases = []struct {
 }{ {{range .J.Cases}}
 {
 	description:	{{printf "%q"  .Description}},
-	slice:		{{printf "%#v"  .Array}},
-	key:		{{printf "%d"  .Value}},
+	slice:		{{printf "%#v" .Input.Array}},
+	key:		{{printf "%d"  .Input.Value}},
 	x:	{{printf "%d"  .Expected}},
 },{{end}}
 }

--- a/exercises/binary-search/cases_test.go
+++ b/exercises/binary-search/cases_test.go
@@ -1,8 +1,8 @@
 package binarysearch
 
 // Source: exercism/problem-specifications
-// Commit: 8acd78c Replace x-common with problem-specifications
-// Problem Specifications Version: 1.0.0
+// Commit: 6114d03 binary-search: Update json for new input policy
+// Problem Specifications Version: 1.1.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.