### PR TITLE
two-fer: Added double quotes arround the observed and the expected values in the test failure message

### DIFF
--- a/exercises/two-fer/two_fer_test.go
+++ b/exercises/two-fer/two_fer_test.go
@@ -15,7 +15,7 @@ var tests = []struct {
 func TestShareWith(t *testing.T) {
 	for _, test := range tests {
 		if observed := ShareWith(test.name); observed != test.expected {
-			t.Fatalf("ShareWith(%s) = %v, want %v", test.name, observed, test.expected)
+			t.Fatalf("ShareWith(%s) = \"%v\", want \"%v\"", test.name, observed, test.expected)
 		}
 	}
 }


### PR DESCRIPTION
This PR tries to add clarity to the test failure message, when the empty string is returned from the `ShareWith` function, by adding double quotes around the expected and the observed values.

Failure message before changes:
`two_fer_test.go:18: ShareWith() = , want One for you, one for me.`

Failure message before changes:
`two_fer_test.go:18: ShareWith() = "", want "One for you, one for me."`

This way the students will clearly see that their function returns empty string and where the expected string starts.

It is a questionable change, but I thought that the students (especially the new one) should not spend a lot of time trying to decipher the test output.