### PR TITLE
[wip] many exercises: use subtests for table driven tests

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,3 @@
 Follow the instructions for your system on the installation page at [golang.org](http://golang.org/doc/install).
 
-Exercism supports Go 1.2 and higher.
+Exercism supports Go 1.7 and higher.

--- a/exercises/clock/.meta/gen.go
+++ b/exercises/clock/.meta/gen.go
@@ -69,35 +69,47 @@ var tmpl = `package clock
 {{range .J.Groups}}
 	// {{ .Description }}
 
-	{{- if .CreateCases }}
-		var timeTests = []struct {
+{{- if .CreateCases }}
+	var timeTests = []struct {
+			n string
 			h, m int
 			want string
 		}{
 			{{- range .CreateCases }}
-				{ {{.Input.Hour}}, {{.Input.Minute}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+				{
+				  {{ printf "%q" .Description }},
+				  {{.Input.Hour}}, {{.Input.Minute}}, {{.Expected | printf "%#v"}},
+				},
 			{{- end }}
 		}
 	{{- end }}
 
 	{{- if .AddCases }}
 		var {{ .GroupShortName }}Tests = []struct {
+			n string
 			h, m, a int
 			want string
 		}{
 			{{- range .AddCases }}
-				{ {{.Input.Hour}}, {{.Input.Minute}}, {{.Input.Value}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+				{
+				  {{ printf "%q" .Description}},
+				  {{.Input.Hour}}, {{.Input.Minute}}, {{.Input.Value}}, {{.Expected | printf "%#v"}},
+				 },
 			{{- end }}
 		}
 	{{- end }}
 
 	{{- if .SubtractCases }}
 		var {{ .GroupShortName }}Tests = []struct {
+			n string
 			h, m, a int
 			want string
 		}{
 			{{- range .SubtractCases }}
-				{ {{.Input.Hour}}, {{.Input.Minute}}, {{.Input.Value}}, {{.Expected | printf "%#v"}}}, // {{.Description}}
+			    {
+				  {{ printf "%q" .Description}},
+				  {{.Input.Hour}}, {{.Input.Minute}}, {{.Input.Value}}, {{.Expected | printf "%#v"}},
+				},
 			{{- end }}
 		}
 	{{- end }}
@@ -105,12 +117,13 @@ var tmpl = `package clock
 	{{- if .EqCases }}
 		type hm struct{ h, m int }
 		var eqTests = []struct {
+			n string
 			c1, c2 hm
 			want   bool
 		}{
 			{{- range .EqCases }}
-				// {{.Description}}
 				{
+				  {{ printf "%q" .Description}},
 					hm{ {{.Input.Clock1.Hour}}, {{.Input.Clock1.Minute}}},
 					hm{ {{.Input.Clock2.Hour}}, {{.Input.Clock2.Minute}}},
 					{{.Expected}},

--- a/exercises/clock/cases_test.go
+++ b/exercises/clock/cases_test.go
@@ -6,160 +6,272 @@ package clock
 
 // Create a new clock with an initial time
 var timeTests = []struct {
+	n    string
 	h, m int
 	want string
 }{
-	{8, 0, "08:00"},        // on the hour
-	{11, 9, "11:09"},       // past the hour
-	{24, 0, "00:00"},       // midnight is zero hours
-	{25, 0, "01:00"},       // hour rolls over
-	{100, 0, "04:00"},      // hour rolls over continuously
-	{1, 60, "02:00"},       // sixty minutes is next hour
-	{0, 160, "02:40"},      // minutes roll over
-	{0, 1723, "04:43"},     // minutes roll over continuously
-	{25, 160, "03:40"},     // hour and minutes roll over
-	{201, 3001, "11:01"},   // hour and minutes roll over continuously
-	{72, 8640, "00:00"},    // hour and minutes roll over to exactly midnight
-	{-1, 15, "23:15"},      // negative hour
-	{-25, 0, "23:00"},      // negative hour rolls over
-	{-91, 0, "05:00"},      // negative hour rolls over continuously
-	{1, -40, "00:20"},      // negative minutes
-	{1, -160, "22:20"},     // negative minutes roll over
-	{1, -4820, "16:40"},    // negative minutes roll over continuously
-	{2, -60, "01:00"},      // negative sixty minutes is previous hour
-	{-25, -160, "20:20"},   // negative hour and minutes both roll over
-	{-121, -5810, "22:10"}, // negative hour and minutes both roll over continuously
+	{
+		"on the hour",
+		8, 0, "08:00",
+	},
+	{
+		"past the hour",
+		11, 9, "11:09",
+	},
+	{
+		"midnight is zero hours",
+		24, 0, "00:00",
+	},
+	{
+		"hour rolls over",
+		25, 0, "01:00",
+	},
+	{
+		"hour rolls over continuously",
+		100, 0, "04:00",
+	},
+	{
+		"sixty minutes is next hour",
+		1, 60, "02:00",
+	},
+	{
+		"minutes roll over",
+		0, 160, "02:40",
+	},
+	{
+		"minutes roll over continuously",
+		0, 1723, "04:43",
+	},
+	{
+		"hour and minutes roll over",
+		25, 160, "03:40",
+	},
+	{
+		"hour and minutes roll over continuously",
+		201, 3001, "11:01",
+	},
+	{
+		"hour and minutes roll over to exactly midnight",
+		72, 8640, "00:00",
+	},
+	{
+		"negative hour",
+		-1, 15, "23:15",
+	},
+	{
+		"negative hour rolls over",
+		-25, 0, "23:00",
+	},
+	{
+		"negative hour rolls over continuously",
+		-91, 0, "05:00",
+	},
+	{
+		"negative minutes",
+		1, -40, "00:20",
+	},
+	{
+		"negative minutes roll over",
+		1, -160, "22:20",
+	},
+	{
+		"negative minutes roll over continuously",
+		1, -4820, "16:40",
+	},
+	{
+		"negative sixty minutes is previous hour",
+		2, -60, "01:00",
+	},
+	{
+		"negative hour and minutes both roll over",
+		-25, -160, "20:20",
+	},
+	{
+		"negative hour and minutes both roll over continuously",
+		-121, -5810, "22:10",
+	},
 }
 
 // Add minutes
 var addTests = []struct {
+	n       string
 	h, m, a int
 	want    string
 }{
-	{10, 0, 3, "10:03"},    // add minutes
-	{6, 41, 0, "06:41"},    // add no minutes
-	{0, 45, 40, "01:25"},   // add to next hour
-	{10, 0, 61, "11:01"},   // add more than one hour
-	{0, 45, 160, "03:25"},  // add more than two hours with carry
-	{23, 59, 2, "00:01"},   // add across midnight
-	{5, 32, 1500, "06:32"}, // add more than one day (1500 min = 25 hrs)
-	{1, 1, 3500, "11:21"},  // add more than two days
+	{
+		"add minutes",
+		10, 0, 3, "10:03",
+	},
+	{
+		"add no minutes",
+		6, 41, 0, "06:41",
+	},
+	{
+		"add to next hour",
+		0, 45, 40, "01:25",
+	},
+	{
+		"add more than one hour",
+		10, 0, 61, "11:01",
+	},
+	{
+		"add more than two hours with carry",
+		0, 45, 160, "03:25",
+	},
+	{
+		"add across midnight",
+		23, 59, 2, "00:01",
+	},
+	{
+		"add more than one day (1500 min = 25 hrs)",
+		5, 32, 1500, "06:32",
+	},
+	{
+		"add more than two days",
+		1, 1, 3500, "11:21",
+	},
 }
 
 // Subtract minutes
 var subtractTests = []struct {
+	n       string
 	h, m, a int
 	want    string
 }{
-	{10, 3, 3, "10:00"},    // subtract minutes
-	{10, 3, 30, "09:33"},   // subtract to previous hour
-	{10, 3, 70, "08:53"},   // subtract more than an hour
-	{0, 3, 4, "23:59"},     // subtract across midnight
-	{0, 0, 160, "21:20"},   // subtract more than two hours
-	{6, 15, 160, "03:35"},  // subtract more than two hours with borrow
-	{5, 32, 1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
-	{2, 20, 3000, "00:20"}, // subtract more than two days
+	{
+		"subtract minutes",
+		10, 3, 3, "10:00",
+	},
+	{
+		"subtract to previous hour",
+		10, 3, 30, "09:33",
+	},
+	{
+		"subtract more than an hour",
+		10, 3, 70, "08:53",
+	},
+	{
+		"subtract across midnight",
+		0, 3, 4, "23:59",
+	},
+	{
+		"subtract more than two hours",
+		0, 0, 160, "21:20",
+	},
+	{
+		"subtract more than two hours with borrow",
+		6, 15, 160, "03:35",
+	},
+	{
+		"subtract more than one day (1500 min = 25 hrs)",
+		5, 32, 1500, "04:32",
+	},
+	{
+		"subtract more than two days",
+		2, 20, 3000, "00:20",
+	},
 }
 
 // Compare two clocks for equality
 type hm struct{ h, m int }
 
 var eqTests = []struct {
+	n      string
 	c1, c2 hm
 	want   bool
 }{
-	// clocks with same time
 	{
+		"clocks with same time",
 		hm{15, 37},
 		hm{15, 37},
 		true,
 	},
-	// clocks a minute apart
 	{
+		"clocks a minute apart",
 		hm{15, 36},
 		hm{15, 37},
 		false,
 	},
-	// clocks an hour apart
 	{
+		"clocks an hour apart",
 		hm{14, 37},
 		hm{15, 37},
 		false,
 	},
-	// clocks with hour overflow
 	{
+		"clocks with hour overflow",
 		hm{10, 37},
 		hm{34, 37},
 		true,
 	},
-	// clocks with hour overflow by several days
 	{
+		"clocks with hour overflow by several days",
 		hm{3, 11},
 		hm{99, 11},
 		true,
 	},
-	// clocks with negative hour
 	{
+		"clocks with negative hour",
 		hm{22, 40},
 		hm{-2, 40},
 		true,
 	},
-	// clocks with negative hour that wraps
 	{
+		"clocks with negative hour that wraps",
 		hm{17, 3},
 		hm{-31, 3},
 		true,
 	},
-	// clocks with negative hour that wraps multiple times
 	{
+		"clocks with negative hour that wraps multiple times",
 		hm{13, 49},
 		hm{-83, 49},
 		true,
 	},
-	// clocks with minute overflow
 	{
+		"clocks with minute overflow",
 		hm{0, 1},
 		hm{0, 1441},
 		true,
 	},
-	// clocks with minute overflow by several days
 	{
+		"clocks with minute overflow by several days",
 		hm{2, 2},
 		hm{2, 4322},
 		true,
 	},
-	// clocks with negative minute
 	{
+		"clocks with negative minute",
 		hm{2, 40},
 		hm{3, -20},
 		true,
 	},
-	// clocks with negative minute that wraps
 	{
+		"clocks with negative minute that wraps",
 		hm{4, 10},
 		hm{5, -1490},
 		true,
 	},
-	// clocks with negative minute that wraps multiple times
 	{
+		"clocks with negative minute that wraps multiple times",
 		hm{6, 15},
 		hm{6, -4305},
 		true,
 	},
-	// clocks with negative hours and minutes
 	{
+		"clocks with negative hours and minutes",
 		hm{7, 32},
 		hm{-12, -268},
 		true,
 	},
-	// clocks with negative hours and minutes that wrap
 	{
+		"clocks with negative hours and minutes that wrap",
 		hm{18, 7},
 		hm{-54, -11513},
 		true,
 	},
-	// full clock and zeroed clock
 	{
+		"full clock and zeroed clock",
 		hm{24, 0},
 		hm{0, 0},
 		true,

--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -29,47 +29,55 @@ import (
 
 func TestCreateClock(t *testing.T) {
 	for _, n := range timeTests {
-		if got := New(n.h, n.m); got.String() != n.want {
-			t.Fatalf("New(%d, %d) = %q, want %q", n.h, n.m, got, n.want)
-		}
+		t.Run(n.n, func(t *testing.T) {
+			if got := New(n.h, n.m); got.String() != n.want {
+				t.Fatalf("New(%d, %d) = %q, want %q", n.h, n.m, got, n.want)
+			}
+		})
 	}
 	t.Log(len(timeTests), "test cases")
 }
 
 func TestAddMinutes(t *testing.T) {
 	for _, a := range addTests {
-		if got := New(a.h, a.m).Add(a.a); got.String() != a.want {
-			t.Fatalf("New(%d, %d).Add(%d) = %q, want %q",
-				a.h, a.m, a.a, got, a.want)
-		}
+		t.Run(a.n, func(t *testing.T) {
+			if got := New(a.h, a.m).Add(a.a); got.String() != a.want {
+				t.Fatalf("New(%d, %d).Add(%d) = %q, want %q",
+					a.h, a.m, a.a, got, a.want)
+			}
+		})
 	}
 	t.Log(len(addTests), "test cases")
 }
 
 func TestSubtractMinutes(t *testing.T) {
 	for _, a := range subtractTests {
-		if got := New(a.h, a.m).Subtract(a.a); got.String() != a.want {
-			t.Fatalf("New(%d, %d).Subtract(%d) = %q, want %q",
-				a.h, a.m, a.a, got, a.want)
-		}
+		t.Run(a.n, func(t *testing.T) {
+			if got := New(a.h, a.m).Subtract(a.a); got.String() != a.want {
+				t.Fatalf("New(%d, %d).Subtract(%d) = %q, want %q",
+					a.h, a.m, a.a, got, a.want)
+			}
+		})
 	}
 	t.Log(len(subtractTests), "test cases")
 }
 
 func TestCompareClocks(t *testing.T) {
 	for _, e := range eqTests {
-		clock1 := New(e.c1.h, e.c1.m)
-		clock2 := New(e.c2.h, e.c2.m)
-		got := clock1 == clock2
-		if got != e.want {
-			t.Log("Clock1:", clock1)
-			t.Log("Clock2:", clock2)
-			t.Logf("Clock1 == Clock2 is %t, want %t", got, e.want)
-			if reflect.DeepEqual(clock1, clock2) {
-				t.Log("(Hint: see comments in clock_test.go.)")
+		t.Run(e.n, func(t *testing.T) {
+			clock1 := New(e.c1.h, e.c1.m)
+			clock2 := New(e.c2.h, e.c2.m)
+			got := clock1 == clock2
+			if got != e.want {
+				t.Log("Clock1:", clock1)
+				t.Log("Clock2:", clock2)
+				t.Logf("Clock1 == Clock2 is %t, want %t", got, e.want)
+				if reflect.DeepEqual(clock1, clock2) {
+					t.Log("(Hint: see comments in clock_test.go.)")
+				}
+				t.FailNow()
 			}
-			t.FailNow()
-		}
+		})
 	}
 	t.Log(len(eqTests), "test cases")
 }

--- a/exercises/tree-building/tree_test.go
+++ b/exercises/tree-building/tree_test.go
@@ -222,26 +222,30 @@ func (n Node) String() string {
 
 func TestMakeTreeSuccess(t *testing.T) {
 	for _, tt := range successTestCases {
-		actual, err := Build(tt.input)
-		if err != nil {
-			var _ error = err
-			t.Fatalf("Build for test case %q returned error %q. Error not expected.",
-				tt.name, err)
-		}
-		if !reflect.DeepEqual(actual, tt.expected) {
-			t.Fatalf("Build for test case %q returned %s but was expected to return %s.",
-				tt.name, actual, tt.expected)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := Build(tt.input)
+			if err != nil {
+				var _ error = err
+				t.Fatalf("Build for test case %q returned error %q. Error not expected.",
+					tt.name, err)
+			}
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Fatalf("Build for test case %q returned %s but was expected to return %s.",
+					tt.name, actual, tt.expected)
+			}
+		})
 	}
 }
 
 func TestMakeTreeFailure(t *testing.T) {
 	for _, tt := range failureTestCases {
-		actual, err := Build(tt.input)
-		if err == nil {
-			t.Fatalf("Build for test case %q returned %s but was expected to fail.",
-				tt.name, actual)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := Build(tt.input)
+			if err == nil {
+				t.Fatalf("Build for test case %q returned %s but was expected to fail.",
+					tt.name, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This is a work in progress to use subtests for all table driven tests for all exercises. I use exercism for teaching/coaching and a lot of the students have problems identifying the failing test case. Subtests make this much easier.

There is a downside though: using t.Run raises the minimum go version to 1.7.  Go 1.7 was released back in August '16. In my opinion it is prudent to require a version that old.

If the maintainers agree all table driven tests will be converted in all exercises