### PR TITLE
simple-cipher: fix error formatting in test

### DIFF
--- a/exercises/simple-cipher/simple_cipher_test.go
+++ b/exercises/simple-cipher/simple_cipher_test.go
@@ -96,7 +96,7 @@ func TestShift(t *testing.T) {
 	// invalid shifts
 	for _, s := range []int{-27, -26, 0, 26, 27} {
 		if NewShift(s) != nil {
-			t.Fatal("NewShift(%d) returned non-nil, "+
+			t.Fatalf("NewShift(%d) returned non-nil, "+
 				"Want nil return for invalid argument.", s)
 		}
 	}


### PR DESCRIPTION
Fix the reported error message in [line 99](https://github.com/exercism/go/blob/master/exercises/simple-cipher/simple_cipher_test.go#L99) where it should be `t.Fatalf` instead of `t.Fatal`