### PR TITLE
protein-translation: add errors logic

### DIFF
--- a/exercises/protein-translation/example.go
+++ b/exercises/protein-translation/example.go
@@ -1,57 +1,71 @@
+// Package protein translates RNA sequences into proteins.
 package protein
 
-func FromCodon(codon string) string {
-	switch codon {
+import "errors"
+
+var (
+	STOP           = errors.New("stop")
+	ErrInvalidBase = errors.New("invalid base")
+)
+
+// IsStopCodon checks whether a codon is a stop codon.
+func IsStopCodon(c string) bool {
+	return c == "UAA" || c == "UAG" || c == "UGA"
+
+}
+
+// FromCodon returns the protein for the given codon.
+// If the codon is a stop codon, it returns STOP.
+// If the codon is unrecognized, it returns invalidBase.
+func FromCodon(c string) (string, error) {
+	if IsStopCodon(c) {
+		return "", STOP
+	}
+
+	switch c {
 	case
 		"AUG":
-		return "Methionine"
+		return "Methionine", nil
 	case
 		"UUU",
 		"UUC":
-		return "Phenylalanine"
+		return "Phenylalanine", nil
 	case
 		"UUA",
 		"UUG":
-		return "Leucine"
+		return "Leucine", nil
 	case
 		"UCU",
 		"UCC",
 		"UCA",
 		"UCG":
-		return "Serine"
+		return "Serine", nil
 	case
 		"UAU",
 		"UAC":
-		return "Tyrosine"
+		return "Tyrosine", nil
 	case
 		"UGU",
 		"UGC":
-		return "Cysteine"
+		return "Cysteine", nil
 	case
 		"UGG":
-		return "Tryptophan"
-	case
-		"UAA",
-		"UAG",
-		"UGA":
-		return "STOP"
+		return "Tryptophan", nil
+	default:
+		return "", ErrInvalidBase
 	}
-	return "STOP"
 }
 
+// FromRNA returns the protein sequence for an RNA strand.
 func FromRNA(s string) []string {
-	var res = ""
 	var proteins []string
-	for index, codon := range s {
-		res += string(codon)
-		if index > 0 && (index+1)%3 == 0 {
-			tempCodon := FromCodon(res)
-			if tempCodon == "STOP" {
-				break
-			}
-			proteins = append(proteins, tempCodon)
-			res = ""
+	bases := []rune(s)
+	for i := 0; i < len(bases); i += 3 {
+		p, err := FromCodon(string(bases[i : i+3]))
+		if err == STOP {
+			break
 		}
+		proteins = append(proteins, p)
 	}
 	return proteins
 }

--- a/exercises/protein-translation/example.go
+++ b/exercises/protein-translation/example.go
@@ -1,7 +1,9 @@
 // Package protein translates RNA sequences into proteins.
 package protein
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	STOP           = errors.New("stop")
@@ -16,7 +18,7 @@ func IsStopCodon(c string) bool {
 
 // FromCodon returns the protein for the given codon.
 // If the codon is a stop codon, it returns STOP.
-// If the codon is unrecognized, it returns invalidBase.
+// If the codon is unrecognized, it returns ErrInvalidBase.
 func FromCodon(c string) (string, error) {
 	if IsStopCodon(c) {
 		return "", STOP
@@ -57,15 +59,20 @@ func FromCodon(c string) (string, error) {
 }
 
 // FromRNA returns the protein sequence for an RNA strand.
-func FromRNA(s string) []string {
+// If the sequence contains invalid characters, it returns ErrInvalidBase.
+func FromRNA(s string) ([]string, error) {
 	var proteins []string
 	bases := []rune(s)
 	for i := 0; i < len(bases); i += 3 {
 		p, err := FromCodon(string(bases[i : i+3]))
-		if err == STOP {
-			break
+		switch err {
+		case STOP:
+			return proteins, nil
+		case ErrInvalidBase:
+			return proteins, err
+		default:
+			proteins = append(proteins, p)
 		}
-		proteins = append(proteins, p)
 	}
-	return proteins
+	return proteins, nil
 }

--- a/exercises/protein-translation/protein_translation_test.go
+++ b/exercises/protein-translation/protein_translation_test.go
@@ -89,38 +89,70 @@ func TestCodon(t *testing.T) {
 		actual, err := FromCodon(test.input)
 		if test.errorExpected != nil {
 			if test.errorExpected != err {
-				t.Errorf("FAIL: Protein translation test: %s\nExpected error: %q\nActual error: %q",
+				t.Fatalf("FAIL: Protein translation test: %s\nExpected error: %q\nActual error: %q",
 					test.input, test.errorExpected, err)
 			}
 		} else if err != nil {
-			t.Errorf("FAIL: Protein translation test: %s\nExpected: %s\nGot error: %q",
+			t.Fatalf("FAIL: Protein translation test: %s\nExpected: %s\nGot error: %q",
 				test.input, test.expected, err)
 		}
 		if actual != test.expected {
-			t.Errorf("FAIL: Protein translation test: %s\nExpected: %s\nActual: %s",
+			t.Fatalf("FAIL: Protein translation test: %s\nExpected: %s\nActual: %s",
 				test.input, test.expected, actual)
 		}
-		t.Logf("PASS: %s", test.input)
+		t.Logf("PASS: Protein translation test: %s", test.input)
 	}
 }
 
 type rnaCase struct {
-	input    string
-	expected []string
+	input         string
+	expected      []string
+	errorExpected error
 }
 
 var proteinTestCases = []rnaCase{
-	{"AUGUUUUCUUAAAUG", []string{"Methionine", "Phenylalanine", "Serine"}},
-	{"AUGUUUUGG", []string{"Methionine", "Phenylalanine", "Tryptophan"}},
-	{"AUGUUUUAA", []string{"Methionine", "Phenylalanine"}},
-	{"UGGUGUUAUUAAUGGUUU", []string{"Tryptophan", "Cysteine", "Tyrosine"}},
+	{
+		"AUGUUUUCUUAAAUG",
+		[]string{"Methionine", "Phenylalanine", "Serine"},
+		nil,
+	},
+	{
+		"AUGUUUUGG",
+		[]string{"Methionine", "Phenylalanine", "Tryptophan"},
+		nil,
+	},
+	{
+		"AUGUUUUAA",
+		[]string{"Methionine", "Phenylalanine"},
+		nil,
+	},
+	{
+		"UGGUGUUAUUAAUGGUUU",
+		[]string{"Tryptophan", "Cysteine", "Tyrosine"},
+		nil,
+	},
+	{
+		"UGGAGAAUUAAUGGUUU",
+		[]string{"Tryptophan"},
+		ErrInvalidBase,
+	},
 }
 
 func TestProtein(t *testing.T) {
 	for _, test := range proteinTestCases {
-		actual := FromRNA(test.input)
-		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("FAIL: RNA Translation test: %s\nExpected: %q\nActual %q", test.input, test.expected, actual)
+		actual, err := FromRNA(test.input)
+		if test.errorExpected != nil {
+			if test.errorExpected != err {
+				t.Fatalf("FAIL: RNA translation test: %s\nExpected error: %q\nActual error: %q",
+					test.input, test.errorExpected, err)
+			}
+		} else if err != nil {
+			t.Fatalf("FAIL: RNA translation test: %s\nExpected: %s\nGot error: %q",
+				test.input, test.expected, err)
 		}
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Fatalf("FAIL: RNA Translation test: %s\nExpected: %q\nActual %q", test.input, test.expected, actual)
+		}
+		t.Logf("PASS: RNA translation test: %s", test.input)
 	}
 }

--- a/exercises/protein-translation/protein_translation_test.go
+++ b/exercises/protein-translation/protein_translation_test.go
@@ -6,28 +6,102 @@ import (
 )
 
 type codonCase struct {
-	input    string
-	expected string
+	input         string
+	expected      string
+	errorExpected error
 }
 
 var codonTestCases = []codonCase{
-	{"AUG", "Methionine"},
-	{"UUU", "Phenylalanine"},
-	{"UUC", "Phenylalanine"},
-	{"UUA", "Leucine"},
-	{"UUG", "Leucine"},
-	{"UCU", "Serine"},
-	{"UCC", "Serine"},
-	{"UCA", "Serine"},
-	{"UCG", "Serine"},
-	{"UAU", "Tyrosine"},
-	{"UAC", "Tyrosine"},
-	{"UGU", "Cysteine"},
-	{"UGC", "Cysteine"},
-	{"UGG", "Tryptophan"},
-	{"UAA", "STOP"},
-	{"UAG", "STOP"},
-	{"UGA", "STOP"},
+	{
+		"AUG",
+		"Methionine",
+		nil,
+	},
+	{
+		"UUU",
+		"Phenylalanine",
+		nil,
+	},
+	{
+		"UUC",
+		"Phenylalanine",
+		nil,
+	},
+	{
+		"UUA",
+		"Leucine",
+		nil,
+	},
+	{
+		"UUG",
+		"Leucine",
+		nil,
+	},
+	{
+		"UCG",
+		"Serine",
+		nil,
+	},
+	{
+		"UAU",
+		"Tyrosine",
+		nil,
+	},
+	{
+		"UAC",
+		"Tyrosine",
+		nil,
+	},
+	{
+		"UGU",
+		"Cysteine",
+		nil,
+	},
+	{
+		"UGG",
+		"Tryptophan",
+		nil,
+	},
+	{
+		"UAA",
+		"",
+		STOP,
+	},
+	{
+		"UAG",
+		"",
+		STOP,
+	},
+	{
+		"UGA",
+		"",
+		STOP,
+	},
+	{
+		"ABC",
+		"",
+		ErrInvalidBase,
+	},
+}
+
+func TestCodon(t *testing.T) {
+	for _, test := range codonTestCases {
+		actual, err := FromCodon(test.input)
+		if test.errorExpected != nil {
+			if test.errorExpected != err {
+				t.Errorf("FAIL: Protein translation test: %s\nExpected error: %q\nActual error: %q",
+					test.input, test.errorExpected, err)
+			}
+		} else if err != nil {
+			t.Errorf("FAIL: Protein translation test: %s\nExpected: %s\nGot error: %q",
+				test.input, test.expected, err)
+		}
+		if actual != test.expected {
+			t.Errorf("FAIL: Protein translation test: %s\nExpected: %s\nActual: %s",
+				test.input, test.expected, actual)
+		}
+		t.Logf("PASS: %s", test.input)
+	}
 }
 
 type rnaCase struct {
@@ -42,20 +116,11 @@ var proteinTestCases = []rnaCase{
 	{"UGGUGUUAUUAAUGGUUU", []string{"Tryptophan", "Cysteine", "Tyrosine"}},
 }
 
-func TestCodon(t *testing.T) {
-	for _, test := range codonTestCases {
-		actual := FromCodon(test.input)
-		if actual != test.expected {
-			t.Errorf("Protein Translation test [%s], expected [%s], actual [%s]", test.input, test.expected, actual)
-		}
-	}
-}
-
 func TestProtein(t *testing.T) {
 	for _, test := range proteinTestCases {
 		actual := FromRNA(test.input)
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("Protein Translation test [%s], expected %q, actual %q", test.input, test.expected, actual)
+			t.Errorf("FAIL: RNA Translation test: %s\nExpected: %q\nActual %q", test.input, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Here's my initial pass at a solution for #1132 

Since protein-translation is unlocked by scrabble-score, I thought it was fair game to keep the tests for `FromCodon`, but include the error logic in the tests (and, of course, the example solution). I drew heavily from the golang standard library in designing the solution, but who knows what I may have mangled along the way 😄 