### PR TITLE
clock: add Subtract method to Clock API comment

### DIFF
--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -11,9 +11,8 @@ import (
 // New(hour, minute int) Clock     // a "constructor"
 // (Clock) String() string         // a "stringer"
 // (Clock) Add(minutes int) Clock
+// (Clock) Subtract(minutes int) Clock
 //
-// The Add method should also handle subtraction by accepting negative values.
-
 // To satisfy the README requirement about clocks being equal, values of
 // your Clock type need to work with the == operator. This means that if your
 // New function returns a pointer rather than a value, your clocks will


### PR DESCRIPTION
The Clock API now expects there to be a Subtract method on the custom Clock type. But the comment within clock_test.go mentions a Add method for both adding and subtracting time.   