### PR TITLE
clock: extend exercise with Subtract operation

### DIFF
--- a/exercises/clock/.meta/gen.go
+++ b/exercises/clock/.meta/gen.go
@@ -29,19 +29,32 @@ type testGroup struct {
 	Description string
 	Cases       []json.RawMessage `property:"RAW"`
 	CreateCases []struct {
-		Description  string
-		Hour, Minute int
-		Expected     string
+		Description string
+		Input       struct {
+			Hour, Minute int
+		}
+		Expected string
 	} `property:"create"`
 	AddCases []struct {
-		Description       string
-		Hour, Minute, Add int
-		Expected          string
+		Description string
+		Input       struct {
+			Hour, Minute, Value int
+		}
+		Expected string
 	} `property:"add"`
+	SubtractCases []struct {
+		Description string
+		Input       struct {
+			Hour, Minute, Value int
+		}
+		Expected string
+	} `property:"subtract"`
 	EqCases []struct {
-		Description    string
-		Clock1, Clock2 struct{ Hour, Minute int }
-		Expected       bool
+		Description string
+		Input       struct {
+			Clock1, Clock2 struct{ Hour, Minute int }
+		}
+		Expected bool
 	} `property:"equal"`
 }
 
@@ -62,7 +75,7 @@ var tmpl = `package clock
 			want string
 		}{
 			{{- range .CreateCases }}
-				{ {{.Hour}}, {{.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+				{ {{.Input.Hour}}, {{.Input.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
 			{{- end }}
 		}
 	{{- end }}
@@ -73,7 +86,18 @@ var tmpl = `package clock
 			want string
 		}{
 			{{- range .AddCases }}
-				{ {{.Hour}}, {{.Minute}}, {{.Add}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+				{ {{.Input.Hour}}, {{.Input.Minute}}, {{.Input.Value}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+			{{- end }}
+		}
+	{{- end }}
+
+	{{- if .SubtractCases }}
+		var {{ .GroupShortName }}Tests = []struct {
+			h, m, a int
+			want string
+		}{
+			{{- range .SubtractCases }}
+				{ {{.Input.Hour}}, {{.Input.Minute}}, {{.Input.Value}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
 			{{- end }}
 		}
 	{{- end }}
@@ -87,8 +111,8 @@ var tmpl = `package clock
 			{{- range .EqCases }}
 				// {{.Description}}
 				{
-					hm{ {{.Clock1.Hour}}, {{.Clock1.Minute}}},
-					hm{ {{.Clock2.Hour}}, {{.Clock2.Minute}}},
+					hm{ {{.Input.Clock1.Hour}}, {{.Input.Clock1.Minute}}},
+					hm{ {{.Input.Clock2.Hour}}, {{.Input.Clock2.Minute}}},
 					{{.Expected}},
 				},
 			{{- end }}

--- a/exercises/clock/cases_test.go
+++ b/exercises/clock/cases_test.go
@@ -1,8 +1,8 @@
 package clock
 
 // Source: exercism/problem-specifications
-// Commit: 54c3b74 Cleanup canonical-data for clock
-// Problem Specifications Version: 1.0.1
+// Commit: 8b96944 clock: remove obsolete sentence from comment
+// Problem Specifications Version: 2.2.1
 
 // Create a new clock with an initial time
 var timeTests = []struct {
@@ -50,14 +50,14 @@ var subtractTests = []struct {
 	h, m, a int
 	want    string
 }{
-	{10, 3, -3, "10:00"},    // subtract minutes
-	{10, 3, -30, "09:33"},   // subtract to previous hour
-	{10, 3, -70, "08:53"},   // subtract more than an hour
-	{0, 3, -4, "23:59"},     // subtract across midnight
-	{0, 0, -160, "21:20"},   // subtract more than two hours
-	{6, 15, -160, "03:35"},  // subtract more than two hours with borrow
-	{5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
-	{2, 20, -3000, "00:20"}, // subtract more than two days
+	{10, 3, 3, "10:00"},    // subtract minutes
+	{10, 3, 30, "09:33"},   // subtract to previous hour
+	{10, 3, 70, "08:53"},   // subtract more than an hour
+	{0, 3, 4, "23:59"},     // subtract across midnight
+	{0, 0, 160, "21:20"},   // subtract more than two hours
+	{6, 15, 160, "03:35"},  // subtract more than two hours with borrow
+	{5, 32, 1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
+	{2, 20, 3000, "00:20"}, // subtract more than two days
 }
 
 // Compare two clocks for equality

--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -44,13 +44,17 @@ func TestAddMinutes(t *testing.T) {
 				a.h, a.m, a.a, got, a.want)
 		}
 	}
+	t.Log(len(addTests), "test cases")
+}
+
+func TestSubtractMinutes(t *testing.T) {
 	for _, a := range subtractTests {
-		if got := New(a.h, a.m).Add(a.a); got.String() != a.want {
+		if got := New(a.h, a.m).Subtract(a.a); got.String() != a.want {
 			t.Fatalf("New(%d, %d).Add(%d) = %q, want %q",
 				a.h, a.m, a.a, got, a.want)
 		}
 	}
-	t.Log(len(addTests), "test cases")
+	t.Log(len(subtractTests), "test cases")
 }
 
 func TestCompareClocks(t *testing.T) {
@@ -77,6 +81,16 @@ func BenchmarkAddMinutes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, a := range addTests {
 			c.Add(a.a)
+		}
+	}
+}
+
+func BenchmarkSubtractMinutes(b *testing.B) {
+	c := New(12, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, a := range subtractTests {
+			c.Subtract(a.a)
 		}
 	}
 }

--- a/exercises/clock/example.go
+++ b/exercises/clock/example.go
@@ -16,6 +16,10 @@ func (c Clock) Add(m int) Clock {
 	return New(0, int(c)+m)
 }
 
+func (c Clock) Subtract(m int) Clock {
+	return New(0, int(c)-m)
+}
+
 func (c Clock) String() string {
 	return fmt.Sprintf("%02d:%02d", c/60, c%60)
 }

--- a/exercises/clock/example_clock_test.go
+++ b/exercises/clock/example_clock_test.go
@@ -10,7 +10,7 @@ func ExampleClock_new() {
 	// Output: 10:30
 }
 
-func ExampleClock_Add_add() {
+func ExampleClock_Add() {
 	// create a clock
 	clock := New(10, 30)
 
@@ -21,12 +21,12 @@ func ExampleClock_Add_add() {
 	// Output: 11:00
 }
 
-func ExampleClock_Add_subtract() {
+func ExampleClock_Subtract() {
 	// create a clock
 	clock := New(10, 30)
 
 	// subtract an hour and a half from it
-	clock = clock.Add(-90)
+	clock = clock.Subtract(90)
 	fmt.Println(clock.String())
 
 	// Output: 09:00


### PR DESCRIPTION
The problem-specifications canonical-data.json was updated
to define separate subtract property test cases and also indicated
that the exercise should include a Subtract function.

Update generator to recognize "subtract" property separately
and output subtractTests; also update for the new "input" schema.

Update example solution to implement Subtract operation.

Update test program to call Subtract operation
in TestSubtractMinutes and add BenchmarkSubtractMinutes.