### PR TITLE
linked-list: fix discrepancy between instructions in README and test cases

### DIFF
--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -16,14 +16,20 @@ Node to hold a value and pointers to the next and previous nodes. Then
 implement a List which holds references to the first and last node and
 offers an array-like interface for adding and removing items:
 
-* `push` (*insert value at back*);
-* `pop` (*remove value at back*);
-* `shift` (*remove value at front*).
-* `unshift` (*insert value at front*);
+* `PushBack` (*insert value at back*);
+* `PopBack` (*remove value at back*);
+* `PopFront` (*remove value at front*).
+* `PushFront` (*insert value at front*);
 
-To keep your implementation simple, the tests will not cover error
-conditions. Specifically: `pop` or `shift` will never be called on an
-empty list.
+The List should be initialized with a sequence of values to be held in
+initial nodes. This sequence can be empty.
+
+The implementation of `PopBack` and `PopFront` should return the popped
+value and an error code. The case where the List is empty should return
+0 and the error `ErrEmptyList`.
+
+Finally, implement a `Reverse` method that reverses the order of the List's
+nodes.
 
 If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
 


### PR DESCRIPTION
1. The README for the linked-list exercise states that:
> To keep your implementation simple, the tests will not cover error conditions. Specifically: pop or shift will never be called on an empty list.

Or the test cases do try to pop an empty list, and expect a return value (0, ErrEmptyList). The error is not defined in the test cases source.

2. The README doesn't mention a Reverse method to implement, but it is part of the test.

The next two points are less important, but they add to the confusion from the instructions:

3. The List is initialized with node values, but it's not explicitely required from the README. One could expect to always initialize an empty List, and then push values into it.

4. The names given to the List's push and pop operations: `push`, `pop`, `shift`, `unshift` are common but the test cases expect `PushBack`, `PopBack`, `PopFront` and `PushFront`. One could expect the instructions to specify the names of the operations to implement.

I've updated the README accordingly