### PR TITLE
reverse-string: add UTF-8 multibyte test case

### DIFF
--- a/exercises/reverse-string/.meta/gen.go
+++ b/exercises/reverse-string/.meta/gen.go
@@ -40,11 +40,13 @@ var tmpl = `package reverse
 
 {{.Header}}
 
-var testCases = []struct {
+type reverseTestCase struct {
 	description	string
 	input		string
 	expected	string
-}{ {{range .J.Cases}}
+}
+
+var testCases = []reverseTestCase{ {{range .J.Cases}}
 {
 	description:	{{printf "%q"  .Description}},
 	input:		{{printf "%q"  .Input.Value}},

--- a/exercises/reverse-string/cases_test.go
+++ b/exercises/reverse-string/cases_test.go
@@ -4,11 +4,13 @@ package reverse
 // Commit: 2f77985 reverse-string: apply "input" policy
 // Problem Specifications Version: 1.1.0
 
-var testCases = []struct {
+type reverseTestCase struct {
 	description string
 	input       string
 	expected    string
-}{
+}
+
+var testCases = []reverseTestCase{
 	{
 		description: "an empty string",
 		input:       "",

--- a/exercises/reverse-string/reverse_string_test.go
+++ b/exercises/reverse-string/reverse_string_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestReverse(t *testing.T) {
-	for _, testCase := range testCases {
+	for _, testCase := range append(testCases, multiByteCases...) {
 		if res := String(testCase.input); res != testCase.expected {
 			t.Fatalf("FAIL: %s(%s)\nExpected: %q\nActual: %q",
 				testCase.description, testCase.input, testCase.expected, res)
@@ -30,4 +30,15 @@ func BenchmarkReverse(b *testing.B) {
 			String(test.input)
 		}
 	}
+}
+
+// mutiByteCases adds UTF-8 multi-byte case,
+// since the canonical-data.json (generator data source for cases_test.go)
+// doesn't have any such cases.
+var multiByteCases = []reverseTestCase{
+	{
+		description: "a multi-byte test case",
+		input:       "Hello, 世界",
+		expected:    "界世 ,olleH",
+	},
 }


### PR DESCRIPTION
Add reverseTestCase type in generator output to be
used in the test program.

Since file cases_test.go is generated from
problem-specifications/exercises/reverse-string/canonical-data.json,
add an additional test case for UTF-8 within the test program.

Resolves #1068