### PR TITLE
tree-building: add test cases for duplicate nodes

### DIFF
--- a/exercises/tree-building/tree_test.go
+++ b/exercises/tree-building/tree_test.go
@@ -159,6 +159,21 @@ var failureTestCases = []struct {
 		},
 	},
 	{
+		name: "duplicate node",
+		input: []Record{
+			{ID: 0, Parent: 0},
+			{ID: 1, Parent: 0},
+			{ID: 1, Parent: 0},
+		},
+	},
+	{
+		name: "duplicate root",
+		input: []Record{
+			{ID: 0, Parent: 0},
+			{ID: 0, Parent: 0},
+		},
+	},
+	{
 		name: "non-continuous",
 		input: []Record{
 			{ID: 2, Parent: 0},


### PR DESCRIPTION
Input with duplicate nodes should not be valid even if the nodes themselves are. 
Added one case for a generic duplicate node and another for a duplicate root node, to prevent comparison against zero value (either of ID or of Record) when checking for dupes.