### PR TITLE
bin/test-without-stubs: Removed the redundant slash from the 'file' stub file path variable

### DIFF
--- a/bin/test-without-stubs
+++ b/bin/test-without-stubs
@@ -12,7 +12,7 @@
 
 for dir in exercises/*/; do
   stub=$(echo $(basename $dir) | tr - _)
-  file="$dir/$stub.go"
+  file="$dir$stub.go"
   if [ -f $file ]; then
     echo "moving stub $file"
     mv $file "$dir/$stub.notgo"


### PR DESCRIPTION
Fixes the output of the Travis script.

Before:
`moving stub exercises/leap//leap.go`

After:
`moving stub exercises/leap/leap.go`

Also ensures that there will be no unexpected behavior when the `file` variable is used.