### PR TITLE
add meta hint to readme

### DIFF
--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -28,6 +28,10 @@ One way to figure out what the function signature(s) you would need is to look
 at the corresponding \*\_test.go file. It will show you what the package level
 functions(s) should be that the test will use to verify the solution.
 
+## Planet Type
+
+The test cases make use of a custom `Planet` type that is sent to your function. You will need to implement this custom type yourself. Implementing this new custom type as a string should suffice.
+
 
 ## Running the tests
 


### PR DESCRIPTION
There was a hint added to the .meta file in #1236, but the commands to add it to the readme were not run. This PR fixes it.

Fixes #1239.