### PR TITLE
all-your-base: fix checker to ignore output in error case

### DIFF
--- a/exercises/all-your-base/all_your_base_test.go
+++ b/exercises/all-your-base/all_your_base_test.go
@@ -8,12 +8,13 @@ import (
 func TestConvertToBase(t *testing.T) {
 	for _, c := range testCases {
 		output, err := ConvertToBase(c.inputBase, c.inputDigits, c.outputBase)
-		if c.err != "" && (err == nil || c.err != err.Error()) {
-			t.Fatalf(`FAIL: %s
+		if c.err != "" {
+			if err == nil || c.err != err.Error() {
+				t.Fatalf(`FAIL: %s
 	Expected error: %s
 	Got: %v`, c.description, c.err, err)
-		}
-		if !reflect.DeepEqual(c.expected, output) {
+			}
+		} else if !reflect.DeepEqual(c.expected, output) {
 			t.Fatalf(`FAIL: %s
     Input base: %d
     Input digits: %#v


### PR DESCRIPTION
The current test for `all-your-base` compares the outputs even in the erroneous case, which won't let some correct solutions to pass. I'm changing this test to behave like other exercises: only check output in non-error test cases.