### PR TITLE
book-store: update generator to new input schema

### DIFF
--- a/exercises/book-store/.meta/gen.go
+++ b/exercises/book-store/.meta/gen.go
@@ -31,8 +31,10 @@ type TestGroup struct {
 
 type OneCase struct {
 	Description string
-	Basket      []int
-	Expected    float64
+	Input       struct {
+		Basket []int
+	}
+	Expected float64
 }
 
 // template applied to above data structure generates the Go test cases
@@ -47,7 +49,7 @@ var testCases = []struct {
 }{{range .J.Groups}}{
 {{range .Cases}} {
 	description: "{{.Description}}",
-	basket:      {{printf "%#v" .Basket}},
+	basket:      {{printf "%#v" .Input.Basket}},
 	expected:    {{printf "%.2f" .Expected}},
 },
 {{end}}}{{end}}

--- a/exercises/book-store/cases_test.go
+++ b/exercises/book-store/cases_test.go
@@ -1,8 +1,8 @@
 package bookstore
 
 // Source: exercism/problem-specifications
-// Commit: a636903 Update description per @insti comments
-// Problem Specifications Version: 1.1.0
+// Commit: 78006a2 move "targetgrouping" to "comments"
+// Problem Specifications Version: 1.2.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.