### PR TITLE
twelve days: add benchmark

### DIFF
--- a/exercises/twelve-days/twelve_days_test.go
+++ b/exercises/twelve-days/twelve_days_test.go
@@ -70,3 +70,17 @@ func TestVerse(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkVerse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, test := range testCases {
+			Verse(test.input)
+		}
+	}
+}
+
+func BenchmarkSong(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Song()
+	}
+}


### PR DESCRIPTION
Hello all,

While working on the "Twelve days" exercise I have created a small benchmark in local with the goal of testing two different approaches:
1) Creating verse by appending strings via "+" operator
2) Creating verse by creating a strings.Builder and appending via the WriteString method.

My idea is that these benchmarks could help those who would like to see the difference in performance for these and potentially other approaches. Would it make sense to you to add them in the test suite?