### PR TITLE
Updates for golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 tmp
 bin/configlet
 bin/configlet.exe
+bin/golangci-lint
+bin/golangci-lint.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install: true
 before_script:
   - bin/fetch-configlet
   - bin/configlet lint .
-  - bin/fetch-golangci-lint v1.13
+  - bin/fetch-golangci-lint v1.16.0
 
 # Our "build" is to run `go test` which is what our users do.
 # -cpu 2 is for our problems that involve concurrency to test that they

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install: true
 before_script:
   - bin/fetch-configlet
   - bin/configlet lint .
+  - bin/fetch-golangci-lint v1.13
 
 # Our "build" is to run `go test` which is what our users do.
 # -cpu 2 is for our problems that involve concurrency to test that they
@@ -54,6 +55,9 @@ script:
   - if [ -n "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs fmt; fi
   - if [ -n "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs vet; fi
   - if [ -z "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs; fi
+  - if [ -n "$STATIC_CHECKERS" ]; then
+        ./bin/test-without-stubs lint '--disable=errcheck,megacheck --enable=goimports,goconst,gocyclo';
+    fi
 
 # special cases for the build matrix are STATIC_CHECKERS gets its own entry
 # and that tip is allowed to fail.  Broken tips are extremely rare these days

--- a/bin/fetch-golangci-lint
+++ b/bin/fetch-golangci-lint
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+VERSION=$1
+
+# The latest will be fetched if VERSION not specified
+if [ -z "$VERSION" ] ; then
+  VERSION=latest
+else
+  if [ "$VERSION" != "latest" -a "${VERSION:0:1}" != "v" ] ; then
+    # Kindly prepend a 'v' for a good version string.
+    VERSION=v$VERSION
+  fi
+fi
+
+curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ./bin $VERSION

--- a/bin/test-without-stubs
+++ b/bin/test-without-stubs
@@ -62,6 +62,21 @@ if [ "$1" = "vet" ]; then
   exit 0
 fi
 
+if [ "$1" = "lint" ]; then
+  # Let $2 (if given) specify the golangci-lint option parameters; otherwise default them.
+  LINT_OPTS="$2"
+  if [ -z "$LINT_OPTS" ] ; then
+    LINT_OPTS="--disable=errcheck,megacheck --enable=goimports,goconst,gocyclo"
+  fi
+  ./bin/golangci-lint --version
+  # Invoke golangci-lint from top directory which will also lint the gen/ directory and all exercises.
+  if ! ./bin/golangci-lint run $LINT_OPTS; then
+    echo "please correct the 'golangci-lint' issues reported." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
 # This is the last command in the file,
 # so the exit status of this script is the exit status of go test.
 # If this ever changes, remember to preserve the exit status accordingly.

--- a/exercises/error-handling/error_handling_test.go
+++ b/exercises/error-handling/error_handling_test.go
@@ -15,6 +15,8 @@ type mockResource struct {
 	defrob func(string)
 }
 
+const hello = "hello"
+
 func (mr mockResource) Close() error      { return mr.close() }
 func (mr mockResource) Frob(input string) { mr.frob(input) }
 func (mr mockResource) Defrob(tag string) { mr.defrob(tag) }
@@ -28,13 +30,12 @@ func TestNoErrors(t *testing.T) {
 		frob:  func(input string) { frobInput = input },
 	}
 	opener := func() (Resource, error) { return mr, nil }
-	inp := "hello"
-	err := Use(opener, inp)
+	err := Use(opener, hello)
 	if err != nil {
 		t.Fatalf("Unexpected error from Use: %v", err)
 	}
-	if frobInput != inp {
-		t.Fatalf("Wrong string passed to Frob: got %v, expected %v", frobInput, inp)
+	if frobInput != hello {
+		t.Fatalf("Wrong string passed to Frob: got %v, expected %v", frobInput, hello)
 	}
 	if !closeCalled {
 		t.Fatalf("Close was not called")
@@ -56,13 +57,12 @@ func TestKeepTryOpenOnTransient(t *testing.T) {
 		}
 		return mr, nil
 	}
-	inp := "hello"
-	err := Use(opener, inp)
+	err := Use(opener, hello)
 	if err != nil {
 		t.Fatalf("Unexpected error from Use: %v", err)
 	}
-	if frobInput != inp {
-		t.Fatalf("Wrong string passed to Frob: got %v, expected %v", frobInput, inp)
+	if frobInput != hello {
+		t.Fatalf("Wrong string passed to Frob: got %v, expected %v", frobInput, hello)
 	}
 }
 
@@ -76,8 +76,7 @@ func TestFailOpenOnNonTransient(t *testing.T) {
 		}
 		return nil, errors.New("too awesome")
 	}
-	inp := "hello"
-	err := Use(opener, inp)
+	err := Use(opener, hello)
 	if err == nil {
 		t.Fatalf("Unexpected lack of error from Use")
 	}
@@ -103,8 +102,7 @@ func TestCallDefrobAndCloseOnFrobError(t *testing.T) {
 		},
 	}
 	opener := func() (Resource, error) { return mr, nil }
-	inp := "hello"
-	err := Use(opener, inp)
+	err := Use(opener, hello)
 	if err == nil {
 		t.Fatalf("Unexpected lack of error from Use")
 	}
@@ -130,8 +128,7 @@ func TestCallCloseOnNonFrobError(t *testing.T) {
 		defrob: func(tag string) { defrobCalled = true },
 	}
 	opener := func() (Resource, error) { return mr, nil }
-	inp := "hello"
-	err := Use(opener, inp)
+	err := Use(opener, hello)
 	if err == nil {
 		t.Fatalf("Unexpected lack of error from Use")
 	}

--- a/exercises/palindrome-products/palindrome_products_test.go
+++ b/exercises/palindrome-products/palindrome_products_test.go
@@ -41,6 +41,7 @@ var testData = []struct {
 }
 
 // Bonus curiosities. Can a negative number be a palindrome? Most say no.
+/*
 var bonusData = []struct {
 	fmin, fmax int
 	pmin, pmax Product
@@ -48,8 +49,8 @@ var bonusData = []struct {
 }{
 	// The following two test cases have the same input, but different expectations. Uncomment just one or the other.
 
-	/* Here you can test that you can reach the limit of the largest palindrome made of two 2-digit numbers.
-	{-99, -10, Product{}, Product{}, "Negative limits"}, */
+	// Here you can test that you can reach the limit of the largest palindrome made of two 2-digit numbers.
+	// {-99, -10, Product{}, Product{}, "Negative limits"},
 
 	// You can still get non-negative products from negative factors.
 	{-99, -10,
@@ -59,12 +60,12 @@ var bonusData = []struct {
 
 	// The following two test cases have the same input, but different expectations. Uncomment just one or the other.
 
-	/*In case you reverse the *digits* you could have the following cases:
-	- the zero has to be considered
-	{-2, 2,
-		Product{0, [][2]int{{-2, 0}, {-1, 0}, {0, 0}, {0, 1}, {0, 2}}},
-		Product{4, [][2]int{{-2, -2}, {2, 2}}},
-		""}, */
+	//In case you reverse the *digits* you could have the following cases:
+	//- the zero has to be considered
+	//{-2, 2,
+	//	Product{0, [][2]int{{-2, 0}, {-1, 0}, {0, 0}, {0, 1}, {0, 2}}},
+	//	Product{4, [][2]int{{-2, -2}, {2, 2}}},
+	//	""},
 
 	// - you can keep the minus sign in place
 	{-2, 2,
@@ -72,9 +73,10 @@ var bonusData = []struct {
 		Product{4, [][2]int{{-2, -2}, {2, 2}}},
 		""},
 }
+*/
 
 func TestPalindromeProducts(t *testing.T) {
-	// Uncomment the following line to add the bonus test to the default tests
+	// Uncomment the following line and the bonusData var above to add the bonus test to the default tests
 	// testData = append(testData, bonusData...)
 	for _, test := range testData {
 		// common preamble for test failures

--- a/exercises/poker/example.go
+++ b/exercises/poker/example.go
@@ -41,11 +41,6 @@ type card struct {
 	suit rune
 }
 
-type parsedHand struct {
-	hand  string
-	cards []card
-}
-
 type rankCount struct {
 	rank  int
 	count int

--- a/exercises/proverb/proverb_test.go
+++ b/exercises/proverb/proverb_test.go
@@ -9,8 +9,10 @@ func TestProverb(t *testing.T) {
 	for _, test := range stringTestCases {
 		actual := Proverb(test.input)
 		if fmt.Sprintf("%q", actual) != fmt.Sprintf("%q", test.expected) {
-			t.Fatalf("Proverb test [%s], expected [%s], actual [%s]", test.input, test.expected, actual)
+			t.Fatalf("FAIL %s - Proverb test [%s]\n\texpected: [%s],\n\tactual:   [%s]",
+				test.description, test.input, test.expected, actual)
 		}
+		t.Logf("PASS %s", test.description)
 	}
 }
 

--- a/exercises/robot-name/bonus_test.go
+++ b/exercises/robot-name/bonus_test.go
@@ -4,6 +4,8 @@ package robotname
 
 import "testing"
 
+var maxNames = 26 * 26 * 10 * 10 * 10
+
 func TestCollisions(t *testing.T) {
 	// Test uniqueness for new robots.
 	for i := len(seen); i <= maxNames-600000; i++ {

--- a/exercises/robot-name/robot_name_test.go
+++ b/exercises/robot-name/robot_name_test.go
@@ -7,7 +7,6 @@ import (
 
 var namePat = regexp.MustCompile(`^[A-Z]{2}\d{3}$`)
 var seen = map[string]int{}
-var maxNames = 26 * 26 * 10 * 10 * 10
 
 func New() *Robot { return new(Robot) }
 

--- a/exercises/run-length-encoding/example.go
+++ b/exercises/run-length-encoding/example.go
@@ -18,7 +18,7 @@ func RunLengthEncode(s string) string {
 		}
 	}
 	if len(s) != 0 {
-		count, output = encode(count, len(s), s, output)
+		_, output = encode(count, len(s), s, output)
 	}
 	return output
 }

--- a/exercises/two-bucket/example.go
+++ b/exercises/two-bucket/example.go
@@ -14,8 +14,7 @@ const (
 type step int
 
 const (
-	none step = iota
-	emptyOne
+	emptyOne step = iota
 	emptyTwo
 	fillOne
 	fillTwo

--- a/exercises/two-bucket/two_bucket_test.go
+++ b/exercises/two-bucket/two_bucket_test.go
@@ -19,7 +19,7 @@ func runTestCase(t *testing.T, tc bucketTestCase) {
 				tc.goalBucket, tc.moves, tc.otherBucket,
 				g, m, other)
 		}
-	} else if e != nil {
+	} else {
 		if !tc.errorExpected {
 			t.Fatalf("FAIL: %s\nSolve(%d, %d, %d, %q)\nExpected: %q, %d, %d\nGot Error %q",
 				tc.description,

--- a/exercises/yacht/example.go
+++ b/exercises/yacht/example.go
@@ -33,42 +33,62 @@ func Score(dice []int, category string) int {
 	case "ones", "twos", "threes", "fours", "fives", "sixes":
 		return scoreN(dice, diceValueMap[category])
 	case "full house":
-		//Note, a yacht scores zero as a full house
-		if dice[0] == dice[1] && dice[2] == dice[3] && dice[3] == dice[4] && dice[1] != dice[2] {
-			return scoreAll(dice)
-		}
-		if dice[0] == dice[1] && dice[1] == dice[2] && dice[3] == dice[4] && dice[2] != dice[3] {
-			return scoreAll(dice)
-		}
-		return 0
+		return fullHouseScore(dice)
 	case "four of a kind":
-		//Note, a yacht can score as four of a kind, but only 4 dice are counted
-		if dice[0] == dice[1] && dice[1] == dice[2] && dice[2] == dice[3] {
-			return dice[0] * 4
-		}
-		if dice[1] == dice[2] && dice[2] == dice[3] && dice[3] == dice[4] {
-			return dice[1] * 4
-		}
-		return 0
+		return fourOfaKindScore(dice)
 	case "little straight":
-		if dice[0] == 1 && dice[1] == 2 && dice[2] == 3 && dice[3] == 4 && dice[4] == 5 {
-			return 30
-		}
-		return 0
+		return littleStraightScore(dice)
 	case "big straight":
-		if dice[0] == 2 && dice[1] == 3 && dice[2] == 4 && dice[3] == 5 && dice[4] == 6 {
-			return 30
-		}
-		return 0
+		return bigStraightScore(dice)
 	case "choice":
 		return scoreAll(dice)
 	case "yacht":
-		if dice[0] == dice[1] && dice[1] == dice[2] && dice[2] == dice[3] && dice[3] == dice[4] {
-			return 50
-		}
-		return 0
+		return yachtScore(dice)
 	default:
 		//This can't happen, so panic is appropriate
 		panic("Unknown category")
 	}
+}
+
+func fullHouseScore(dice []int) int {
+	//Note, a yacht scores zero as a full house
+	if dice[0] == dice[1] && dice[2] == dice[3] && dice[3] == dice[4] && dice[1] != dice[2] {
+		return scoreAll(dice)
+	}
+	if dice[0] == dice[1] && dice[1] == dice[2] && dice[3] == dice[4] && dice[2] != dice[3] {
+		return scoreAll(dice)
+	}
+	return 0
+}
+
+func fourOfaKindScore(dice []int) int {
+	//Note, a yacht can score as four of a kind, but only 4 dice are counted
+	if dice[0] == dice[1] && dice[1] == dice[2] && dice[2] == dice[3] {
+		return dice[0] * 4
+	}
+	if dice[1] == dice[2] && dice[2] == dice[3] && dice[3] == dice[4] {
+		return dice[1] * 4
+	}
+	return 0
+}
+
+func littleStraightScore(dice []int) int {
+	if dice[0] == 1 && dice[1] == 2 && dice[2] == 3 && dice[3] == 4 && dice[4] == 5 {
+		return 30
+	}
+	return 0
+}
+
+func bigStraightScore(dice []int) int {
+	if dice[0] == 2 && dice[1] == 3 && dice[2] == 4 && dice[3] == 5 && dice[4] == 6 {
+		return 30
+	}
+	return 0
+}
+
+func yachtScore(dice []int) int {
+	if dice[0] == dice[1] && dice[1] == dice[2] && dice[2] == dice[3] && dice[3] == dice[4] {
+		return 50
+	}
+	return 0
 }

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -186,17 +186,18 @@ func getLocal(jFile string) (jPath, jOrigin, jCommit string) {
 	// repository.  For development however, accept a file in current directory
 	// if there is no .json in source control.  Also allow an override in any
 	// case by environment variable.
+	const local_file = "local file"
 	if jPath := os.Getenv("EXTEST"); jPath > "" {
-		return jPath, "local file", "" // override
+		return jPath, local_file, "" // override
 	}
 	c := exec.Command("git", "log", "-1", "--oneline", jFile)
 	c.Dir = dirMetadata
 	origin, err := c.Output()
 	if err != nil {
-		return "", "local file", "" // no source control
+		return "", local_file, "" // no source control
 	}
 	if _, err = os.Stat(filepath.Join(c.Dir, jFile)); err != nil {
-		return "", "local file", "" // not in source control
+		return "", local_file, "" // not in source control
 	}
 	// good.  return source control dir and commit.
 	return c.Dir, "exercism/problem-specifications", string(bytes.TrimSpace(origin))


### PR DESCRIPTION
I could have omitted the .travis.yml change until after consensus on the Go code lint "fixes", but I wanted to see if it could operate successfully.

The golangci-lint options used by @sebito91 in #1168 were used for starters.