### PR TITLE
list-ops: Corrected name of test case

### DIFF
--- a/exercises/list-ops/listops_test.go
+++ b/exercises/list-ops/listops_test.go
@@ -44,7 +44,7 @@ var foldTestCases = []struct {
 		list:     []int{},
 	},
 	{
-		name:     "direction dependent function applied to non-empty list",
+		name:     "direction independent function applied to non-empty list",
 		property: "foldr",
 		fn:       func(x, y int) int { return x + y },
 		initial:  5,


### PR DESCRIPTION
Fixes small naming issue : #1145 .

