### PR TITLE
LinkedList: On error, return nil, not int(0). Don't test val on error.

### DIFF
--- a/exercises/linked-list/cases_test.go
+++ b/exercises/linked-list/cases_test.go
@@ -101,7 +101,7 @@ var pushPopTestCases = []struct {
 			popFront(2, nil),
 			popFront(3, nil),
 			popFront(4, nil),
-			popFront(0, ErrEmptyList),
+			popFront(nil, ErrEmptyList),
 		},
 		expected: []interface{}{},
 	},
@@ -122,7 +122,7 @@ var pushPopTestCases = []struct {
 			popBack(3, nil),
 			popBack(2, nil),
 			popBack(1, nil),
-			popBack(0, ErrEmptyList),
+			popBack(nil, ErrEmptyList),
 		},
 		expected: []interface{}{},
 	},
@@ -136,8 +136,8 @@ var pushPopTestCases = []struct {
 			popFront(2, nil),
 			popBack(4, nil),
 			popBack(3, nil),
-			popBack(0, ErrEmptyList),
-			popFront(0, ErrEmptyList),
+			popBack(nil, ErrEmptyList),
+			popFront(nil, ErrEmptyList),
 			pushFront(8),
 			pushBack(7),
 			pushFront(9),
@@ -169,7 +169,7 @@ func popFront(expected interface{}, expectedErr error) checkedAction {
 			t.Errorf("PopFront() returned wrong, expected no error, got= %v", err)
 		}
 
-		if v != expected {
+		if expectedErr == nil && v != expected {
 			t.Errorf("PopFront() returned wrong, expected= %v, got= %v", expected, v)
 		}
 	}
@@ -182,7 +182,7 @@ func popBack(expected interface{}, expectedErr error) checkedAction {
 			t.Errorf("PopBack() returned wrong, expected no error, got= %v", err)
 		}
 
-		if v != expected {
+		if expectedErr == nil && v != expected {
 			t.Errorf("PopBack() returned wrong, expected= %v, got= %v", expected, v)
 		}
 	}

--- a/exercises/linked-list/example.go
+++ b/exercises/linked-list/example.go
@@ -173,7 +173,7 @@ func (ll *List) PopFront() (interface{}, error) {
 	default:
 		panic("bad PopFront implementation")
 	case ll.head == nil && ll.tail == nil: // empty list
-		return 0, ErrEmptyList
+		return nil, ErrEmptyList
 	case ll.head != nil && ll.tail != nil && ll.head.next == nil: // 1 element
 		v := ll.head.Val
 		ll.head = nil
@@ -195,7 +195,7 @@ func (ll *List) PopBack() (interface{}, error) {
 	default:
 		panic("bad PopBack implementation")
 	case ll.head == nil && ll.tail == nil: // empty list
-		return 0, ErrEmptyList
+		return nil, ErrEmptyList
 	case ll.head != nil && ll.tail != nil && ll.tail.prev == nil: // 1 element
 		v := ll.tail.Val
 		ll.head = nil


### PR DESCRIPTION
1. On an error, use `nil` for the return value over `int(0)`
2. In the unit tests, do not check the return value when there is an error.