### PR TITLE
bowling: update generator to new input schema

### DIFF
--- a/exercises/bowling/.meta/gen.go
+++ b/exercises/bowling/.meta/gen.go
@@ -29,11 +29,13 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 
 type OneCase struct {
-	Description   string
-	Property      string
-	PreviousRolls []int `json:"previous_rolls"`
-	Roll          int
-	Expected      interface{}
+	Description string
+	Property    string
+	Input       struct {
+		PreviousRolls []int
+		Roll          int
+	}
+	Expected interface{}
 }
 
 // ScoreTest and RollTest help determine which type of test case
@@ -90,7 +92,7 @@ var scoreTestCases = []struct {
 }{ {{range .J.Cases}}
 {{if .ScoreTest}}{
 	{{printf "%q"  .Description}},
-	{{printf "%#v" .PreviousRolls}},
+	{{printf "%#v" .Input.PreviousRolls}},
 	{{printf "%v"  .Valid}},
 	{{printf "%d"  .Score}},
 	{{printf "%q"  .ExplainText}},
@@ -106,9 +108,9 @@ var rollTestCases = []struct {
 }{ {{range .J.Cases}}
 {{if .RollTest}}{
 	{{printf "%q"  .Description}},
-	{{printf "%#v" .PreviousRolls}},
+	{{printf "%#v" .Input.PreviousRolls}},
 	{{printf "%v"  .Valid}},
-	{{printf "%d"  .Roll}},
+	{{printf "%d"  .Input.Roll}},
 	{{printf "%q"  .ExplainText}},
 },{{- end}}{{end}}
 }

--- a/exercises/bowling/cases_test.go
+++ b/exercises/bowling/cases_test.go
@@ -1,8 +1,8 @@
 package bowling
 
 // Source: exercism/problem-specifications
-// Commit: 26e345e [Bowling] Fix case descriptions (#832)
-// Problem Specifications Version: 1.0.1
+// Commit: dfdc0e2 bowling: bump version
+// Problem Specifications Version: 1.1.0
 
 var scoreTestCases = []struct {
 	description   string


### PR DESCRIPTION
Sync generator to latest canonical-data.json update
where the input uses another sub-item in JSON.