### PR TITLE
hamming: check returned error before value

### DIFF
--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -15,16 +15,16 @@ func TestHamming(t *testing.T) {
 					tc.s1, tc.s2)
 			}
 		} else {
-			if got != tc.want {
-				t.Fatalf("Distance(%q, %q) = %d, want %d.",
-					tc.s1, tc.s2, got, tc.want)
-			}
-
 			// we do not expect error
 			if err != nil {
 				t.Fatalf("Distance(%q, %q) returned unexpected error: %v",
 					tc.s1, tc.s2, err)
 			}
+			if got != tc.want {
+				t.Fatalf("Distance(%q, %q) = %d, want %d.",
+					tc.s1, tc.s2, got, tc.want)
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
Consider this (real) solution:

```go
func Distance(a, b string) (int, error) {
	// return error if strings are of different length
	if len(a) != len(b) {
		return 0, fmt.Errorf("unequal lengths: %q, %q", a, b)
	}

	if a == "" || b == "" {
		return 0, nil
	}

	diff := 0
	ar, br := []rune(a), []rune(b)
	for i, r := range ar {
		if r != br[i] {
			diff++
		}
	}
	return diff, nil
}
```

It contains a subtle bug: when checking if the inputs are of equal length, it checks the _string_ length, not the _rune sequence_ length. If one of the strings contains a wide character (for example `Ã`) and the other one doesn't, their lengths will be unequal and the function will bail out with an error, returning 0 for the data value.

So far, so good. But the test code doesn't handle this correctly. When the test case doesn't expect an error, it checks the _data value first_. If this is not what's expected, the test fails with a misleading message:

```
--- FAIL: TestHamming (0.00s)
    hamming_test.go:19: Distance("aaa", "aÃa") = 0, want 1.
```

It should have checked the _error value_ first, because if the error is non-nil, the data value is meaningless (and idiomatically will in fact be zero). If the test code checks the error first, the test failure is more helpful:

```
--- FAIL: TestHamming (0.00s)
    hamming_test.go:20: Distance("aaa", "aÃa") returned unexpected error: unequal lengths: "aaa", "aÃa"
```

Now at least the student can see which part of the code needs fixing.