### PR TITLE
leap: Added an argument variable to the IsLeapYear function

### DIFF
--- a/exercises/leap/leap.go
+++ b/exercises/leap/leap.go
@@ -6,7 +6,7 @@
 package leap
 
 // IsLeapYear should have a comment documenting it.
-func IsLeapYear(int) bool {
+func IsLeapYear(year int) bool {
 	// Write some code here to pass the test suite.
 	// Then remove all the stock comments.
 	// They're here to help you get started but they only clutter a finished solution.


### PR DESCRIPTION
Out of all the exercises that provide a stub file, `leap` is the only one that does not have an argument variable in the stub function.

This PR tries to address it, by adding an explicit argument variable.