### PR TITLE
two-fer: add param name to stub function

### DIFF
--- a/exercises/two-fer/two_fer.go
+++ b/exercises/two-fer/two_fer.go
@@ -6,7 +6,7 @@
 package twofer
 
 // ShareWith should have a comment documenting it.
-func ShareWith(string) string {
+func ShareWith(name string) string {
 	// Write some code here to pass the test suite.
 	// Then remove all the stock comments.
 	// They're here to help you get started but they only clutter a finished solution.


### PR DESCRIPTION
Not sure if this was intentional, but adding missing parameter name to exercise file.