### PR TITLE
bank-account: Check that the Balance after Close is 0

### DIFF
--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -65,6 +65,12 @@ func TestSeqOpenBalanceClose(t *testing.T) {
 		t.Log("Balance still available on closed account.")
 		t.Fatalf("a.Balance() = %d, %t.  Want ok == false", b, ok)
 	}
+			
+	// verify closing balance is 0
+	if b, _ := a.Balance(); b != 0 {
+		t.Log("Balance after close is non-zero.")
+		t.Fatalf("After a.Close() balance is %d and not 0", b)
+	}
 }
 
 func TestSeqOpenDepositClose(t *testing.T) {


### PR DESCRIPTION
Noticed a community solution that missed removing the funds from the balance.

Noted that if you get a non-nil error from a method the value is often ignored, but felt is worth checking the balance is 0 after a close.

Maybe over-thinking but you wouldn't expect a closed account to have money left. If used in the real world it would be a big accounting error.

Happy to take any comments and direction if this should be added to some of the other test cases.