### PR TITLE
grep: move later, after 'tournament'

### DIFF
--- a/config.json
+++ b/config.json
@@ -1299,7 +1299,7 @@
       "slug": "grep",
       "uuid": "ec5dab72-dd96-4dce-8886-aff52a6eb090",
       "core": false,
-      "unlocked_by": "hamming",
+      "unlocked_by": "tournament",
       "difficulty": 4,
       "topics": [
         "algorithms",


### PR DESCRIPTION
Fixes #1131:

> grep is unlocked by Hamming. While a learner may be able to stumble through an ugly solution after Hamming, they'll be much more ready to write a clean solution after having mastered some of the later concepts.

> How about 'Tournament'? If you've done that, you probably know how to use a bufio.Scanner, use input records to build a data structure, and write out formatted results.

