### PR TITLE
.travis.yml: use go version 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: false
 # it is better citizenship to not test the additional versions.
 go:
   - 1.9.x
-  - 1.x
+  - 1.10.x
   - tip
 
 # Travis runs in a 64 bit environment but beginning with Go 1.5, building a
@@ -61,7 +61,7 @@ script:
 matrix:
   include:
     # Keep this in sync with the latest version.
-    - go: 1.x
+    - go: 1.10.x
       env: STATIC_CHECKERS=1
   allow_failures:
     - go: tip


### PR DESCRIPTION
For travis-ci, the 1.x is picking up version 1.11beta1 instead of 1.10.3.

The go fmt changes for 1.11beta1 is breaking all PRs
because of the STATIC_CHECKERS using 1.11beta1 since
it has a go fmt change that exercise scrabble-score fails on.

Use 1.10.x instead of 1.x to avoid 1.11beta1 in the short term.

TODO: revisit any necessary 'go fmt' changes for STATIC_CHECKERS
after version 1.11 releases.