### PR TITLE
variable-length-quantity: update generator 

### DIFF
--- a/exercises/acronym/acronym.go
+++ b/exercises/acronym/acronym.go
@@ -1,0 +1,15 @@
+// This is a "stub" file.  It's a little start on your solution.
+// It's not a complete solution though; you have to write some code.
+
+// Package acronym should have a package comment that summarizes what it's about.
+// https://golang.org/doc/effective_go.html#commentary
+package acronym
+
+// Abbreviate should have a comment documenting it.
+func Abbreviate(s string) string {
+	// Write some code here to pass the test suite.
+	// Then remove all the stock comments.
+	// They're here to help you get started but they only clutter a finished solution.
+	// If you leave them in, reviewers may protest!
+	return ""
+}

--- a/exercises/variable-length-quantity/.meta/gen.go
+++ b/exercises/variable-length-quantity/.meta/gen.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 	"text/template"
 
@@ -47,7 +48,31 @@ type OneCase struct {
 	Input       struct {
 		Integers []uint32 // supports both []byte and []uint32 in JSON.
 	}
-	Expected []uint32 // supports []byte, []uint32, or null in JSON.
+	Expected ExpectedType // can be {"error": "message"} or [x,y,z]
+}
+
+type ExpectedType struct {
+	ValueSlice     []uint32
+	ValueErrorFlag bool
+}
+
+func (e *ExpectedType) UnmarshalJSON(b []byte) error {
+	if b[0] == '[' {
+		var values []uint32
+		if err := json.Unmarshal(b, &values); err != nil {
+			return err
+		}
+		e.ValueSlice = values
+		e.ValueErrorFlag = false
+	} else {
+		var s map[string]string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		e.ValueSlice = []uint32{}
+		e.ValueErrorFlag = true
+	}
+	return nil
 }
 
 // PropertyMatch returns true when given test case c has .Property field matching property;
@@ -88,20 +113,22 @@ var encodeTestCases = []struct {
 	{{if .PropertyMatch "encode"}} {
 		{{printf "%q" .Description}},
 		{{printf "%#v" .Input.Integers }},
-		{{byteSlice .Expected | printf "%#v" }},
+		{{byteSlice .Expected.ValueSlice | printf "%#v" }},
 	},{{- end}}{{end}}{{end}}
 }
 
 // {{GroupComment .J.Groups "decode"}}
 var decodeTestCases = []struct {
 	description string
-	input	[]byte
-	output	[]uint32 // nil slice indicates error expected.
+	input		[]byte
+	output		[]uint32 // nil slice indicates error expected.
+	shouldFail	bool
 }{ {{range .J.Groups}} {{range .Cases}}
 	{{if .PropertyMatch "decode"}} {
 		{{printf "%q" .Description}},
 		{{byteSlice .Input.Integers | printf "%#v" }},
-		{{printf "%#v" .Expected }},
+		{{printf "%#v" .Expected.ValueSlice }},
+		{{printf "%#v" .Expected.ValueErrorFlag }},
 	},{{- end}}{{end}}{{end}}
 }
 `

--- a/exercises/variable-length-quantity/cases_test.go
+++ b/exercises/variable-length-quantity/cases_test.go
@@ -1,8 +1,8 @@
 package variablelengthquantity
 
 // Source: exercism/problem-specifications
-// Commit: 48dc5e6 variable-length-quantity: Apply new "input" policy
-// Problem Specifications Version: 1.1.0
+// Commit: 191f8086 variable-length-quantity: add mention of 'error' to comment
+// Problem Specifications Version: 1.2.0
 
 // Encode a series of integers, producing a series of bytes.
 var encodeTestCases = []struct {
@@ -107,46 +107,55 @@ var decodeTestCases = []struct {
 	description string
 	input       []byte
 	output      []uint32 // nil slice indicates error expected.
+	shouldFail  bool
 }{
 
 	{
 		"one byte",
 		[]byte{0x7f},
 		[]uint32{0x7f},
+		false,
 	},
 	{
 		"two bytes",
 		[]byte{0xc0, 0x0},
 		[]uint32{0x2000},
+		false,
 	},
 	{
 		"three bytes",
 		[]byte{0xff, 0xff, 0x7f},
 		[]uint32{0x1fffff},
+		false,
 	},
 	{
 		"four bytes",
 		[]byte{0x81, 0x80, 0x80, 0x0},
 		[]uint32{0x200000},
+		false,
 	},
 	{
 		"maximum 32-bit integer",
 		[]byte{0x8f, 0xff, 0xff, 0xff, 0x7f},
 		[]uint32{0xffffffff},
+		false,
 	},
 	{
 		"incomplete sequence causes error",
 		[]byte{0xff},
-		[]uint32(nil),
+		[]uint32{},
+		true,
 	},
 	{
 		"incomplete sequence causes error, even if value is zero",
 		[]byte{0x80},
-		[]uint32(nil),
+		[]uint32{},
+		true,
 	},
 	{
 		"multiple values",
 		[]byte{0xc0, 0x0, 0xc8, 0xe8, 0x56, 0xff, 0xff, 0xff, 0x7f, 0x0, 0xff, 0x7f, 0x81, 0x80, 0x0},
 		[]uint32{0x2000, 0x123456, 0xfffffff, 0x0, 0x3fff, 0x4000},
+		false,
 	},
 }

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -10,8 +10,7 @@ func TestDecodeVarint(t *testing.T) {
 	for i, tc := range decodeTestCases {
 		o, err := DecodeVarint(tc.input)
 		if err != nil {
-			var _ error = err
-			if tc.output != nil {
+			if !tc.shouldFail {
 				t.Fatalf("FAIL: case %d | %s\nexpected %#v got error: %q\n", i, tc.description, tc.output, err)
 			}
 		} else if tc.output == nil {


### PR DESCRIPTION
upstream problem specifications have been [updated](https://github.com/exercism/problem-specifications/commit/9cdc06462f99064ff7bd4174f9586b93e7b7318f#diff-3030cdac0a2738a37774e6e7ae38ae11) with the addition of an expected 'error' object