### PR TITLE
triangle: Fix references to twofer in stub comments

### DIFF
--- a/exercises/triangle/triangle.go
+++ b/exercises/triangle/triangle.go
@@ -1,7 +1,7 @@
 // This is a "stub" file.  It's a little start on your solution.
 // It's not a complete solution though; you have to write some code.
 
-// Package twofer should have a package comment that summarizes what it's about.
+// Package triangle should have a package comment that summarizes what it's about.
 // https://golang.org/doc/effective_go.html#commentary
 package triangle
 
@@ -17,7 +17,7 @@ const (
     Sca // scalene
 )
 
-// ShareWith should have a comment documenting it.
+// KindFromSides should have a comment documenting it.
 func KindFromSides(a, b, c float64) Kind {
 	// Write some code here to pass the test suite.
 	// Then remove all the stock comments.


### PR DESCRIPTION
Correct comments in stub file to reference the correct package and function name. 

This closes #1123 