### PR TITLE
forth: update generator for error object

### DIFF
--- a/exercises/forth/cases_test.go
+++ b/exercises/forth/cases_test.go
@@ -1,8 +1,8 @@
 package forth
 
 // Source: exercism/problem-specifications
-// Commit: c853973 forth: add tests for word redefinition (#1243)
-// Problem Specifications Version: 1.6.0
+// Commit: 5ba35c7 forth: add mention of 'error' to comment
+// Problem Specifications Version: 1.7.0
 
 type testGroup struct {
 	group string


### PR DESCRIPTION
The canonical-data.json now uses a json error object
for the error expected cases instead of null.
Add IntSlice() function for OneCase to
handle the error object and return nil for an error
or return the slice of integers for the expected result.