### PR TITLE
Changes planet type to string

### DIFF
--- a/exercises/space-age/cases_test.go
+++ b/exercises/space-age/cases_test.go
@@ -6,7 +6,7 @@ package space
 
 var testCases = []struct {
 	description string
-	planet      Planet
+	planet      string
 	seconds     float64
 	expected    float64
 }{


### PR DESCRIPTION
This was returning an error: `cannot use "Earth" (type string) as type Planet in field value`. This type Planet just confused me, after changing to string I was able to run the tests and complete the exercise.