### PR TITLE
collatz-conjecture: update generator to new input schema

### DIFF
--- a/exercises/collatz-conjecture/.meta/gen.go
+++ b/exercises/collatz-conjecture/.meta/gen.go
@@ -20,8 +20,10 @@ func main() {
 
 type OneCase struct {
 	Description string
-	Number      int
-	Expected    interface{}
+	Input       struct {
+		Number int
+	}
+	Expected interface{}
 }
 
 // The JSON structure we expect to be able to unmarshal into
@@ -63,7 +65,7 @@ var testCases = []struct {
 }{
 {{range .J.Cases}}{
 	description:	"{{.Description}}",
-	input:		{{.Number}},
+	input:		{{.Input.Number}},
 {{if .Valid}} expected:	{{.Answer}},
 {{- else}} expectError: true,
 {{- end}}

--- a/exercises/collatz-conjecture/cases_test.go
+++ b/exercises/collatz-conjecture/cases_test.go
@@ -1,8 +1,8 @@
 package collatzconjecture
 
 // Source: exercism/problem-specifications
-// Commit: 25c4479 Collatz-conjecture: remove trailing space in test name (#839)
-// Problem Specifications Version: 1.1.1
+// Commit: 7bb0a64 collatz-conjecture: Apply new "input" policy
+// Problem Specifications Version: 1.2.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.