### PR TITLE
fix: Update test cases for outdated exercises.

### DIFF
--- a/exercises/acronym/cases_test.go
+++ b/exercises/acronym/cases_test.go
@@ -1,8 +1,8 @@
 package acronym
 
 // Source: exercism/problem-specifications
-// Commit: 2e46654b Acronym: New test case for apostrophe (#1377)
-// Problem Specifications Version: 1.6.0
+// Commit: cacf1f1 Acronym: add underscore test case (#1436)
+// Problem Specifications Version: 1.7.0
 
 type acronymTest struct {
 	input    string
@@ -41,5 +41,9 @@ var stringTestCases = []acronymTest{
 	{
 		input:    "Halley's Comet",
 		expected: "HC",
+	},
+	{
+		input:    "The Road _Not_ Taken",
+		expected: "TRNT",
 	},
 }

--- a/exercises/armstrong-numbers/cases_test.go
+++ b/exercises/armstrong-numbers/cases_test.go
@@ -1,14 +1,19 @@
 package armstrong
 
 // Source: exercism/problem-specifications
-// Commit: 5c3baae armstrong-numbers: new exercise (#1018)
-// Problem Specifications Version: 1.0.0
+// Commit: b3c2522 armstrong-numbers: Zero is an Armstrong number and requires specific testing (#1505)
+// Problem Specifications Version: 1.1.0
 
 var testCases = []struct {
 	description string
 	input       int
 	expected    bool
 }{
+	{
+		description: "Zero is an Armstrong number",
+		input:       0,
+		expected:    true,
+	},
 	{
 		description: "Single digit numbers are Armstrong numbers",
 		input:       5,

--- a/exercises/binary-search/cases_test.go
+++ b/exercises/binary-search/cases_test.go
@@ -1,8 +1,8 @@
 package binarysearch
 
 // Source: exercism/problem-specifications
-// Commit: e0ffb00 binary-search: Use error object instead of sentinel -1 (#1338)
-// Problem Specifications Version: 1.2.0
+// Commit: bfb218f binary-search: test description tweak
+// Problem Specifications Version: 1.3.0
 
 var testCases = []struct {
 	description string
@@ -61,23 +61,30 @@ var testCases = []struct {
 		err:         "value not in array",
 	},
 	{
-		description: "a value smaller than the array's smallest value is not included",
+		description: "a value smaller than the array's smallest value is not found",
 		slice:       []int{1, 3, 4, 6, 8, 9, 11},
 		key:         0,
 		x:           -1,
 		err:         "value not in array",
 	},
 	{
-		description: "a value larger than the array's largest value is not included",
+		description: "a value larger than the array's largest value is not found",
 		slice:       []int{1, 3, 4, 6, 8, 9, 11},
 		key:         13,
 		x:           -1,
 		err:         "value not in array",
 	},
 	{
-		description: "nothing is included in an empty array",
+		description: "nothing is found in an empty array",
 		slice:       []int{},
 		key:         1,
+		x:           -1,
+		err:         "value not in array",
+	},
+	{
+		description: "nothing is found when the left and right bounds cross",
+		slice:       []int{1, 2},
+		key:         0,
 		x:           -1,
 		err:         "value not in array",
 	},

--- a/exercises/change/cases_test.go
+++ b/exercises/change/cases_test.go
@@ -1,8 +1,8 @@
 package change
 
 // Source: exercism/problem-specifications
-// Commit: 044d09a change: Apply new "input" policy
-// Problem Specifications Version: 1.2.0
+// Commit: 258c807 change: Use error object instead of sentinel -1 (#1340)
+// Problem Specifications Version: 1.3.0
 
 var testCases = []struct {
 	description    string

--- a/exercises/clock/cases_test.go
+++ b/exercises/clock/cases_test.go
@@ -1,8 +1,8 @@
 package clock
 
 // Source: exercism/problem-specifications
-// Commit: 1680779 clock: add test case for comparing 24:00 and 00:00 clocks (#1306)
-// Problem Specifications Version: 2.3.0
+// Commit: b344762 clock: Add test case for exactly negative sixty minutes.
+// Problem Specifications Version: 2.4.0
 
 // Create a new clock with an initial time
 var timeTests = []struct {
@@ -26,6 +26,7 @@ var timeTests = []struct {
 	{1, -40, "00:20"},      // negative minutes
 	{1, -160, "22:20"},     // negative minutes roll over
 	{1, -4820, "16:40"},    // negative minutes roll over continuously
+	{2, -60, "01:00"},      // negative sixty minutes is previous hour
 	{-25, -160, "20:20"},   // negative hour and minutes both roll over
 	{-121, -5810, "22:10"}, // negative hour and minutes both roll over continuously
 }

--- a/exercises/forth/cases_test.go
+++ b/exercises/forth/cases_test.go
@@ -1,8 +1,8 @@
 package forth
 
 // Source: exercism/problem-specifications
-// Commit: 5ba35c7 forth: add mention of 'error' to comment
-// Problem Specifications Version: 1.7.0
+// Commit: 75f4c0a Corrected minor typos in the error msg expectation (doesn't match other similar error patterns and so breaks auto generated tests)
+// Problem Specifications Version: 1.7.1
 
 type testGroup struct {
 	group string

--- a/exercises/grains/cases_test.go
+++ b/exercises/grains/cases_test.go
@@ -1,8 +1,8 @@
 package grains
 
 // Source: exercism/problem-specifications
-// Commit: f079c2d grains: Move input (square) to input object (#1191)
-// Problem Specifications Version: 1.1.0
+// Commit: 2ec42ab Grains: Fixed canonical data to have standard error indicator (#1322)
+// Problem Specifications Version: 1.2.0
 
 // returns the number of grains on the square
 var squareTests = []struct {

--- a/exercises/hamming/cases_test.go
+++ b/exercises/hamming/cases_test.go
@@ -1,8 +1,8 @@
 package hamming
 
 // Source: exercism/problem-specifications
-// Commit: 4c453c8 hamming: remove redundant test cases
-// Problem Specifications Version: 2.2.0
+// Commit: 4119671 Hamming: Add a tests to avoid wrong recursion solution (#1450)
+// Problem Specifications Version: 2.3.0
 
 var testCases = []struct {
 	s1          string
@@ -49,6 +49,18 @@ var testCases = []struct {
 	{ // disallow second strand longer
 		"ATA",
 		"AGTG",
+		0,
+		true,
+	},
+	{ // disallow left empty strand
+		"",
+		"G",
+		0,
+		true,
+	},
+	{ // disallow right empty strand
+		"G",
+		"",
 		0,
 		true,
 	},

--- a/exercises/isogram/cases_test.go
+++ b/exercises/isogram/cases_test.go
@@ -1,8 +1,8 @@
 package isogram
 
 // Source: exercism/problem-specifications
-// Commit: 7cea153 isogram: add test case with same first and last character (#1308)
-// Problem Specifications Version: 1.6.0
+// Commit: 74869e8 isogram: Add test case for dupe after non-letter (fixes #1390)
+// Problem Specifications Version: 1.7.0
 
 var testCases = []struct {
 	description string
@@ -48,6 +48,11 @@ var testCases = []struct {
 		description: "hypothetical isogrammic word with hyphen",
 		input:       "thumbscrew-japingly",
 		expected:    true,
+	},
+	{
+		description: "hypothetical word with duplicated character following hyphen",
+		input:       "thumbscrew-jappingly",
+		expected:    false,
 	},
 	{
 		description: "isogram with duplicated hyphen",

--- a/exercises/leap/cases_test.go
+++ b/exercises/leap/cases_test.go
@@ -1,17 +1,18 @@
 package leap
 
 // Source: exercism/problem-specifications
-// Commit: 3134d31 leap 1.4.0: negative test: year divisible by 200, not by 400
-// Problem Specifications Version: 1.4.0
+// Commit: 18875ec Leap: Improve the specification so that code generation is more readable - … (#1468)
+// Problem Specifications Version: 1.5.1
 
 var testCases = []struct {
 	year        int
 	expected    bool
 	description string
 }{
-	{2015, false, "year not divisible by 4: common year"},
-	{1996, true, "year divisible by 4, not divisible by 100: leap year"},
-	{2100, false, "year divisible by 100, not divisible by 400: common year"},
-	{2000, true, "year divisible by 400: leap year"},
-	{1800, false, "year divisible by 200, not divisible by 400: common year"},
+	{2015, false, "year not divisible by 4 in common year"},
+	{1970, false, "year divisible by 2, not divisible by 4 in common year"},
+	{1996, true, "year divisible by 4, not divisible by 100 in leap year"},
+	{2100, false, "year divisible by 100, not divisible by 400 in common year"},
+	{2000, true, "year divisible by 400 in leap year"},
+	{1800, false, "year divisible by 200, not divisible by 400 in common year"},
 }

--- a/exercises/luhn/cases_test.go
+++ b/exercises/luhn/cases_test.go
@@ -1,8 +1,8 @@
 package luhn
 
 // Source: exercism/problem-specifications
-// Commit: 4a80663 luhn: non-digit at end is invalid
-// Problem Specifications Version: 1.4.0
+// Commit: d7fdadc Luhn: Add a test with an odd number of spaces (#1500)
+// Problem Specifications Version: 1.6.0
 
 var testCases = []struct {
 	description string
@@ -50,9 +50,9 @@ var testCases = []struct {
 		true,
 	},
 	{
-		"valid strings with a non-digit included become invalid",
-		"055a 444 285",
-		false,
+		"valid number with an odd number of spaces",
+		"234 567 891 234",
+		true,
 	},
 	{
 		"valid strings with a non-digit added at the end become invalid",
@@ -85,7 +85,12 @@ var testCases = []struct {
 		true,
 	},
 	{
-		"strings with non-digits is invalid",
+		"using ascii value for non-doubled non-digit isn't allowed",
+		"055b 444 285",
+		false,
+	},
+	{
+		"using ascii value for doubled non-digit isn't allowed",
 		":9",
 		false,
 	},

--- a/exercises/pangram/cases_test.go
+++ b/exercises/pangram/cases_test.go
@@ -1,8 +1,8 @@
 package pangram
 
 // Source: exercism/problem-specifications
-// Commit: c319f15 pangram: Apply new "input" policy
-// Problem Specifications Version: 1.4.0
+// Commit: 2c020bc Fix typo
+// Problem Specifications Version: 1.4.1
 
 var testCases = []struct {
 	description string

--- a/exercises/phone-number/cases_test.go
+++ b/exercises/phone-number/cases_test.go
@@ -1,8 +1,8 @@
 package phonenumber
 
 // Source: exercism/problem-specifications
-// Commit: fc57696 Phone-Number: Resolve inconsistencies in error messages. (#1361)
-// Problem Specifications Version: 1.6.1
+// Commit: 435b472 phone-number: improve error message for letters
+// Problem Specifications Version: 1.7.0
 
 // Cleanup user-entered phone numbers
 var numberTests = []struct {
@@ -71,7 +71,7 @@ var numberTests = []struct {
 		description:      "invalid with letters",
 		input:            "123-abc-7890",
 		expectErr:        true,
-		errorDescription: "alphanumerics not permitted",
+		errorDescription: "letters not permitted",
 	},
 	{
 		description:      "invalid with punctuations",

--- a/exercises/scale-generator/cases_test.go
+++ b/exercises/scale-generator/cases_test.go
@@ -1,8 +1,8 @@
 package scale
 
 // Source: exercism/problem-specifications
-// Commit: 1b1c0e4 scale generator: Add canonical data (#1156)
-// Problem Specifications Version: 1.0.0
+// Commit: 65cc51b Update scale-generator version to 2.0.0
+// Problem Specifications Version: 2.0.0
 
 type scaleTest struct {
 	description string

--- a/exercises/word-count/cases_test.go
+++ b/exercises/word-count/cases_test.go
@@ -1,8 +1,8 @@
 package wordcount
 
 // Source: exercism/problem-specifications
-// Commit: 77623ec word-count: Use camel-case for property name word-count: remove newline from eof
-// Problem Specifications Version: 1.2.0
+// Commit: d793398 word-count: check counting of empty words (#1446)
+// Problem Specifications Version: 1.3.0
 
 var testCases = []struct {
 	description string
@@ -63,5 +63,10 @@ var testCases = []struct {
 		"multiple spaces not detected as a word",
 		" multiple   whitespaces",
 		Frequency{"multiple": 1, "whitespaces": 1},
+	},
+	{
+		"alternating word separators not detected as a word",
+		",\n,one,\n ,two \n 'three'",
+		Frequency{"one": 1, "three": 1, "two": 1},
 	},
 }

--- a/exercises/wordy/cases_test.go
+++ b/exercises/wordy/cases_test.go
@@ -1,8 +1,8 @@
 package wordy
 
 // Source: exercism/problem-specifications
-// Commit: df75482 wordy: Apply new "input" policy
-// Problem Specifications Version: 1.1.0
+// Commit: 51c9b0b wordy: Test question `What is?` because it's too short
+// Problem Specifications Version: 1.5.0
 
 type wordyTest struct {
 	description string
@@ -12,6 +12,12 @@ type wordyTest struct {
 }
 
 var tests = []wordyTest{
+	{
+		"just a number",
+		"What is 5?",
+		true,
+		5,
+	},
 	{
 		"addition",
 		"What is 1 plus 1?",
@@ -105,6 +111,42 @@ var tests = []wordyTest{
 	{
 		"Non math question",
 		"Who is the President of the United States?",
+		false,
+		0,
+	},
+	{
+		"reject problem missing an operand",
+		"What is 1 plus?",
+		false,
+		0,
+	},
+	{
+		"reject problem with no operands or operators",
+		"What is?",
+		false,
+		0,
+	},
+	{
+		"reject two operations in a row",
+		"What is 1 plus plus 2?",
+		false,
+		0,
+	},
+	{
+		"reject two numbers in a row",
+		"What is 1 plus 2 1?",
+		false,
+		0,
+	},
+	{
+		"reject postfix notation",
+		"What is 1 2 plus?",
+		false,
+		0,
+	},
+	{
+		"reject prefix notation",
+		"What is plus 1 2?",
 		false,
 		0,
 	},

--- a/exercises/yacht/cases_test.go
+++ b/exercises/yacht/cases_test.go
@@ -1,8 +1,8 @@
 package yacht
 
 // Source: exercism/problem-specifications
-// Commit: 6eb19d2 yacht: Add "Four of a kind is not a full house" test case (#1232)
-// Problem Specifications Version: 1.1.0
+// Commit: 69f0783 yacht: Add "No pairs but not a big straight" test case (#1508)
+// Problem Specifications Version: 1.2.0
 
 var testCases = []struct {
 	description string
@@ -158,6 +158,12 @@ var testCases = []struct {
 		description: "Big Straight as little straight",
 		dice:        []int{6, 5, 4, 3, 2},
 		category:    "little straight",
+		expected:    0,
+	},
+	{
+		description: "No pairs but not a big straight",
+		dice:        []int{6, 5, 4, 3, 1},
+		category:    "big straight",
 		expected:    0,
 	},
 	{


### PR DESCRIPTION
1. Why is this change neccesary?
Because some exercises like isogram allowed you to use a `break` a statement
inside a for loop and having all the tests pass, this can lead to some confusion
between `break` and `continue` statements that are inside a for loop.

With the current test suite one could do something like this:

```
for i, letter := range word {
		letter = unicode.ToLower(letter)
		if !unicode.IsLetter(letter) {
			break
		}
		if strings.ContainsRune(word[i+1:], letter) {
			return false
		}
	}
```

And have all the test pass.

This could be problematic as the `break` statement gives a better benchmark but
it's because of a coincidence with the test cases.

Other exercises had similar problems.

2. How does it address the issue?
The test cases for all of the exercises were updated.

3. What side effects does this change have?
We're up-to-date with the latest test cases! :)