### PR TITLE
luhn: add test case with non-digit at the end

### DIFF
--- a/exercises/luhn/cases_test.go
+++ b/exercises/luhn/cases_test.go
@@ -1,8 +1,8 @@
 package luhn
 
 // Source: exercism/problem-specifications
-// Commit: 06b37c1 luhn: Add test case for valid number with even length (fixes #1391)
-// Problem Specifications Version: 1.3.0
+// Commit: 4a80663 luhn: non-digit at end is invalid
+// Problem Specifications Version: 1.4.0
 
 var testCases = []struct {
 	description string
@@ -52,6 +52,11 @@ var testCases = []struct {
 	{
 		"valid strings with a non-digit included become invalid",
 		"055a 444 285",
+		false,
+	},
+	{
+		"valid strings with a non-digit added at the end become invalid",
+		"059a",
 		false,
 	},
 	{


### PR DESCRIPTION
Problem: I had a student only include the digits before the first invalid character. There was no test that failed his solution.

Solution: Added a test that should return `false` but does not if the student takes only the numbers up to first non-digit.