### PR TITLE
exercises: move no stub information to first encounter exercise's README

### DIFF
--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -17,6 +17,18 @@ Convert a number to a string, the contents of which depend on the number's facto
 - 34 has four factors: 1, 2, 17, and 34.
   - In raindrop-speak, this would be "34".
 
+## No Stub
+
+This may be the first Go track exercise you encounter without a stub: a
+pre-existing `raindrops.go` file for your solution. You may not see stubs in
+the future and should begin to get comfortable with creating your own Go files
+for your solutions.
+
+One way to figure out what the function signature(s) you would need is to look
+at the corresponding \*\_test.go file. It will show you what the package level
+functions(s) should be that the test will use to verify the solution.
+
+
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.

--- a/exercises/space-age/.meta/hints.md
+++ b/exercises/space-age/.meta/hints.md
@@ -1,7 +1,7 @@
 ## No Stub
 
 This may be the first Go track exercise you encounter without a stub: a
-pre-existing `raindrops.go` file for your solution. You may not see stubs in
+pre-existing `space_age.go` file for your solution. You may not see stubs in
 the future and should begin to get comfortable with creating your own Go files
 for your solutions.
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -12,10 +12,23 @@ Given an age in seconds, calculate how old someone would be on:
    - Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31.69 Earth-years old.
+be able to say that they're 31.69 Earth-years old. Round all ages to
+the nearest hundredth of a year.
 
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+
+## No Stub
+
+This may be the first Go track exercise you encounter without a stub: a
+pre-existing `space_age.go` file for your solution. You may not see stubs in
+the future and should begin to get comfortable with creating your own Go files
+for your solutions.
+
+One way to figure out what the function signature(s) you would need is to look
+at the corresponding \*\_test.go file. It will show you what the package level
+functions(s) should be that the test will use to verify the solution.
+
 
 ## Running the tests
 

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -28,10 +28,6 @@ On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, 
 On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 ```
 
-## No Stub
-This is the first Go track exercise you encounter without a stub: a pre-existing "twelve-days.go" file for your solution. You may not see stubs in the future and should begin to get comfortable with creating your own Go files for your solutions.
-
-
 ## Running the tests
 
 To run the tests run the command `go test` from within the exercise directory.
@@ -51,7 +47,8 @@ you're having trouble, please visit the exercism.io [Go language page](http://ex
 
 ## Source
 
-Wikipedia [http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)](http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song))
+Wikipedia [http://en.wikipedia.org/wiki/The*Twelve_Days_of_Christmas*(song)](<http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)>)
 
 ## Submitting Incomplete Solutions
+
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Moved information about not having stubs available to two locations:
`raindrops` and `space-age`, either may be the first encounter of a no
stub exercise. The former on the core track the latter as a bonus
exercise. Also removed the no stub info from `twelve days`. Also added
a `hints.md` style notice for `space-age` and regenerated the READMEs
for `raindrops` and `space-age`.

Resolves #1049, see also #1048.