### PR TITLE
simple-linked-list: improve benchmark runtime

### DIFF
--- a/exercises/simple-linked-list/linked_list_test.go
+++ b/exercises/simple-linked-list/linked_list_test.go
@@ -165,10 +165,9 @@ func BenchmarkNewList(b *testing.B) {
 }
 
 func BenchmarkListSize(b *testing.B) {
+	list := New(array1To10)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		list := New(array1To10)
-		b.StartTimer()
 		_ = list.Size()
 	}
 }
@@ -176,35 +175,40 @@ func BenchmarkListSize(b *testing.B) {
 func BenchmarkListPush(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		list := New(array1To10)
+		list := New([]int{})
 		b.StartTimer()
-		list.Push(11)
+		for k := 0; k < 100; k++ {
+			list.Push(k)
+		}
 	}
 }
 
 func BenchmarkListPop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		list := New(array1To10)
+		list := New([]int{})
+		for k := 0; k < 100; k++ {
+			list.Push(k)
+		}
 		b.StartTimer()
-		_, _ = list.Pop()
+		for k := 0; k < 100; k++ {
+			_, _ = list.Pop()
+		}
 	}
 }
 
 func BenchmarkListToArray(b *testing.B) {
+	list := New(array1To10)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		list := New(array1To10)
-		b.StartTimer()
 		_ = list.Array()
 	}
 }
 
 func BenchmarkListReverse(b *testing.B) {
+	list := New(array1To10)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		list := New(array1To10)
-		b.StartTimer()
 		_ = list.Reverse()
 	}
 }

--- a/exercises/simple-linked-list/linked_list_test.go
+++ b/exercises/simple-linked-list/linked_list_test.go
@@ -177,7 +177,7 @@ func BenchmarkListPush(b *testing.B) {
 		b.StopTimer()
 		list := New([]int{})
 		b.StartTimer()
-		for k := 0; k < 100; k++ {
+		for k := 0; k < 1000; k++ {
 			list.Push(k)
 		}
 	}
@@ -187,11 +187,11 @@ func BenchmarkListPop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		list := New([]int{})
-		for k := 0; k < 100; k++ {
+		for k := 0; k < 1000; k++ {
 			list.Push(k)
 		}
 		b.StartTimer()
-		for k := 0; k < 100; k++ {
+		for k := 0; k < 1000; k++ {
 			_, _ = list.Pop()
 		}
 	}


### PR DESCRIPTION
Running go test -bench on this exercise is taking
far too much time (several minutes).

Improve the benchmark routines by
doing the list creation outside the loop
and using ResetTimer; this applies to routines
    BenchmarkNewList,
    BenchmarkListSize,
    BenchmarkListToArray, and
    BenchmarkListReverse.

For BenchmarkListPush and BenchmarkListPop,
use an inner loop to measure 100 instances
of the respective Push or Pop operations.
This approach reduces the overhead runtime in relation
to the operations being measured.

Resolves #1073