### PR TITLE
robot-name: have Name() return (string, error)

### DIFF
--- a/exercises/robot-name/bonus_example.go
+++ b/exercises/robot-name/bonus_example.go
@@ -3,6 +3,7 @@
 package robotname
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 )
@@ -13,9 +14,9 @@ type Robot struct {
 
 var issued = map[string]bool{}
 
-func (r *Robot) Name() string {
+func (r *Robot) Name() (string, error) {
 	if r.name > "" {
-		return r.name
+		return r.name, nil
 	}
 	a1 := rand.Intn(26)
 	a2 := rand.Intn(26)
@@ -30,11 +31,11 @@ func (r *Robot) Name() string {
 		}
 		r.name = fmt.Sprintf("%c%c%03d", 'A'+byte(a1), 'A'+byte(a2), n)
 		if r.name == start {
-			panic("all valid robot names issued")
+			return "", errors.New("all valid robot names issued")
 		}
 	}
 	issued[r.name] = true
-	return r.name
+	return r.name, nil
 }
 
 func (r *Robot) Reset() {

--- a/exercises/robot-name/bonus_test.go
+++ b/exercises/robot-name/bonus_test.go
@@ -10,7 +10,10 @@ func TestCollisions(t *testing.T) {
 	// 10k should be plenty to catch names generated
 	// randomly without a uniqueness check.
 	for i := 0; i < 10000; i++ {
-		n := New().Name()
+		n, err := New().Name()
+		if err != nil {
+			t.Fatalf("Name() returned unexpected error: %v", err)
+		}
 		if m[n] {
 			t.Fatalf("Name %s reissued after %d robots.", n, i)
 		}
@@ -20,7 +23,10 @@ func TestCollisions(t *testing.T) {
 	r := New()
 	for i := 0; i < 10000; i++ {
 		r.Reset()
-		n := r.Name()
+		n, err := r.Name()
+		if err != nil {
+			t.Fatalf("Name() returned unexpected error: %v", err)
+		}
 		if m[n] {
 			t.Fatalf("Name %s reissued after Reset.", n)
 		}

--- a/exercises/robot-name/example.go
+++ b/exercises/robot-name/example.go
@@ -11,14 +11,14 @@ type Robot struct {
 	name string
 }
 
-func (r *Robot) Name() string {
+func (r *Robot) Name() (string, error) {
 	if r.name == "" {
 		r.name = fmt.Sprintf("%c%c%03d",
 			'A'+byte(rand.Intn(26)),
 			'A'+byte(rand.Intn(26)),
 			rand.Intn(1000))
 	}
-	return r.name
+	return r.name, nil
 }
 
 func (r *Robot) Reset() {

--- a/exercises/robot-name/robot_name_test.go
+++ b/exercises/robot-name/robot_name_test.go
@@ -10,7 +10,10 @@ var namePat = regexp.MustCompile(`^[A-Z]{2}\d{3}$`)
 func New() *Robot { return new(Robot) }
 
 func TestNameValid(t *testing.T) {
-	n := New().Name()
+	n, err := New().Name()
+	if err != nil {
+		t.Errorf("Name() returned unexpected error: %v", err)
+	}
 	if !namePat.MatchString(n) {
 		t.Errorf(`Invalid robot name %q, want form "AA###".`, n)
 	}
@@ -18,25 +21,27 @@ func TestNameValid(t *testing.T) {
 
 func TestNameSticks(t *testing.T) {
 	r := New()
-	n1 := r.Name()
-	n2 := r.Name()
+	n1, _ := r.Name()
+	n2, _ := r.Name()
 	if n2 != n1 {
 		t.Errorf(`Robot name changed.  Now %s, was %s.`, n2, n1)
 	}
 }
 
 func TestSuccessiveRobotsHaveDifferentNames(t *testing.T) {
-	n1 := New().Name()
-	if New().Name() == n1 {
+	n1, _ := New().Name()
+	n2, _ := New().Name()
+	if n2 == n1 {
 		t.Errorf(`Robots with same name.  Two %s's.`, n1)
 	}
 }
 
 func TestResetName(t *testing.T) {
 	r := New()
-	n1 := r.Name()
+	n1, _ := r.Name()
 	r.Reset()
-	if r.Name() == n1 {
+	n2, _ := r.Name()
+	if n2 == n1 {
 		t.Errorf(`Robot name not cleared on reset.  Still %s.`, n1)
 	}
 }


### PR DESCRIPTION
I've noticed that a lot of students are unfamiliar with Go's error return conventions, and struggle a bit when required to handle an error condition. I've also noticed that practically no solutions to 'Robot Name' ever handle the case where the available robot names are exhausted (usually they just loop forever).

Changing the function signature of `Name()` to return `(string, error)` seems to me both a nice introduction to error returns, and a valuable hint that there _is_ an error condition to think about. Fixes #1191.