### PR TITLE
word-count: check counting of empty words

### DIFF
--- a/exercises/word-count/cases_test.go
+++ b/exercises/word-count/cases_test.go
@@ -35,6 +35,11 @@ var testCases = []struct {
 		Frequency{"one": 1, "three": 1, "two": 1},
 	},
 	{
+		"handles expanded lists with leading space",
+		" one,\n two,\n three",
+		Frequency{"one": 1, "three": 1, "two": 1},
+	},
+	{
 		"ignore punctuation",
 		"car: carpet as java: javascript!!&@$%^&",
 		Frequency{"as": 1, "car": 1, "carpet": 1, "java": 1, "javascript": 1},


### PR DESCRIPTION
Ran across this solution that will count empty words on some inputs:

```
package wordcount

import (
	"strings"
	"unicode"
)

// Frequency is the structure of words frequency
type Frequency map[string]int

// WordCount counts the occurrences of each word in a given phrase
func WordCount(input string) Frequency {
	counter := Frequency{}
	phrase := strings.FieldsFunc(input, split)

	for _, word := range phrase {
		word = normalize(word)
		counter[word]++
	}

	return counter
}

func normalize(word string) string {
	word = strings.ToLower(word)

	return strings.TrimFunc(word, func(r rune) bool {
		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
	})
}

func split(r rune) bool {
	return r == ' ' || r == ','
}
```

The added test catches that behaviour.