### PR TITLE
Add a new test case for the isogram exercise

### DIFF
--- a/exercises/isogram/cases_test.go
+++ b/exercises/isogram/cases_test.go
@@ -60,6 +60,11 @@ var testCases = []struct {
 		expected:    true,
 	},
 	{
+		description: "isogram with duplicated hyphen and duplicated character",
+		input:       "six-years-old",
+		expected:    false,
+	},
+	{
 		description: "made-up name that is an isogram",
 		input:       "Emily Jung Schwartzkopf",
 		expected:    true,


### PR DESCRIPTION
With the current test cases It was possible to stop processing if you detected a symbol character and the tests would all pass, this new test case stops that being a valid way of getting passing test.