### PR TITLE
variable-length-quantity: update generator

### DIFF
--- a/exercises/variable-length-quantity/cases_test.go
+++ b/exercises/variable-length-quantity/cases_test.go
@@ -1,8 +1,8 @@
 package variablelengthquantity
 
 // Source: exercism/problem-specifications
-// Commit: 48dc5e6 variable-length-quantity: Apply new "input" policy
-// Problem Specifications Version: 1.1.0
+// Commit: 191f8086 variable-length-quantity: add mention of 'error' to comment
+// Problem Specifications Version: 1.2.0
 
 // Encode a series of integers, producing a series of bytes.
 var encodeTestCases = []struct {
@@ -104,49 +104,58 @@ var encodeTestCases = []struct {
 
 // Decode a series of bytes, producing a series of integers.
 var decodeTestCases = []struct {
-	description string
-	input       []byte
-	output      []uint32 // nil slice indicates error expected.
+	description   string
+	input         []byte
+	output        []uint32 // nil slice indicates error expected.
+	errorExpected bool
 }{
 
 	{
 		"one byte",
 		[]byte{0x7f},
 		[]uint32{0x7f},
+		false,
 	},
 	{
 		"two bytes",
 		[]byte{0xc0, 0x0},
 		[]uint32{0x2000},
+		false,
 	},
 	{
 		"three bytes",
 		[]byte{0xff, 0xff, 0x7f},
 		[]uint32{0x1fffff},
+		false,
 	},
 	{
 		"four bytes",
 		[]byte{0x81, 0x80, 0x80, 0x0},
 		[]uint32{0x200000},
+		false,
 	},
 	{
 		"maximum 32-bit integer",
 		[]byte{0x8f, 0xff, 0xff, 0xff, 0x7f},
 		[]uint32{0xffffffff},
+		false,
 	},
 	{
 		"incomplete sequence causes error",
 		[]byte{0xff},
-		[]uint32(nil),
+		[]uint32{},
+		true,
 	},
 	{
 		"incomplete sequence causes error, even if value is zero",
 		[]byte{0x80},
-		[]uint32(nil),
+		[]uint32{},
+		true,
 	},
 	{
 		"multiple values",
 		[]byte{0xc0, 0x0, 0xc8, 0xe8, 0x56, 0xff, 0xff, 0xff, 0x7f, 0x0, 0xff, 0x7f, 0x81, 0x80, 0x0},
 		[]uint32{0x2000, 0x123456, 0xfffffff, 0x0, 0x3fff, 0x4000},
+		false,
 	},
 }

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -10,8 +10,7 @@ func TestDecodeVarint(t *testing.T) {
 	for i, tc := range decodeTestCases {
 		o, err := DecodeVarint(tc.input)
 		if err != nil {
-			var _ error = err
-			if tc.output != nil {
+			if !tc.errorExpected {
 				t.Fatalf("FAIL: case %d | %s\nexpected %#v got error: %q\n", i, tc.description, tc.output, err)
 			}
 		} else if tc.output == nil {

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -10,6 +10,7 @@ func TestDecodeVarint(t *testing.T) {
 	for i, tc := range decodeTestCases {
 		o, err := DecodeVarint(tc.input)
 		if err != nil {
+			var _ error = err // check if err is of error type
 			if !tc.errorExpected {
 				t.Fatalf("FAIL: case %d | %s\nexpected %#v got error: %q\n", i, tc.description, tc.output, err)
 			}


### PR DESCRIPTION
upstream problem specifications have been [updated](https://github.com/exercism/problem-specifications/commit/9cdc06462f99064ff7bd4174f9586b93e7b7318f#diff-3030cdac0a2738a37774e6e7ae38ae11) with the addition of an expected 'error' object