### PR TITLE
hamming: use 'expectError` in test cases, not -1

### DIFF
--- a/exercises/hamming/.meta/gen.go
+++ b/exercises/hamming/.meta/gen.go
@@ -37,7 +37,13 @@ func (o oneCase) Want() int {
 	if ok {
 		return int(d)
 	}
-	return -1
+	// A non-nil error value is expected, so the data value should be zero, idiomatically.
+	return 0
+}
+
+func (o oneCase) ExpectError() bool {
+	_, ok := o.Expected.(float64)
+	return !ok
 }
 
 // template applied to above data structure generates the Go test cases
@@ -46,14 +52,16 @@ var tmpl = `package hamming
 {{.Header}}
 
 var testCases = []struct {
-	s1   string
-	s2   string
-	want int
+	s1          string
+	s2          string
+	want        int
+	expectError bool
 }{
 {{range .J.Cases}}{ // {{.Description}}
 	{{printf "%q" .Input.Strand1}},
 	{{printf "%q" .Input.Strand2}},
 	{{.Want}},
+	{{.ExpectError}},
 },
 {{end}}}
 `

--- a/exercises/hamming/cases_test.go
+++ b/exercises/hamming/cases_test.go
@@ -1,87 +1,55 @@
 package hamming
 
 // Source: exercism/problem-specifications
-// Commit: b5d154b hamming: move inputs (strand1, strand2) to input object
-// Problem Specifications Version: 2.1.0
+// Commit: 4c453c8 hamming: remove redundant test cases
+// Problem Specifications Version: 2.2.0
 
 var testCases = []struct {
-	s1   string
-	s2   string
-	want int
+	s1          string
+	s2          string
+	want        int
+	expectError bool
 }{
 	{ // empty strands
 		"",
 		"",
 		0,
+		false,
 	},
-	{ // identical strands
+	{ // single letter identical strands
 		"A",
 		"A",
 		0,
+		false,
+	},
+	{ // single letter different strands
+		"G",
+		"T",
+		1,
+		false,
 	},
 	{ // long identical strands
-		"GGACTGA",
-		"GGACTGA",
+		"GGACTGAAATCTG",
+		"GGACTGAAATCTG",
 		0,
+		false,
 	},
-	{ // complete distance in single nucleotide strands
-		"A",
-		"G",
-		1,
-	},
-	{ // complete distance in small strands
-		"AG",
-		"CT",
-		2,
-	},
-	{ // small distance in small strands
-		"AT",
-		"CT",
-		1,
-	},
-	{ // small distance
-		"GGACG",
-		"GGTCG",
-		1,
-	},
-	{ // small distance in long strands
-		"ACCAGGG",
-		"ACTATGG",
-		2,
-	},
-	{ // non-unique character in first strand
-		"AAG",
-		"AAA",
-		1,
-	},
-	{ // non-unique character in second strand
-		"AAA",
-		"AAG",
-		1,
-	},
-	{ // same nucleotides in different positions
-		"TAG",
-		"GAT",
-		2,
-	},
-	{ // large distance
-		"GATACA",
-		"GCATAA",
-		4,
-	},
-	{ // large distance in off-by-one strand
+	{ // long different strands
 		"GGACGGATTCTG",
 		"AGGACGGATTCT",
 		9,
+		false,
 	},
 	{ // disallow first strand longer
 		"AATG",
 		"AAA",
-		-1,
+		0,
+		true,
 	},
 	{ // disallow second strand longer
 		"ATA",
 		"AGTG",
-		-1,
+		0,
+		true,
 	},
 }

--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -5,13 +5,13 @@ import "testing"
 func TestHamming(t *testing.T) {
 	for _, tc := range testCases {
 		got, err := Distance(tc.s1, tc.s2)
-		if tc.want < 0 {
+		if tc.expectError {
 			// check if err is of error type
 			var _ error = err
 
 			// we expect error
 			if err == nil {
-				t.Fatalf("Distance(%q, %q). error is nil.",
+				t.Fatalf("Distance(%q, %q); expected error, got nil.",
 					tc.s1, tc.s2)
 			}
 		} else {
@@ -22,7 +22,7 @@ func TestHamming(t *testing.T) {
 
 			// we do not expect error
 			if err != nil {
-				t.Fatalf("Distance(%q, %q) returned error: %v when expecting none.",
+				t.Fatalf("Distance(%q, %q) returned unexpected error: %v",
 					tc.s1, tc.s2, err)
 			}
 		}


### PR DESCRIPTION
This is most students' first encounter with Go's error return conventions. Many of them are not sure what _data_ value to return in the error case, so they look at the test cases, see that the expected value is `-1`, and return that.

The test case generator was using -1 as an out-of-band value to indicate that an error was expected. To avoid misleading students, this PR changes the generator to set an `expectError` bool on the test case instead. In the error case, the 'expected' data value is now 0, although of course this is not checked (nor should it be).

This makes it really clear from the test cases what the student is expected to do in the error case: return 0 and a non-nil error.

This PR also regenerates the test cases from upstream, using the updated generator.