### PR TITLE
Space Age: Add hint for implementing custom Planet type

### DIFF
--- a/exercises/space-age/.meta/hints.md
+++ b/exercises/space-age/.meta/hints.md
@@ -8,3 +8,7 @@ for your solutions.
 One way to figure out what the function signature(s) you would need is to look
 at the corresponding \*\_test.go file. It will show you what the package level
 functions(s) should be that the test will use to verify the solution.
+
+## Planet Type
+
+The test cases make use of a custom `Planet` type that is sent to your function. You will need to implement this custom type yourself. Implementing this new custom type as a string should suffice.


### PR DESCRIPTION
The current test cases use a `Planet` type for specifying a planet in the exercise. However, this `Planet` isn't defined anywhere, and the test cases actually pass a string to the function. When running the tests I get the following error:

```
./cases_test.go:9: undefined: Planet
```

I think this is a mistake? The type should be a string.