### PR TITLE
atbash-cipher: update generator to new input schema

### DIFF
--- a/exercises/atbash-cipher/.meta/gen.go
+++ b/exercises/atbash-cipher/.meta/gen.go
@@ -32,8 +32,10 @@ type js struct {
 		Cases       []struct {
 			Description string
 			Property    string
-			Phrase      string
-			Expected    string
+			Input       struct {
+				Phrase string
+			}
+			Expected string
 		}
 	}
 }
@@ -50,9 +52,9 @@ type atbashTest struct {
 
 var tests = []atbashTest {
 {{range .J.Cases}} {{range .Cases}}{
-	{{if isEncode .Property}} s: {{printf "%q" .Phrase }},
+	{{if isEncode .Property}} s: {{printf "%q" .Input.Phrase }},
 		expected: {{printf "%q" .Expected }}, {{else}} s: {{printf "%q" .Expected }},
-		expected:  {{printf "%q" .Phrase }}, {{- end}}
+		expected:  {{printf "%q" .Input.Phrase }}, {{- end}}
 },
 {{end}}{{end}}
 }

--- a/exercises/atbash-cipher/cases_test.go
+++ b/exercises/atbash-cipher/cases_test.go
@@ -1,8 +1,8 @@
 package atbash
 
 // Source: exercism/problem-specifications
-// Commit: bb4f220 atbash-cipher: Fix canonical-data.json formatting
-// Problem Specifications Version: 1.0.0
+// Commit: dda678b atbash-cipher: Apply new "input" policy
+// Problem Specifications Version: 1.1.0
 
 type atbashTest struct {
 	s        string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.