### PR TITLE
book-store: use fixed point output

### DIFF
--- a/exercises/book-store/.meta/gen.go
+++ b/exercises/book-store/.meta/gen.go
@@ -34,7 +34,7 @@ type OneCase struct {
 	Input       struct {
 		Basket []int
 	}
-	Expected float64
+	Expected int
 }
 
 // template applied to above data structure generates the Go test cases
@@ -45,12 +45,12 @@ var tmpl = `package bookstore
 var testCases = []struct {
 	description string
 	basket      []int
-	expected    float64
+	expected    int
 }{{range .J.Groups}}{
 {{range .Cases}} {
 	description: "{{.Description}}",
 	basket:      {{printf "%#v" .Input.Basket}},
-	expected:    {{printf "%.2f" .Expected}},
+	expected:    {{printf "%d" .Expected}},
 },
 {{end}}}{{end}}
 `

--- a/exercises/book-store/.meta/hints.md
+++ b/exercises/book-store/.meta/hints.md
@@ -1,0 +1,14 @@
+## Implementation
+
+Define a single Go func, Cost, which calculates the cost
+for a given list of books based on the defined discounts.
+
+Use the following signature for func Cost:
+
+```
+func Cost(books[]int) int
+```
+Cost will return the total cost (after discounts) in cents.
+For example, for a single book, the cost is 800 cents, which equals $8.00.
+Only integer calculations are necessary for this exercise.
+

--- a/exercises/book-store/.meta/hints.md
+++ b/exercises/book-store/.meta/hints.md
@@ -6,7 +6,7 @@ for a given list of books based on the defined discounts.
 Use the following signature for func Cost:
 
 ```
-func Cost(books[]int) int
+func Cost(books []int) int
 ```
 Cost will return the total cost (after discounts) in cents.
 For example, for a single book, the cost is 800 cents, which equals $8.00.

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -75,7 +75,7 @@ for a given list of books based on the defined discounts.
 Use the following signature for func Cost:
 
 ```
-func Cost(books[]int) int
+func Cost(books []int) int
 ```
 Cost will return the total cost (after discounts) in cents.
 For example, for a single book, the cost is 800 cents, which equals $8.00.

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -67,6 +67,22 @@ For a total of $51.20
 
 And $51.20 is the price with the biggest discount.
 
+## Implementation
+
+Define a single Go func, Cost, which calculates the cost
+for a given list of books based on the defined discounts.
+
+Use the following signature for func Cost:
+
+```
+func Cost(books[]int) int
+```
+Cost will return the total cost (after discounts) in cents.
+For example, for a single book, the cost is 800 cents, which equals $8.00.
+Only integer calculations are necessary for this exercise.
+
+
+
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.
@@ -86,7 +102,7 @@ you're having trouble, please visit the exercism.io [Go language page](http://ex
 
 ## Source
 
-[Inspired by the harry potter kata from Cyber-Dojo](http://cyber-dojo.org).
+Inspired by the harry potter kata from Cyber-Dojo. [http://cyber-dojo.org](http://cyber-dojo.org)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/book-store/cases_test.go
+++ b/exercises/book-store/cases_test.go
@@ -1,82 +1,82 @@
 package bookstore
 
 // Source: exercism/problem-specifications
-// Commit: 78006a2 move "targetgrouping" to "comments"
-// Problem Specifications Version: 1.2.0
+// Commit: a2ed4f7 book-store: Clarify expected monetary denomination
+// Problem Specifications Version: 1.3.0
 
 var testCases = []struct {
 	description string
 	basket      []int
-	expected    float64
+	expected    int
 }{
 	{
 		description: "Only a single book",
 		basket:      []int{1},
-		expected:    8.00,
+		expected:    800,
 	},
 	{
 		description: "Two of the same book",
 		basket:      []int{2, 2},
-		expected:    16.00,
+		expected:    1600,
 	},
 	{
 		description: "Empty basket",
 		basket:      []int{},
-		expected:    0.00,
+		expected:    0,
 	},
 	{
 		description: "Two different books",
 		basket:      []int{1, 2},
-		expected:    15.20,
+		expected:    1520,
 	},
 	{
 		description: "Three different books",
 		basket:      []int{1, 2, 3},
-		expected:    21.60,
+		expected:    2160,
 	},
 	{
 		description: "Four different books",
 		basket:      []int{1, 2, 3, 4},
-		expected:    25.60,
+		expected:    2560,
 	},
 	{
 		description: "Five different books",
 		basket:      []int{1, 2, 3, 4, 5},
-		expected:    30.00,
+		expected:    3000,
 	},
 	{
 		description: "Two groups of four is cheaper than group of five plus group of three",
 		basket:      []int{1, 1, 2, 2, 3, 3, 4, 5},
-		expected:    51.20,
+		expected:    5120,
 	},
 	{
 		description: "Group of four plus group of two is cheaper than two groups of three",
 		basket:      []int{1, 1, 2, 2, 3, 4},
-		expected:    40.80,
+		expected:    4080,
 	},
 	{
 		description: "Two each of first 4 books and 1 copy each of rest",
 		basket:      []int{1, 1, 2, 2, 3, 3, 4, 4, 5},
-		expected:    55.60,
+		expected:    5560,
 	},
 	{
 		description: "Two copies of each book",
 		basket:      []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5},
-		expected:    60.00,
+		expected:    6000,
 	},
 	{
 		description: "Three copies of first book and 2 each of remaining",
 		basket:      []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1},
-		expected:    68.00,
+		expected:    6800,
 	},
 	{
 		description: "Three each of first 2 books and 2 each of remaining books",
 		basket:      []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2},
-		expected:    75.20,
+		expected:    7520,
 	},
 	{
 		description: "Four groups of four are cheaper than two groups each of five and three",
 		basket:      []int{1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5},
-		expected:    102.40,
+		expected:    10240,
 	},
 }

--- a/exercises/book-store/example.go
+++ b/exercises/book-store/example.go
@@ -1,25 +1,23 @@
 package bookstore
 
-import (
-	"math"
-)
+import "math"
 
-const bookPrice = 8
+const bookPrice = 800 // 800 cents = $8.00
 
-var discountTiers = [...]float64{0, 0.05, 0.1, 0.2, 0.25}
+var discountTiers = [...]int{0, 5, 10, 20, 25}
 
 // Cost implements the book store exercise.
-func Cost(books []int) float64 {
+func Cost(books []int) int {
 	return cost(books, 0)
 }
 
-func cost(books []int, priceSoFar float64) float64 {
+func cost(books []int, priceSoFar int) int {
 	if len(books) == 0 {
 		return priceSoFar
 	}
 
 	distinctBooks, remainingBooks := getDistinctBooks(books)
-	minPrice := math.MaxFloat32
+	minPrice := math.MaxInt32
 
 	for i := 1; i <= len(distinctBooks); i++ {
 		newRemainingBooks := make([]int, len(remainingBooks))
@@ -27,7 +25,9 @@ func cost(books []int, priceSoFar float64) float64 {
 		newRemainingBooks = append(newRemainingBooks, distinctBooks[i:]...)
 
 		price := cost(newRemainingBooks, priceSoFar+groupCost(i))
-		minPrice = math.Min(minPrice, price)
+		if price < minPrice {
+			minPrice = price
+		}
 	}
 
 	return minPrice
@@ -47,6 +47,8 @@ func getDistinctBooks(books []int) (distinct []int, remaining []int) {
 	return
 }
 
-func groupCost(groupSize int) float64 {
-	return float64(bookPrice*groupSize) * (1.00 - discountTiers[groupSize-1])
+func groupCost(groupSize int) int {
+	normalPrice := bookPrice * groupSize
+	discount := (normalPrice * discountTiers[groupSize-1]) / 100
+	return normalPrice - discount
 }


### PR DESCRIPTION
Update generator for latest canonical-data.json
which uses integer expected values instead of floating point.

Update exercise to use type int for Cost output.
Add hints.md for guidance.
Update README.md.