### PR TITLE
error-handling: fix for golint

### DIFF
--- a/exercises/error-handling/common.go
+++ b/exercises/error-handling/common.go
@@ -33,6 +33,7 @@ func (e FrobError) Error() string {
 	return e.inner.Error()
 }
 
+// Resource defines an interface for a resource.
 type Resource interface {
 
 	// Resource is using composition to inherit the requirements of the io.Closer


### PR DESCRIPTION
In case the student runs `golint` on his solution there is an error in the exercise package. Automatic tools will detect that too and blame the student.