### PR TITLE
crypto-square: add spaces if text does not fill rectangle

### DIFF
--- a/exercises/crypto-square/crypto_square_test.go
+++ b/exercises/crypto-square/crypto_square_test.go
@@ -12,7 +12,7 @@ var tests = []struct {
 	},
 	{
 		"1, 2, 3 GO!",
-		"1g 2o 3",
+		"1g 2o 3 ",
 	},
 	{
 		"1234",
@@ -32,19 +32,19 @@ var tests = []struct {
 	},
 	{
 		"ZOMG! ZOMBIES!!!",
-		"zzi ooe mms gb",
+		"zzi ooe mms gb ",
 	},
 	{
 		"Time is an illusion. Lunchtime doubly so.",
-		"tasney inicds miohoo elntu illib suuml",
+		"tasney inicds miohoo elntu  illib  suuml ",
 	},
 	{
 		"We all know interspecies romance is weird.",
-		"wneiaw eorene awssci liprer lneoid ktcms",
+		"wneiaw eorene awssci liprer lneoid ktcms ",
 	},
 	{
 		"Madness, and then illumination.",
-		"msemo aanin dnin ndla etlt shui",
+		"msemo aanin dnin  ndla  etlt  shui ",
 	},
 	{
 		"Vampires are people too!",
@@ -64,19 +64,19 @@ var tests = []struct {
 	},
 	{
 		"12 3",
-		"13 2",
+		"13 2 ",
 	},
 	{
 		"12345678",
-		"147 258 36",
+		"147 258 36 ",
 	},
 	{
 		"123456789a",
-		"159 26a 37 48",
+		"159 26a 37  48 ",
 	},
 	{
 		"If man was meant to stay on the ground god would have given us roots",
-		"imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau",
+		"imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ",
 	},
 	{
 		"Have a nice day. Feed the dog & chill out!",

--- a/exercises/crypto-square/example.go
+++ b/exercises/crypto-square/example.go
@@ -18,9 +18,16 @@ func norm(r rune) rune {
 func Encode(pt string) string {
 	pt = strings.Map(norm, pt)
 	numCols := int(math.Ceil(math.Sqrt(float64(len(pt)))))
+	padding := numCols*(numCols-1) - len(pt)
+	if padding < 0 {
+		padding = numCols*numCols - len(pt)
+	}
 	cols := make([]string, numCols)
 	for i, r := range pt {
 		cols[i%numCols] += string(r)
+	}
+	for i := 0; i < padding; i++ {
+		cols[numCols-i-1] += string(' ')
 	}
 	return strings.Join(cols, " ")
 }

--- a/exercises/crypto-square/example.go
+++ b/exercises/crypto-square/example.go
@@ -27,7 +27,7 @@ func Encode(pt string) string {
 		cols[i%numCols] += string(r)
 	}
 	for i := 0; i < padding; i++ {
-		cols[numCols-i-1] += string(' ')
+		cols[numCols-i-1] += " "
 	}
 	return strings.Join(cols, " ")
 }


### PR DESCRIPTION
The exercise description inside the readme calls for padding with
trailing spaces on the last n chunks if the message does not perfectly
fill the calculated rectangle.  This commit fixes the testcases and the
example implementation.

Fixes: https://github.com/exercism/go/issues/1086