### PR TITLE
[hamming] Ignore error in test

### DIFF
--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -33,7 +33,7 @@ func BenchmarkHamming(b *testing.B) {
 	// bench combined time to run through all test cases
 	for i := 0; i < b.N; i++ {
 		for _, tc := range testCases {
-			Distance(tc.s1, tc.s2)
+			_, _ = Distance(tc.s1, tc.s2)
 		}
 	}
 }

--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -33,6 +33,7 @@ func BenchmarkHamming(b *testing.B) {
 	// bench combined time to run through all test cases
 	for i := 0; i < b.N; i++ {
 		for _, tc := range testCases {
+			// ignoring errors and results because we're just timing function execution
 			_, _ = Distance(tc.s1, tc.s2)
 		}
 	}


### PR DESCRIPTION
Executing `golangci-lint` gave me
```
hamming_test.go:36:12: Error return value of `Distance` is not checked (errcheck)
                        Distance(tc.s1, tc.s2)
                                ^
```
before this change.