### PR TITLE
Fix misleading comments abount member function

### DIFF
--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -1,9 +1,9 @@
 // API:
 //
 // Open(initialDeposit int64) *Account
-// (Account) Close() (payout int64, ok bool)
-// (Account) Balance() (balance int64, ok bool)
-// (Account) Deposit(amount int64) (newBalance int64, ok bool)
+// (*Account) Close() (payout int64, ok bool)
+// (*Account) Balance() (balance int64, ok bool)
+// (*Account) Deposit(amount int64) (newBalance int64, ok bool)
 //
 // If Open is given a negative initial deposit, it must return nil.
 // Deposit must handle a negative amount as a withdrawal. Withdrawals must


### PR DESCRIPTION
Member functions should receive Pointers, so the don't receive a copy
of the actual bank account.

I started with the boilerplate from `bank_account_tests.go` and wondered why my tests failed:
```go
➜ bank-account$ go test
--- FAIL: TestSeqOpenDepositClose (0.00s)
	bank_account_test.go:77: Account 'a' opened with initial balance of 10.
	bank_account_test.go:88: Deposit of 20 accepted to account 'a'
	bank_account_test.go:95: a.Close() returned payout = 10, want 30.
--- FAIL: TestMoreSeqCases (0.00s)
	bank_account_test.go:113: Account 'a' opened with initial balance of 10.
	bank_account_test.go:120: Account 'z' opened with initial balance of 0.
	bank_account_test.go:151: Withdrawal of 3 accepted from account 'a'
	bank_account_test.go:161: a.Balance() = 10, want 7
```