### PR TITLE
phone-number: update generator for error object

### DIFF
--- a/exercises/phone-number/cases_test.go
+++ b/exercises/phone-number/cases_test.go
@@ -1,17 +1,18 @@
 package phonenumber
 
 // Source: exercism/problem-specifications
-// Commit: 0783171 phone-number: Apply new "input" policy
-// Problem Specifications Version: 1.4.0
+// Commit: fc57696 Phone-Number: Resolve inconsistencies in error messages. (#1361)
+// Problem Specifications Version: 1.6.1
 
 // Cleanup user-entered phone numbers
 var numberTests = []struct {
-	description string
-	input       string
-	expectErr   bool
-	number      string
-	areaCode    string
-	formatted   string
+	description      string
+	input            string
+	expectErr        bool
+	errorDescription string
+	number           string
+	areaCode         string
+	formatted        string
 }{
 	{
 		description: "cleans the number",
@@ -35,14 +36,16 @@ var numberTests = []struct {
 		formatted:   "(223) 456-7890",
 	},
 	{
-		description: "invalid when 9 digits",
-		input:       "123456789",
-		expectErr:   true,
+		description:      "invalid when 9 digits",
+		input:            "123456789",
+		expectErr:        true,
+		errorDescription: "incorrect number of digits",
 	},
 	{
-		description: "invalid when 11 digits does not start with a 1",
-		input:       "22234567890",
-		expectErr:   true,
+		description:      "invalid when 11 digits does not start with a 1",
+		input:            "22234567890",
+		expectErr:        true,
+		errorDescription: "11 digits must start with 1",
 	},
 	{
 		description: "valid when 11 digits and starting with 1",
@@ -59,38 +62,69 @@ var numberTests = []struct {
 		formatted:   "(223) 456-7890",
 	},
 	{
-		description: "invalid when more than 11 digits",
-		input:       "321234567890",
-		expectErr:   true,
+		description:      "invalid when more than 11 digits",
+		input:            "321234567890",
+		expectErr:        true,
+		errorDescription: "more than 11 digits",
 	},
 	{
-		description: "invalid with letters",
-		input:       "123-abc-7890",
-		expectErr:   true,
+		description:      "invalid with letters",
+		input:            "123-abc-7890",
+		expectErr:        true,
+		errorDescription: "alphanumerics not permitted",
 	},
 	{
-		description: "invalid with punctuations",
-		input:       "123-@:!-7890",
-		expectErr:   true,
+		description:      "invalid with punctuations",
+		input:            "123-@:!-7890",
+		expectErr:        true,
+		errorDescription: "punctuations not permitted",
 	},
 	{
-		description: "invalid if area code starts with 0",
-		input:       "(023) 456-7890",
-		expectErr:   true,
+		description:      "invalid if area code starts with 0",
+		input:            "(023) 456-7890",
+		expectErr:        true,
+		errorDescription: "area code cannot start with zero",
 	},
 	{
-		description: "invalid if area code starts with 1",
-		input:       "(123) 456-7890",
-		expectErr:   true,
+		description:      "invalid if area code starts with 1",
+		input:            "(123) 456-7890",
+		expectErr:        true,
+		errorDescription: "area code cannot start with one",
 	},
 	{
-		description: "invalid if exchange code starts with 0",
-		input:       "(223) 056-7890",
-		expectErr:   true,
+		description:      "invalid if exchange code starts with 0",
+		input:            "(223) 056-7890",
+		expectErr:        true,
+		errorDescription: "exchange code cannot start with zero",
 	},
 	{
-		description: "invalid if exchange code starts with 1",
-		input:       "(223) 156-7890",
-		expectErr:   true,
+		description:      "invalid if exchange code starts with 1",
+		input:            "(223) 156-7890",
+		expectErr:        true,
+		errorDescription: "exchange code cannot start with one",
+	},
+	{
+		description:      "invalid if area code starts with 0 on valid 11-digit number",
+		input:            "1 (023) 456-7890",
+		expectErr:        true,
+		errorDescription: "area code cannot start with zero",
+	},
+	{
+		description:      "invalid if area code starts with 1 on valid 11-digit number",
+		input:            "1 (123) 456-7890",
+		expectErr:        true,
+		errorDescription: "area code cannot start with one",
+	},
+	{
+		description:      "invalid if exchange code starts with 0 on valid 11-digit number",
+		input:            "1 (223) 056-7890",
+		expectErr:        true,
+		errorDescription: "exchange code cannot start with zero",
+	},
+	{
+		description:      "invalid if exchange code starts with 1 on valid 11-digit number",
+		input:            "1 (223) 156-7890",
+		expectErr:        true,
+		errorDescription: "exchange code cannot start with one",
 	},
 }


### PR DESCRIPTION
[latest version of problem specifications](https://github.com/exercism/problem-specifications/commit/7290b84b809ccdacfa7ab674b1cb1237ca55105f#diff-2702bfb9de14559d38fdf33aab5089bf) implements 'error objects' as expected values; generator should be updated to unmarshal the new JSON with changed semantics (e.g. field "expected" can be a string or a map[string]string in case of error) 