### PR TITLE
Update isogram test cases

### DIFF
--- a/exercises/isogram/cases_test.go
+++ b/exercises/isogram/cases_test.go
@@ -54,4 +54,9 @@ var testCases = []struct {
 		input:       "accentor",
 		expected:    false,
 	},
+	{
+		description: "longest German isogram",
+		input:       "Heizölrückstoßabdämpfung",
+		expected:    true,
+	},
 }


### PR DESCRIPTION
The longest German isogram is "Heizölrückstoßabdämpfung" (heating oil recoil dampening) with 24 letters.