### PR TITLE
tree-building: add fix for duplicate node test

### DIFF
--- a/exercises/tree-building/tree_building.go
+++ b/exercises/tree-building/tree_building.go
@@ -24,6 +24,19 @@ func Build(records []Record) (*Node, error) {
 	if len(records) == 0 {
 		return nil, nil
 	}
+	dupe := make(map[int]*Record)
+	for _, r := range records {
+		temp := dupe[r.ID]
+
+		if temp == nil {
+			dupe[r.ID] = &r
+			continue
+		}
+
+		if temp.Parent == r.Parent {
+			return nil, fmt.Errorf("Node is a duplicate - {ID: %d, Parent: %d}", r.ID, r.Parent)
+		}
+	}
 	root := &Node{}
 	todo := []*Node{root}
 	n := 1


### PR DESCRIPTION
This fix adds a duplicate check for the failing "duplicate node" test case.

Without this fix, running the tests fails with:
```
go test
--- FAIL: TestMakeTreeFailure (0.00s)
        tree_test.go:242: Build for test case "duplicate node" returned 0:[1:[] 1:[]] but was expected to fail.
FAIL
exit status 1
FAIL    _/.../exercism/go/tree-building    0.011s
```