### PR TITLE
diffie-hellman: change big.Int formatting

### DIFF
--- a/exercises/diffie-hellman/diffie_hellman_test.go
+++ b/exercises/diffie-hellman/diffie_hellman_test.go
@@ -83,7 +83,7 @@ func TestPrivateKey(t *testing.T) {
 	priv := func(p *big.Int) *big.Int {
 		a := PrivateKey(p)
 		if a.Cmp(_one) <= 0 || a.Cmp(p) >= 0 {
-			t.Fatalf("PrivateKey(%d) = %d, out of range (1, %d)", p, a, p)
+			t.Fatalf("PrivateKey(%s) = %s, out of range (1, %s)", p.String(), a.String(), p.String())
 		}
 		return a
 	}
@@ -94,12 +94,12 @@ func TestPrivateKey(t *testing.T) {
 		mb[priv(biggerTest.p).String()] = true
 	}
 	if len(ms) == 1 {
-		t.Fatalf("For prime %d same key generated every time.  "+
-			"Want random keys.", smallTest.p)
+		t.Fatalf("For prime %s same key generated every time.  "+
+			"Want random keys.", smallTest.p.String())
 	}
 	if len(mb) < 100 {
-		t.Fatal("For prime %d duplicate keys generated.  "+
-			"Want unique keys.", biggerTest.p)
+		t.Fatalf("For prime %s duplicate keys generated.  "+
+			"Want unique keys.", biggerTest.p.String())
 	}
 }
 
@@ -136,12 +136,12 @@ func TestNewPair(t *testing.T) {
 	p, g := biggerTest.p, biggerTest.g
 	test := func(a, A *big.Int) {
 		if a.Cmp(_one) <= 0 || a.Cmp(p) >= 0 {
-			t.Fatalf("NewPair(%d, %d) private key = %d, out of range (1, %d)",
-				p, g, a, p)
+			t.Fatalf("NewPair(%s, %d) private key = %s, out of range (1, %s)",
+				p.String(), g, a.String(), p.String())
 		}
 		if A.Cmp(_one) <= 0 || A.Cmp(p) >= 0 {
-			t.Fatalf("NewPair(%d, %d) public key = %d, out of range (1, %d)",
-				p, g, A, p)
+			t.Fatalf("NewPair(%s, %d) public key = %s, out of range (1, %s)",
+				p.String(), g, A.String(), p.String())
 		}
 	}
 	a, A := NewPair(p, g)


### PR DESCRIPTION
This fixes the Travis build against Go master, which appears to be failing due to a change in either `fmt` or `math/big`.

Closes #1199