### PR TITLE
Fix test to show pass messages only when passed

### DIFF
--- a/exercises/isbn-verifier/isbn_verifier_test.go
+++ b/exercises/isbn-verifier/isbn_verifier_test.go
@@ -7,11 +7,11 @@ import (
 func TestIsValidISBN(t *testing.T) {
 	for _, test := range testCases {
 		observed := IsValidISBN(test.isbn)
-		if observed != test.expected {
+		if observed == test.expected {
+			t.Logf("PASS: %s", test.description)
+		} else {
 			t.Errorf("FAIL: %s\nIsValidISBN(%q)\nExpected: %t, Actual: %t",
 				test.description, test.isbn, test.expected, observed)
-		} else {
-			t.Logf("PASS: %s", test.description)
 		}
 	}
 }

--- a/exercises/isbn-verifier/isbn_verifier_test.go
+++ b/exercises/isbn-verifier/isbn_verifier_test.go
@@ -10,7 +10,8 @@ func TestIsValidISBN(t *testing.T) {
 		if observed != test.expected {
 			t.Errorf("FAIL: %s\nIsValidISBN(%q)\nExpected: %t, Actual: %t",
 				test.description, test.isbn, test.expected, observed)
+		} else {
+			t.Logf("PASS: %s", test.description)
 		}
-		t.Logf("PASS: %s", test.description)
 	}
 }


### PR DESCRIPTION
There was a minor bug in the isbn-verifier tests: The test result showed pass messages for all tests, even if the tests failed. An example output would have been: 
```
--- FAIL: TestIsValidISBN (0.00s)
    isbn_verifier_test.go:11: FAIL: valid isbn number
        IsValidISBN("3-598-21508-8")
        Expected: true, Actual: false
    isbn_verifier_test.go:14: PASS: valid isbn number
```
The Pull Request fixes this problem.