### PR TITLE
exercises: fix loop ordering in benchmarks

### DIFF
--- a/exercises/accumulate/accumulate_test.go
+++ b/exercises/accumulate/accumulate_test.go
@@ -37,10 +37,10 @@ func TestAccumulate(t *testing.T) {
 
 func BenchmarkAccumulate(b *testing.B) {
 	b.StopTimer()
-	for _, test := range tests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, test := range tests {
 			Accumulate(test.given, test.converter)
 		}
 

--- a/exercises/accumulate/accumulate_test.go
+++ b/exercises/accumulate/accumulate_test.go
@@ -36,14 +36,11 @@ func TestAccumulate(t *testing.T) {
 }
 
 func BenchmarkAccumulate(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, test := range tests {
 			Accumulate(test.given, test.converter)
 		}
 
-		b.StopTimer()
 	}
 }

--- a/exercises/allergies/allergies_test.go
+++ b/exercises/allergies/allergies_test.go
@@ -17,10 +17,10 @@ func TestAllergies(t *testing.T) {
 
 func BenchmarkAllergies(b *testing.B) {
 	b.StopTimer()
-	for _, test := range allergicToTests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, test := range allergicToTests {
 			Allergies(test.score)
 		}
 		b.StopTimer()
@@ -42,11 +42,11 @@ func TestAllergicTo(t *testing.T) {
 
 func BenchmarkAllergicTo(b *testing.B) {
 	b.StopTimer()
-	for _, test := range allergicToTests {
+	for i := 0; i < b.N; i++ {
 		for _, response := range test.expected {
 			b.StartTimer()
 
-			for i := 0; i < b.N; i++ {
+			for _, test := range allergicToTests {
 				AllergicTo(test.score, response.substance)
 			}
 			b.StopTimer()

--- a/exercises/allergies/allergies_test.go
+++ b/exercises/allergies/allergies_test.go
@@ -16,14 +16,11 @@ func TestAllergies(t *testing.T) {
 }
 
 func BenchmarkAllergies(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, test := range allergicToTests {
 			Allergies(test.score)
 		}
-		b.StopTimer()
 	}
 }
 
@@ -41,15 +38,12 @@ func TestAllergicTo(t *testing.T) {
 }
 
 func BenchmarkAllergicTo(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
 		for _, test := range allergicToTests {
-			b.StartTimer()
 
 			for _, response := range test.expected {
 				AllergicTo(test.score, response.substance)
 			}
-			b.StopTimer()
 		}
 	}
 }

--- a/exercises/allergies/allergies_test.go
+++ b/exercises/allergies/allergies_test.go
@@ -43,10 +43,10 @@ func TestAllergicTo(t *testing.T) {
 func BenchmarkAllergicTo(b *testing.B) {
 	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		for _, response := range test.expected {
+		for _, test := range allergicToTests {
 			b.StartTimer()
 
-			for _, test := range allergicToTests {
+			for _, response := range test.expected {
 				AllergicTo(test.score, response.substance)
 			}
 			b.StopTimer()

--- a/exercises/anagram/anagram_test.go
+++ b/exercises/anagram/anagram_test.go
@@ -35,16 +35,12 @@ func TestDetectAnagrams(t *testing.T) {
 
 func BenchmarkDetectAnagrams(b *testing.B) {
 
-	b.StopTimer()
-
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, tt := range testCases {
 			Detect(tt.subject, tt.candidates)
 		}
 
-		b.StopTimer()
 	}
 
 }

--- a/exercises/anagram/anagram_test.go
+++ b/exercises/anagram/anagram_test.go
@@ -37,10 +37,10 @@ func BenchmarkDetectAnagrams(b *testing.B) {
 
 	b.StopTimer()
 
-	for _, tt := range testCases {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, tt := range testCases {
 			Detect(tt.subject, tt.candidates)
 		}
 

--- a/exercises/atbash-cipher/atbash_cipher_test.go
+++ b/exercises/atbash-cipher/atbash_cipher_test.go
@@ -13,10 +13,10 @@ func TestAtbash(t *testing.T) {
 
 func BenchmarkAtbash(b *testing.B) {
 	b.StopTimer()
-	for _, test := range tests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, test := range tests {
 			Atbash(test.s)
 		}
 

--- a/exercises/atbash-cipher/atbash_cipher_test.go
+++ b/exercises/atbash-cipher/atbash_cipher_test.go
@@ -12,14 +12,11 @@ func TestAtbash(t *testing.T) {
 }
 
 func BenchmarkAtbash(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, test := range tests {
 			Atbash(test.s)
 		}
 
-		b.StopTimer()
 	}
 }

--- a/exercises/beer-song/beer_test.go
+++ b/exercises/beer-song/beer_test.go
@@ -111,10 +111,10 @@ func TestSeveralVerses(t *testing.T) {
 
 func BenchmarkSeveralVerses(b *testing.B) {
 	b.StopTimer()
-	for _, tt := range versesTestCases {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, tt := range versesTestCases {
 			Verses(tt.upperBound, tt.lowerBound)
 		}
 

--- a/exercises/beer-song/beer_test.go
+++ b/exercises/beer-song/beer_test.go
@@ -110,15 +110,12 @@ func TestSeveralVerses(t *testing.T) {
 }
 
 func BenchmarkSeveralVerses(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, tt := range versesTestCases {
 			Verses(tt.upperBound, tt.lowerBound)
 		}
 
-		b.StopTimer()
 	}
 }
 

--- a/exercises/bob/bob_test.go
+++ b/exercises/bob/bob_test.go
@@ -17,8 +17,8 @@ func TestHey(t *testing.T) {
 }
 
 func BenchmarkHey(b *testing.B) {
-	for _, tt := range testCases {
-		for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range testCases {
 			Hey(tt.input)
 		}
 	}

--- a/exercises/bracket-push/bracket_push_test.go
+++ b/exercises/bracket-push/bracket_push_test.go
@@ -20,12 +20,9 @@ func TestBracket(t *testing.T) {
 }
 
 func BenchmarkBracket(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 		for _, tt := range testCases {
 			Bracket(tt.input)
 		}
-		b.StopTimer()
 	}
 }

--- a/exercises/bracket-push/bracket_push_test.go
+++ b/exercises/bracket-push/bracket_push_test.go
@@ -21,9 +21,9 @@ func TestBracket(t *testing.T) {
 
 func BenchmarkBracket(b *testing.B) {
 	b.StopTimer()
-	for _, tt := range testCases {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		for i := 0; i < b.N; i++ {
+		for _, tt := range testCases {
 			Bracket(tt.input)
 		}
 		b.StopTimer()

--- a/exercises/change/change_test.go
+++ b/exercises/change/change_test.go
@@ -32,8 +32,8 @@ func TestChange(t *testing.T) {
 }
 
 func BenchmarkChange(b *testing.B) {
-	for _, tc := range testCases {
-		for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
 			Change(tc.coins, tc.target)
 		}
 	}

--- a/exercises/etl/etl_test.go
+++ b/exercises/etl/etl_test.go
@@ -77,14 +77,11 @@ func TestTransform(t *testing.T) {
 }
 
 func BenchmarkTransform(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, tt := range transformTests {
 			Transform(map[int][]string(tt.input))
 		}
 
-		b.StopTimer()
 	}
 }

--- a/exercises/etl/etl_test.go
+++ b/exercises/etl/etl_test.go
@@ -78,10 +78,10 @@ func TestTransform(t *testing.T) {
 
 func BenchmarkTransform(b *testing.B) {
 	b.StopTimer()
-	for _, tt := range transformTests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, tt := range transformTests {
 			Transform(map[int][]string(tt.input))
 		}
 

--- a/exercises/grains/grains_test.go
+++ b/exercises/grains/grains_test.go
@@ -36,10 +36,10 @@ func TestTotal(t *testing.T) {
 func BenchmarkSquare(b *testing.B) {
 	b.StopTimer()
 
-	for _, test := range squareTests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, test := range squareTests {
 			Square(test.input)
 		}
 

--- a/exercises/grains/grains_test.go
+++ b/exercises/grains/grains_test.go
@@ -34,16 +34,13 @@ func TestTotal(t *testing.T) {
 }
 
 func BenchmarkSquare(b *testing.B) {
-	b.StopTimer()
 
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, test := range squareTests {
 			Square(test.input)
 		}
 
-		b.StopTimer()
 	}
 }
 

--- a/exercises/isogram/isogram_test.go
+++ b/exercises/isogram/isogram_test.go
@@ -13,14 +13,11 @@ func TestIsIsogram(t *testing.T) {
 }
 
 func BenchmarkIsIsogram(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, c := range testCases {
 			IsIsogram(c.input)
 		}
 
-		b.StopTimer()
 	}
 }

--- a/exercises/isogram/isogram_test.go
+++ b/exercises/isogram/isogram_test.go
@@ -14,10 +14,10 @@ func TestIsIsogram(t *testing.T) {
 
 func BenchmarkIsIsogram(b *testing.B) {
 	b.StopTimer()
-	for _, c := range testCases {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, c := range testCases {
 			IsIsogram(c.input)
 		}
 

--- a/exercises/octal/octal_test.go
+++ b/exercises/octal/octal_test.go
@@ -37,15 +37,12 @@ func TestParseOctal(t *testing.T) {
 }
 
 func BenchmarkParseOctal(b *testing.B) {
-	b.StopTimer()
 
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 
 		for _, test := range testCases {
 			ParseOctal(test.input)
 		}
 
-		b.StopTimer()
 	}
 }

--- a/exercises/octal/octal_test.go
+++ b/exercises/octal/octal_test.go
@@ -39,10 +39,10 @@ func TestParseOctal(t *testing.T) {
 func BenchmarkParseOctal(b *testing.B) {
 	b.StopTimer()
 
-	for _, test := range testCases {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 
-		for i := 0; i < b.N; i++ {
+		for _, test := range testCases {
 			ParseOctal(test.input)
 		}
 

--- a/exercises/phone-number/phone_number_test.go
+++ b/exercises/phone-number/phone_number_test.go
@@ -24,13 +24,10 @@ func TestNumber(t *testing.T) {
 }
 
 func BenchmarkNumber(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 		for _, test := range numberTests {
 			Number(test.input)
 		}
-		b.StopTimer()
 	}
 }
 
@@ -54,13 +51,10 @@ func TestAreaCode(t *testing.T) {
 }
 
 func BenchmarkAreaCode(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 		for _, test := range numberTests {
 			AreaCode(test.input)
 		}
-		b.StopTimer()
 	}
 }
 
@@ -84,12 +78,9 @@ func TestFormat(t *testing.T) {
 }
 
 func BenchmarkFormat(b *testing.B) {
-	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
 		for _, test := range numberTests {
 			Format(test.input)
 		}
-		b.StopTimer()
 	}
 }

--- a/exercises/phone-number/phone_number_test.go
+++ b/exercises/phone-number/phone_number_test.go
@@ -25,9 +25,9 @@ func TestNumber(t *testing.T) {
 
 func BenchmarkNumber(b *testing.B) {
 	b.StopTimer()
-	for _, test := range numberTests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		for i := 0; i < b.N; i++ {
+		for _, test := range numberTests {
 			Number(test.input)
 		}
 		b.StopTimer()
@@ -55,9 +55,9 @@ func TestAreaCode(t *testing.T) {
 
 func BenchmarkAreaCode(b *testing.B) {
 	b.StopTimer()
-	for _, test := range numberTests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		for i := 0; i < b.N; i++ {
+		for _, test := range numberTests {
 			AreaCode(test.input)
 		}
 		b.StopTimer()
@@ -85,9 +85,9 @@ func TestFormat(t *testing.T) {
 
 func BenchmarkFormat(b *testing.B) {
 	b.StopTimer()
-	for _, test := range numberTests {
+	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		for i := 0; i < b.N; i++ {
+		for _, test := range numberTests {
 			Format(test.input)
 		}
 		b.StopTimer()

--- a/exercises/transpose/transpose_test.go
+++ b/exercises/transpose/transpose_test.go
@@ -36,8 +36,8 @@ func min(a, b int) int {
 }
 
 func BenchmarkTranspose(b *testing.B) {
-	for _, test := range testCases {
-		for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
+		for _, test := range testCases {
 			Transpose(test.input)
 		}
 	}


### PR DESCRIPTION
Initial conversation: https://github.com/exercism/go/pull/1011/files/0af38ee4b324bee573ba1debc174cfde5bde6717#r160101420