### PR TITLE
Spelling Dominoe -> Domino

### DIFF
--- a/exercises/dominoes/.meta/gen.go
+++ b/exercises/dominoes/.meta/gen.go
@@ -29,8 +29,8 @@ type js struct {
 
 type Dominoe [2]int
 
-func (d Dominoe) String() string {
-	return fmt.Sprintf("Dominoe{%d, %d}", d[0], d[1])
+func (d Domino) String() string {
+	return fmt.Sprintf("Domino{%d, %d}", d[0], d[1])
 }
 
 // template applied to above data structure generates the Go test cases
@@ -39,7 +39,7 @@ type OneCase struct {
 	Description string
 	Comments    []string
 	Input       struct {
-		Dominoes []Dominoe
+		Dominoes []Domino
 	}
 	Expected bool
 }
@@ -52,13 +52,13 @@ var tmpl = `package dominoes
 
 var testCases = []struct {
 	description    string
-	dominoes  []Dominoe
+	dominoes  []Domino
 	valid          bool     // true => can chain, false => cannot chain
 }{ {{range .J.Cases}}
 {
 	{{printf "%q"  .Description}},
 	{{range .Comments}}//{{.}}
-	{{end}}[]Dominoe{ {{range .Input.Dominoes}} {{printf "%v" .}}, {{end}} },
+	{{end}}[]Domino{ {{range .Input.Dominoes}} {{printf "%v" .}}, {{end}} },
 	{{printf "%v"  .Expected}},
 }, {{end}}
 }

--- a/exercises/dominoes/.meta/gen.go
+++ b/exercises/dominoes/.meta/gen.go
@@ -27,7 +27,7 @@ type js struct {
 	Cases    []OneCase
 }
 
-type Dominoe [2]int
+type Domino [2]int
 
 func (d Domino) String() string {
 	return fmt.Sprintf("Domino{%d, %d}", d[0], d[1])

--- a/exercises/dominoes/.meta/hints.md
+++ b/exercises/dominoes/.meta/hints.md
@@ -6,14 +6,14 @@ of dominoes and attempts to construct a legal chain of dominoes.
 MakeChain should have the following signature:
 
 ```
-type Dominoe [2]int
+type Domino [2]int
 
-func MakeChain(input []Dominoe) (chain []Dominoe, ok bool)
+func MakeChain(input []Domino) (chain []Domino, ok bool)
 ```
 
-The 'ok' bool result indicates whether the given input dominoe list
+The 'ok' bool result indicates whether the given input domino list
 could be arranged in a legal chain. An empty input list is considered legal,
-and a single dominoe whose sides are the same is also considered legal.
+and a single domino whose sides are the same is also considered legal.
 
 The 'chain' result is a slice of zero or more dominoes
 arranged in an order which shows the legal chain.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -22,19 +22,19 @@ of dominoes and attempts to construct a legal chain of dominoes.
 MakeChain should have the following signature:
 
 ```
-type Dominoe [2]int
+type Domino [2]int
 
-func MakeChain(input []Dominoe) (chain []Dominoe, ok bool)
+func MakeChain(input []Domino) (chain []Domino, ok bool)
 ```
 
-The 'ok' bool result indicates whether the given input dominoe list
+The 'ok' bool result indicates whether the given input domino list
 could be arranged in a legal chain. An empty input list is considered legal,
 and a single dominoe whose sides are the same is also considered legal.
 
 The 'chain' result is a slice of zero or more dominoes
 arranged in an order which shows the legal chain.
 It is acceptable (and expected) that dominoes in 'input' may need
-to be rotated so that each side matches their adjacent dominoe in the chain.
+to be rotated so that each side matches their adjacent domino in the chain.
 Dominoes at the beginning and the end of the chain must also match their outer side.
 
 If the given input slice of dominoes cannot be arranged in a legal chain

--- a/exercises/dominoes/cases_test.go
+++ b/exercises/dominoes/cases_test.go
@@ -6,37 +6,37 @@ package dominoes
 
 var testCases = []struct {
 	description string
-	dominoes    []Dominoe
+	dominoes    []Domino
 	valid       bool // true => can chain, false => cannot chain
 }{
 	{
 		"empty input = empty output",
-		[]Dominoe{},
+		[]Domino{},
 		true,
 	},
 	{
 		"singleton input = singleton output",
-		[]Dominoe{Dominoe{1, 1}},
+		[]Domino{Domino{1, 1}},
 		true,
 	},
 	{
 		"singleton that can't be chained",
-		[]Dominoe{Dominoe{1, 2}},
+		[]Domino{Domino{1, 2}},
 		false,
 	},
 	{
 		"three elements",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{3, 1}, Dominoe{2, 3}},
+		[]Domino{Domino{1, 2}, Domino{3, 1}, Domino{2, 3}},
 		true,
 	},
 	{
 		"can reverse dominoes",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{1, 3}, Dominoe{2, 3}},
+		[]Domino{Domino{1, 2}, Domino{1, 3}, Domino{2, 3}},
 		true,
 	},
 	{
 		"can't be chained",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{4, 1}, Dominoe{2, 3}},
+		[]Domino{Domino{1, 2}, Domino{4, 1}, Domino{2, 3}},
 		false,
 	},
 	{
@@ -46,17 +46,17 @@ var testCases = []struct {
 		//Nevertheless, there is no chain here, as there's no way to get from 1 to 2.
 		//This test (and the two following) prevent solutions from using the even-degree test as the sole criterion,
 		//as that is not a sufficient condition.
-		[]Dominoe{Dominoe{1, 1}, Dominoe{2, 2}},
+		[]Domino{Domino{1, 1}, Domino{2, 2}},
 		false,
 	},
 	{
 		"disconnected - double loop",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{2, 1}, Dominoe{3, 4}, Dominoe{4, 3}},
+		[]Domino{Domino{1, 2}, Domino{2, 1}, Domino{3, 4}, Domino{4, 3}},
 		false,
 	},
 	{
 		"disconnected - single isolated",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{2, 3}, Dominoe{3, 1}, Dominoe{4, 4}},
+		[]Domino{Domino{1, 2}, Domino{2, 3}, Domino{3, 1}, Domino{4, 4}},
 		false,
 	},
 	{
@@ -66,17 +66,17 @@ var testCases = []struct {
 		//there is no chain possible.
 		//There is indeed a chain here, so this test checks for this line of reasoning.
 		//You need to place the (2, 4) after the (1, 2) rather than the (2, 3).
-		[]Dominoe{Dominoe{1, 2}, Dominoe{2, 3}, Dominoe{3, 1}, Dominoe{2, 4}, Dominoe{2, 4}},
+		[]Domino{Domino{1, 2}, Domino{2, 3}, Domino{3, 1}, Domino{2, 4}, Domino{2, 4}},
 		true,
 	},
 	{
 		"separate loops",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{2, 3}, Dominoe{3, 1}, Dominoe{1, 1}, Dominoe{2, 2}, Dominoe{3, 3}},
+		[]Domino{Domino{1, 2}, Domino{2, 3}, Domino{3, 1}, Domino{1, 1}, Domino{2, 2}, Domino{3, 3}},
 		true,
 	},
 	{
 		"nine elements",
-		[]Dominoe{Dominoe{1, 2}, Dominoe{5, 3}, Dominoe{3, 1}, Dominoe{1, 2}, Dominoe{2, 4}, Dominoe{1, 6}, Dominoe{2, 3}, Dominoe{3, 4}, Dominoe{5, 6}},
+		[]Domino{Domino{1, 2}, Domino{5, 3}, Domino{3, 1}, Domino{1, 2}, Domino{2, 4}, Domino{1, 6}, Domino{2, 3}, Domino{3, 4}, Domino{5, 6}},
 		true,
 	},
 }

--- a/exercises/dominoes/dominoes_test.go
+++ b/exercises/dominoes/dominoes_test.go
@@ -32,7 +32,7 @@ var (
 	errChainSetNotSameAsInputSet = errors.New("chain dominoes not same as input")
 )
 
-func verifyChain(input []Dominoe, chain []Dominoe) error {
+func verifyChain(input []Domino, chain []Domino) error {
 	if len(input) != len(chain) {
 		return errWrongLengthChain
 	}
@@ -72,9 +72,9 @@ func verifyChain(input []Dominoe, chain []Dominoe) error {
 	return nil
 }
 
-func copyDominoes(d []Dominoe) (c []Dominoe) {
-	c = make([]Dominoe, len(d))
-	// Put each dominoe in "canonical position" [a,b] where a <= b.
+func copyDominoes(d []Domino) (c []Domino) {
+	c = make([]Domino, len(d))
+	// Put each domino in "canonical position" [a,b] where a <= b.
 	for i := range d {
 		c[i] = d[i]
 		if c[i][0] > c[i][1] {
@@ -84,7 +84,7 @@ func copyDominoes(d []Dominoe) (c []Dominoe) {
 	return c
 }
 
-func sortDominoes(d []Dominoe) {
+func sortDominoes(d []Domino) {
 	sort.Slice(d,
 		func(i, j int) bool {
 			if d[i][0] < d[j][0] {

--- a/exercises/dominoes/example.go
+++ b/exercises/dominoes/example.go
@@ -1,13 +1,13 @@
 package dominoes
 
-type Dominoe [2]int
+type Domino [2]int
 
 // MakeChain returns a chain and true if the dominoes in input
 // can be arranged in a legal chain; otherwise it returns nil, false.
-func MakeChain(input []Dominoe) (chain []Dominoe, ok bool) {
+func MakeChain(input []Domino) (chain []Domino, ok bool) {
 	switch len(input) {
 	case 0:
-		return []Dominoe{}, true
+		return []Domino{}, true
 	case 1:
 		// A single is legal if the ends match.
 		if input[0][0] == input[0][1] {
@@ -15,16 +15,16 @@ func MakeChain(input []Dominoe) (chain []Dominoe, ok bool) {
 		}
 		return nil, false
 	}
-	chain, ok = buildDominoeChain(input)
+	chain, ok = buildDominoChain(input)
 	if !ok {
 		return nil, false
 	}
 	return chain, true
 }
 
-// buildDominoeChain looks for a matching dominoe chain using the 2 or more dominoes in d.
-func buildDominoeChain(d []Dominoe) ([]Dominoe, bool) {
-	permuteList := dominoePermutations(d, len(d))
+// buildDominoChain looks for a matching domino chain using the 2 or more dominoes in d.
+func buildDominoChain(d []Domino) ([]Domino, bool) {
+	permuteList := dominoPermutations(d, len(d))
 	for _, p := range permuteList {
 		chain, ok := arrangeChain(p)
 		if ok {
@@ -35,38 +35,38 @@ func buildDominoeChain(d []Dominoe) ([]Dominoe, bool) {
 }
 
 // arrangeChain uses the dominoes positionally in d[] attempting to make a matching chain;
-// reversing of sides of any dominoe is permitted, but the order of dominoes in d remains
+// reversing of sides of any domino is permitted, but the order of dominoes in d remains
 // the same left to right.
-func arrangeChain(d []Dominoe) (chain []Dominoe, ok bool) {
+func arrangeChain(d []Domino) (chain []Domino, ok bool) {
 	// A good chain will match length of d, so preallocate the chain.
-	chain = make([]Dominoe, len(d))
+	chain = make([]Domino, len(d))
 	n := 0
-	// Put first dominoe into the chain for starting point.
+	// Put first domino into the chain for starting point.
 	chain[n] = d[0]
 	// Loop through the remaining dominoes in d, attempting to add them into the chain,
-	// allowing a reverse of either single one in chain or the new dominoe t at each step.
+	// allowing a reverse of either single one in chain or the new domino t at each step.
 	for i := 1; i < len(d); i++ {
 		t := d[i]
 		last := chain[n]
 		if n == 0 && last[0] == t[0] {
 			// reverse first and only item in chain to match t, and add t to chain.
-			chain[n] = reverseDominoe(last)
+			chain[n] = reverseDomino(last)
 			chain[n+1] = t
 		} else if n == 0 && last[0] == t[1] {
 			// reverse only item in chain and t to match, and add reversed t to chain.
-			chain[n] = reverseDominoe(last)
-			chain[n+1] = reverseDominoe(t)
+			chain[n] = reverseDomino(last)
+			chain[n+1] = reverseDomino(t)
 		} else if last[1] == t[0] {
 			// add t as-is into chain.
 			chain[n+1] = t
 		} else if last[1] == t[1] {
 			// reverse t to match last one in chain, and add reversed t to chain.
-			chain[n+1] = reverseDominoe(t)
+			chain[n+1] = reverseDomino(t)
 		} else {
 			// no match for this chain configuration of d, even with swapping.
 			return nil, false
 		}
-		// chain is now filled in with one more dominoe.
+		// chain is now filled in with one more domino.
 		n++
 	}
 	// Both ends of the chain must also match.
@@ -76,14 +76,14 @@ func arrangeChain(d []Dominoe) (chain []Dominoe, ok bool) {
 	return chain, true
 }
 
-// reverseDominoe returns given Dominoe x, with its sides reversed/rotated.
-func reverseDominoe(x Dominoe) Dominoe {
-	return Dominoe{x[1], x[0]}
+// reverseDomino returns given Domino x, with its sides reversed/rotated.
+func reverseDomino(x Domino) Domino {
+	return Domino{x[1], x[0]}
 }
 
-// dominoePermutations returns a slice containing the r length permutations of the elements in iterable.
+// dominoPermutations returns a slice containing the r length permutations of the elements in iterable.
 // The implementation is modeled after the Python itertools.permutations().
-func dominoePermutations(iterable []Dominoe, r int) (perms [][]Dominoe) {
+func dominoPermutations(iterable []Domino, r int) (perms [][]Domino) {
 	pool := iterable
 	n := len(pool)
 
@@ -101,12 +101,12 @@ func dominoePermutations(iterable []Dominoe, r int) (perms [][]Dominoe) {
 		cycles[i] = n - i
 	}
 
-	result := make([]Dominoe, r)
+	result := make([]Domino, r)
 	for i, el := range indices[:r] {
 		result[i] = pool[el]
 	}
 
-	p := make([]Dominoe, len(result))
+	p := make([]Domino, len(result))
 	copy(p, result)
 	perms = append(perms, p)
 
@@ -129,7 +129,7 @@ func dominoePermutations(iterable []Dominoe, r int) (perms [][]Dominoe) {
 					result[k] = pool[indices[k]]
 				}
 
-				p = make([]Dominoe, len(result))
+				p = make([]Domino, len(result))
 				copy(p, result)
 				perms = append(perms, p)
 


### PR DESCRIPTION
The correct spelling is "Domino" for the singular and "Dominoes" for the plural.

This patch changes the spelling in the code and documentation without changing the functionality at all.