### PR TITLE
change: update generator to new input schema

### DIFF
--- a/exercises/change/.meta/gen.go
+++ b/exercises/change/.meta/gen.go
@@ -31,9 +31,11 @@ type js struct {
 type OneCase struct {
 	Description string
 	Property    string
-	Coins       []int
-	Target      int
-	Expected    interface{}
+	Input       struct {
+		Coins  []int
+		Target int
+	}
+	Expected interface{}
 }
 
 func (c OneCase) Valid() bool {
@@ -83,8 +85,8 @@ var testCases = []struct {
 }{
 {{range .J.Cases}}{
 	{{printf "%q"  .Description}},
-	{{printf "%#v" .Coins}},
-	{{printf "%d"  .Target}},
+	{{printf "%#v" .Input.Coins}},
+	{{printf "%d"  .Input.Target}},
 	{{printf "%v"  .Valid}},
 	{{printf "%#v" .IntSlice}},
 },

--- a/exercises/change/cases_test.go
+++ b/exercises/change/cases_test.go
@@ -1,8 +1,8 @@
 package change
 
 // Source: exercism/problem-specifications
-// Commit: 52cf1cf Add test for incorrect greedy algorithm
-// Problem Specifications Version: 1.1.0
+// Commit: 044d09a change: Apply new "input" policy
+// Problem Specifications Version: 1.2.0
 
 var testCases = []struct {
 	description    string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.