### PR TITLE
bank-account: verify that closed account has zero balance

### DIFF
--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -65,7 +65,7 @@ func TestSeqOpenBalanceClose(t *testing.T) {
 		t.Log("Balance still available on closed account.")
 		t.Fatalf("a.Balance() = %d, %t.  Want ok == false", b, ok)
 	}
-			
+
 	// verify closing balance is 0
 	if b, _ := a.Balance(); b != 0 {
 		t.Log("Balance after close is non-zero.")

--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -65,6 +65,12 @@ func TestSeqOpenBalanceClose(t *testing.T) {
 		t.Log("Balance still available on closed account.")
 		t.Fatalf("a.Balance() = %d, %t.  Want ok == false", b, ok)
 	}
+			
+	// verify closing balance is 0
+	if b, _ := a.Balance(); b != 0 {
+		t.Log("Balance after close is non-zero.")
+		t.Fatalf("After a.Close() balance is %d and not 0", b)
+	}
 }
 
 func TestSeqOpenDepositClose(t *testing.T) {


### PR DESCRIPTION
When an Account is closed we would expect the balance to be zero; this PR adds a test that fails when a closed Account has a non-zero balance. (Carried from #1171.)