### PR TITLE
Generator cases commit updates for all-your-base, word-count, and yacht

### DIFF
--- a/exercises/all-your-base/cases_test.go
+++ b/exercises/all-your-base/cases_test.go
@@ -1,8 +1,8 @@
 package allyourbase
 
 // Source: exercism/problem-specifications
-// Commit: dc0c431 all-your-base: apply lowerCamelCase policy
-// Problem Specifications Version: 2.2.0
+// Commit: c21ffd7 all-your-base: improve "input base is one" test
+// Problem Specifications Version: 2.3.0
 
 var testCases = []struct {
 	description string
@@ -111,7 +111,7 @@ var testCases = []struct {
 	{
 		description: "input base is one",
 		inputBase:   1,
-		inputDigits: []int{},
+		inputDigits: []int{0},
 		outputBase:  10,
 		expected:    []int(nil),
 		err:         "input base must be >= 2",

--- a/exercises/word-count/cases_test.go
+++ b/exercises/word-count/cases_test.go
@@ -1,8 +1,8 @@
 package wordcount
 
 // Source: exercism/problem-specifications
-// Commit: 5559f34 word-count: Apply new "input" policy
-// Problem Specifications Version: 1.1.0
+// Commit: 77623ec word-count: Use camel-case for property name word-count: remove newline from eof
+// Problem Specifications Version: 1.2.0
 
 var testCases = []struct {
 	description string

--- a/exercises/yacht/cases_test.go
+++ b/exercises/yacht/cases_test.go
@@ -1,7 +1,7 @@
 package yacht
 
 // Source: exercism/problem-specifications
-// Commit: ea4689d yacht: create problem specification for scoring a single hand of yacht
+// Commit: ea4689d yacht: create problem specification for scoring a single hand of yacht. (#1207)
 // Problem Specifications Version: 1.0.0
 
 var testCases = []struct {


### PR DESCRIPTION
The commit headers in the cases_test.go of three exercises are updated.
all-your-base also receives an inputDigits change with no impact.