### PR TITLE
space-age: fix Uranus period

### DIFF
--- a/exercises/space-age/cases_test.go
+++ b/exercises/space-age/cases_test.go
@@ -1,8 +1,8 @@
 package space
 
 // Source: exercism/problem-specifications
-// Commit: 8d4df79 space-age: Apply new "input" policy
-// Problem Specifications Version: 1.1.0
+// Commit: 28b3dac0 space-age: restrict seconds to fit within 32-bit int range
+// Problem Specifications Version: 1.2.0
 
 var testCases = []struct {
 	description string
@@ -31,8 +31,8 @@ var testCases = []struct {
 	{
 		description: "age on Mars",
 		planet:      "Mars",
-		seconds:     2329871239,
-		expected:    39.25,
+		seconds:     2129871239,
+		expected:    35.88,
 	},
 	{
 		description: "age on Jupiter",
@@ -43,19 +43,19 @@ var testCases = []struct {
 	{
 		description: "age on Saturn",
 		planet:      "Saturn",
-		seconds:     3000000000,
-		expected:    3.23,
+		seconds:     2000000000,
+		expected:    2.15,
 	},
 	{
 		description: "age on Uranus",
 		planet:      "Uranus",
-		seconds:     3210123456,
-		expected:    1.21,
+		seconds:     1210123456,
+		expected:    0.46,
 	},
 	{
 		description: "age on Neptune",
 		planet:      "Neptune",
-		seconds:     8210123456,
-		expected:    1.58,
+		seconds:     1821023456,
+		expected:    0.35,
 	},
 }

--- a/exercises/space-age/example.go
+++ b/exercises/space-age/example.go
@@ -22,7 +22,7 @@ var periods = map[Planet]float64{
 	PlanetMars:    593542.944,
 	PlanetJupiter: 3743357.76,
 	PlanetSaturn:  9295966.08,
-	PlanetUranus:  26610418.08,
+	PlanetUranus:  26307031.65,
 	PlanetNeptune: 52004185.92,
 }
 


### PR DESCRIPTION
latest upstream json ( https://github.com/exercism/problem-specifications/commit/28b3dac0d8055e22280a885e156c1fd2dba20c26 ) has changed some values, with the result that a test was failing due to rounding errors

```
$ go test
--- FAIL: TestAge (0.00s)
    space_age_test.go:15: PASS: age on Earth
    space_age_test.go:15: PASS: age on Mercury
    space_age_test.go:15: PASS: age on Venus
    space_age_test.go:15: PASS: age on Mars
    space_age_test.go:15: PASS: age on Jupiter
    space_age_test.go:15: PASS: age on Saturn
    space_age_test.go:13: FAIL: age on Uranus
        Expected: 0.46
        Actual: 0.45
FAIL
exit status 1
FAIL	_/home/andrea/projects/exercism-go/exercises/space-age	0.001s

```



