### PR TITLE
connect: update generator to new input schema

### DIFF
--- a/exercises/connect/.meta/gen.go
+++ b/exercises/connect/.meta/gen.go
@@ -22,8 +22,10 @@ func main() {
 type js struct {
 	Cases []struct {
 		Description string
-		Board       []string
-		Expected    string
+		Input       struct {
+			Board []string
+		}
+		Expected string
 	}
 }
 
@@ -39,7 +41,7 @@ var testCases = []struct {
 }{
 	{{range .J.Cases}}{
 		description: {{printf "%q" .Description}},
-		board: []string{ {{range $line := .Board}}{{printf "\n    %q," $line}}{{end}}},
+		board: []string{ {{range $line := .Input.Board}}{{printf "\n    %q," $line}}{{end}}},
 		expected: {{printf "%q" .Expected}},
 },
 {{end}}}

--- a/exercises/connect/cases_test.go
+++ b/exercises/connect/cases_test.go
@@ -1,8 +1,8 @@
 package connect
 
 // Source: exercism/problem-specifications
-// Commit: 327db7f connect: Fix canonical-data.json formatting
-// Problem Specifications Version: 1.0.0
+// Commit: a02d64d connect: Apply new "input" policy
+// Problem Specifications Version: 1.1.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.