### PR TITLE
Diamonds :  Change test-suite to reflect probem

### DIFF
--- a/exercises/diamond/diamond_test.go
+++ b/exercises/diamond/diamond_test.go
@@ -28,10 +28,10 @@ func checkCorrect(requirement func(byte, []string) bool, keepSeparator bool, t *
 			separator = strings.SplitAfter
 		}
 		rows := separator(d, "\n")
-		if len(rows) < 2 {
+		if len(rows) < 1 {
 			return false
 		}
-		return requirement(byte(char), rows[:len(rows)-1])
+		return requirement(byte(char), rows)
 	}
 	if err := quick.Check(assertion, config); err != nil {
 		t.Error(err)
@@ -109,7 +109,7 @@ func TestDiamondIsVerticallySymmetric(t *testing.T) {
 		}
 		return true
 	}
-	checkCorrect(requirement, true, t)
+	checkCorrect(requirement, false, t)
 }
 
 func TestDiamondIsSquare(t *testing.T) {


### PR DESCRIPTION
## Test suite currently expects
```text
A\n
```

Diamond for letter 'C':

```text
··A··\n
·B·B·\n
C···C\n
·B·B·\n
··A··\n
```

Diamond for letter 'E':

```text
····A····\n
···B·B···\n
··C···C··\n
·D·····D·\n
E·······E\n
·D·····D·\n
··C···C··\n
···B·B···\n
····A····\n
```

## After change
```text
A
```

Diamond for letter 'C':

```text
··A··
·B·B·
C···C
·B·B·
··A··
```

Diamond for letter 'E':

```text
····A····
···B·B···
··C···C··
·D·····D·
E·······E
·D·····D·
··C···C··
···B·B···
····A····
```
