### PR TITLE
meetup: update generator to new input schema

### DIFF
--- a/exercises/meetup/.meta/gen.go
+++ b/exercises/meetup/.meta/gen.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"text/template"
@@ -22,14 +23,24 @@ func main() {
 
 // The JSON structure we expect to be able to unmarshal into
 type js struct {
-	Cases []struct {
-		Description string
-		Year        int
-		Month       int
-		Week        string
-		Dayofweek   string
-		Dayofmonth  int
+	Cases []OneCase
+}
+
+type OneCase struct {
+	Description string
+	Input       struct {
+		Year      int
+		Month     int
+		Week      string
+		Dayofweek string
 	}
+	DateString string `json:"expected"`
+}
+
+func (c OneCase) ExpectedDay() int {
+	var y, m, d int
+	fmt.Sscanf(c.DateString, "%4d-%2d-%2d", &y, &m, &d)
+	return d
 }
 
 // template applied to above data structure generates the Go test cases
@@ -46,6 +57,6 @@ var testCases = []struct {
 	weekday time.Weekday
 	expDay  int
 }{
-{{range .J.Cases}}{ {{.Year}}, {{.Month}}, {{week .Week}}, time.{{.Dayofweek}}, {{.Dayofmonth}}}, // {{.Description}}
+{{range .J.Cases}}{ {{.Input.Year}}, {{.Input.Month}}, {{week .Input.Week}}, time.{{.Input.Dayofweek}}, {{.ExpectedDay}}}, // {{.Description}}
 {{end}}}
 `

--- a/exercises/meetup/cases_test.go
+++ b/exercises/meetup/cases_test.go
@@ -1,8 +1,8 @@
 package meetup
 
 // Source: exercism/problem-specifications
-// Commit: fe9630e meetup: Fix canonical-data.json formatting
-// Problem Specifications Version: 1.0.0
+// Commit: 56cdfa5 meetup: Update json for new input policy
+// Problem Specifications Version: 1.1.0
 
 import "time"
 


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.

Convert expected field in canonical-data.json to
day number to be compatible with exercise.