### PR TITLE
matrix: show types in reflect.DeepEqual failure output

### DIFF
--- a/exercises/matrix/matrix_test.go
+++ b/exercises/matrix/matrix_test.go
@@ -174,7 +174,7 @@ func TestRows(t *testing.T) {
 			continue // agreement, and nothing more to test
 		}
 		if !reflect.DeepEqual(r, test.rows) {
-			t.Fatalf("New(%q).Rows() = %v, want %v", test.in, r, test.rows)
+			t.Fatalf("New(%q).Rows() = %v (type %T), want %v (type %T)", test.in, r, r, test.rows, test.rows)
 		}
 		if len(r[0]) == 0 {
 			continue // not currently in test data, but anyway
@@ -201,7 +201,7 @@ func TestCols(t *testing.T) {
 			continue // agreement, and nothing more to test
 		}
 		if !reflect.DeepEqual(c, test.cols) {
-			t.Fatalf("New(%q).Cols() = %v, want %v", test.in, c, test.cols)
+			t.Fatalf("New(%q).Cols() = %v (type %T), want %v (type %T)", test.in, c, c, test.cols, test.cols)
 		}
 		if len(c[0]) == 0 {
 			continue // not currently in test data, but anyway


### PR DESCRIPTION
A few students have been mighty confused by test failures like this:

```
--- FAIL: TestCols (0.00s)
    matrix_test.go:204: New("1 2\n10 20").Cols() = [[1 10] [2 20]], want [[1 10] [2 20]]
```

The data values are identical. But the first rule of `reflect.DeepEqual` (apart from "Do not talk about `reflect.DeepEqual`") is that its arguments must be the same type.

An example of a `Cols()` implementation which fails this test is:

```go
func (m Matrix) Cols() Matrix {
	var ret Matrix
	for i := 0; i < len(m); i++ {
		row := make([]int, len(m))
		for j, r := range m {
			row[j] = r[i]
		}
		ret = append(ret, row)
	}
	return ret
}
```

This PR changes the failure message to include the actual types, making it clear that the method should return `[][]int` instead:

```
--- FAIL: TestCols (0.00s)
    matrix_test.go:204: New("1 2\n10 20").Cols() = [[1 10] [2 20]] (type matrix.Matrix),
    want [[1 10] [2 20]] (type [][]int)
```

Fixes #1219.
