### PR TITLE
complex-numbers: implement exercise - ref #918

### DIFF
--- a/config.json
+++ b/config.json
@@ -1139,6 +1139,17 @@
       ]
     },
     {
+      "slug": "complex-numbers",
+      "uuid": "ef947390-7aa7-422c-8974-63dc5a7b52b2",
+      "core": false,
+      "unlocked_by": "bank-account",
+      "difficulty": 8,
+      "topics": [
+        "floating_point_numbers",
+        "math"
+      ]
+    },
+    {
       "slug": "change",
       "uuid": "94a21509-ebd5-4a66-bb0e-0341e57e3c73",
       "core": false,

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -1,0 +1,53 @@
+# Complex Numbers
+
+A complex number is a number in the form `a + b * i` where `a` and `b` are real and `i` satisfies `i^2 = -1`.
+
+`a` is called the real part and `b` is called the imaginary part of `z`.
+The conjugate of the number `a + b * i` is the number `a - b * i`.
+The absolute value of a complex number `z = a + b * i` is a real number `|z| = sqrt(a^2 + b^2)`. The square of the absolute value `|z|^2` is the result of multiplication of `z` by its complex conjugate.
+
+The sum/difference of two complex numbers involves adding/subtracting their real and imaginary parts separately:
+`(a + i * b) + (c + i * d) = (a + c) + (b + d) * i`,
+`(a + i * b) - (c + i * d) = (a - c) + (b - d) * i`.
+
+Multiplication result is by definition
+`(a + i * b) * (c + i * d) = (a * c - b * d) + (b * c + a * d) * i`.
+
+The reciprocal of a non-zero complex number is
+`1 / (a + i * b) = a/(a^2 + b^2) - b/(a^2 + b^2) * i`.
+
+Dividing a complex number `a + i * b` by another `c + i * d` gives:
+`(a + i * b) / (c + i * d) = (a * c + b * d)/(c^2 + d^2) + (b * c - a * d)/(c^2 + d^2) * i`.
+
+Raising e to a complex exponent can be expressed as `e^(a + i * b) = e^a * e^(i * b)`, the last term of which is given by Euler's formula `e^(i * b) = cos(b) + i * sin(b)`.
+
+Implement the following operations:
+ - addition, subtraction, multiplication and division of two complex numbers,
+ - conjugate, absolute value, exponent of a given complex number.
+
+
+Assume the programming language you are using does not have an implementation of complex numbers.
+
+## Running the tests
+
+To run the tests run the command `go test` from within the exercise directory.
+
+If the test suite contains benchmarks, you can run these with the `--bench` and `--benchmem`
+flags:
+
+    go test -v --bench . --benchmem
+
+Keep in mind that each reviewer will run benchmarks on a different machine, with
+different specs, so the results from these benchmark tests may vary.
+
+## Further information
+
+For more detailed information about the Go track, including how to get help if
+you're having trouble, please visit the exercism.io [Go language page](http://exercism.io/languages/go/resources).
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Complex_number](https://en.wikipedia.org/wiki/Complex_number)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/complex-numbers/cases_test.go
+++ b/exercises/complex-numbers/cases_test.go
@@ -1,0 +1,62 @@
+package complex
+
+var testDataForUnOp = []struct {
+	r, i float64
+}{
+	// Imaginary unit
+	{0, 1},
+	// Complex with real parts only
+	{1, 0},
+	{-1, 0},
+	{5, 0},
+	{7, 0},
+	// Complex with imaginary parts only
+	{0, 3.14},
+	{0, 5},
+	{0, -25},
+	// Complex with real and imaginary parts
+	{1, 2},
+	{15.7, 3.69},
+	{4, 5},
+	{-21.3, 45},
+	{507.14, -616.628},
+}
+
+var testDataForBinOp = []struct {
+	aReal, aImag float64
+	bReal, bImag float64
+}{
+	{ // Complex with real parts only
+		5, 0,
+		7, 0,
+	},
+	{ // Complex with imaginary parts only
+		0, 1,
+		0, 5,
+	},
+	{ // One complex with real part only and the other one with imaginary part only
+		2, 0,
+		0, 5,
+	},
+	// Complex with real and imaginary parts
+	{
+		1, 3,
+		4, -5,
+	},
+	{
+		10.5, -5,
+		4, 3.333,
+	},
+	{
+		42, -1,
+		8, 12,
+	},
+	{
+		37, 71,
+		250, 120,
+	},
+	{
+		42.42, 1789.6,
+		-756, 1492.1,
+	},
+}

--- a/exercises/complex-numbers/complex_numbers_test.go
+++ b/exercises/complex-numbers/complex_numbers_test.go
@@ -1,0 +1,102 @@
+package complex
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+func TestImaginaryUnit(t *testing.T) {
+	expected := 1i
+	imgUnit := NewComplex(0, 1)
+	if actual := complex(imgUnit.Real(), imgUnit.Imag()); expected != actual {
+		t.Fatalf("Expecting the imaginary unit to be %g but was %g", expected, actual)
+	}
+}
+
+func testFuncToFloat64(t *testing.T, resName string, fActual func(Complex) float64, fExpected func(complex128) float64) {
+	for _, test := range testDataForUnOp {
+		n := complex(test.r, test.i)
+		expected := fExpected(n)
+		actual := fActual(NewComplex(test.r, test.i))
+		if compareFloat64(expected, actual) {
+			t.Fatalf("Expecting the %s of %g to be %g but was %g", resName, n, expected, actual)
+		}
+	}
+}
+
+func TestRealPart(t *testing.T) {
+	testFuncToFloat64(t, "real part",
+		func(c Complex) float64 { return c.Real() },
+		func(c complex128) float64 { return real(c) })
+}
+
+func TestImagPart(t *testing.T) {
+	testFuncToFloat64(t, "imaginary part",
+		func(c Complex) float64 { return c.Imag() },
+		func(c complex128) float64 { return imag(c) })
+}
+
+func TestComplexAbs(t *testing.T) {
+	testFuncToFloat64(t, "absolute value", Abs, cmplx.Abs)
+}
+
+func compareFloat64(expected, actual float64) bool {
+	diff := math.Abs(expected - actual)
+	const delta = 1E-10
+	return diff > delta
+}
+
+func compareComplex(expected, actual complex128) bool {
+	return compareFloat64(real(expected), real(actual)) ||
+		compareFloat64(imag(expected), imag(actual))
+}
+
+func testUnaryOp(t *testing.T, resName string, opActual func(Complex) Complex, opExpected func(complex128) complex128) {
+	for _, test := range testDataForUnOp {
+		n := complex(test.r, test.i)
+		expected := opExpected(n)
+		result := opActual(NewComplex(test.r, test.i))
+		actual := complex(result.Real(), result.Imag())
+		if compareComplex(expected, actual) {
+			t.Fatalf("Expecting the %s of %g to be %g but was %g", resName, n, expected, actual)
+		}
+	}
+}
+
+func TestComplexConj(t *testing.T) {
+	testUnaryOp(t, "complex conjugate", Conj, cmplx.Conj)
+}
+
+func TestExpComplex(t *testing.T) {
+	testUnaryOp(t, "exponential", Exp, cmplx.Exp)
+}
+
+func testBinaryOperation(t *testing.T, resName string, opActual func(Complex, Complex) Complex, opExpected func(complex128, complex128) complex128) {
+	for _, test := range testDataForBinOp {
+		a := complex(test.aReal, test.aImag)
+		b := complex(test.bReal, test.bImag)
+		expected := opExpected(a, b)
+		res := opActual(NewComplex(test.aReal, test.aImag), NewComplex(test.bReal, test.bImag))
+		actual := complex(res.Real(), res.Imag())
+		if compareComplex(expected, actual) {
+			t.Fatalf("Expecting the %s of %g and %g to be %g but was %g", resName, a, b, expected, actual)
+		}
+	}
+}
+
+func TestAddComplex(t *testing.T) {
+	testBinaryOperation(t, "sum", Add, func(a, b complex128) complex128 { return a + b })
+}
+
+func TestSubtractComplex(t *testing.T) {
+	testBinaryOperation(t, "difference", Sub, func(a, b complex128) complex128 { return a - b })
+}
+
+func TestMultiplyComplex(t *testing.T) {
+	testBinaryOperation(t, "product", Mult, func(a, b complex128) complex128 { return a * b })
+}
+
+func TestDivisionComplex(t *testing.T) {
+	testBinaryOperation(t, "quotient", Div, func(a, b complex128) complex128 { return a / b })
+}

--- a/exercises/complex-numbers/example.go
+++ b/exercises/complex-numbers/example.go
@@ -1,0 +1,64 @@
+package complex
+
+import "math"
+
+// Complex is a struct that represents a complex number
+// with its real and imaginary parts
+type Complex struct {
+	real, imag float64
+}
+
+// NewComplex returns a new complex number given its real
+// and imaginary parts
+func NewComplex(real, imag float64) Complex {
+	return Complex{real, imag}
+}
+
+// Real returns the real part of the complex number
+func (c Complex) Real() float64 { return c.real }
+
+// Imag returns the imaginary part of the complex number
+func (c Complex) Imag() float64 { return c.imag }
+
+// Add returns the sum of two complex numbers
+func Add(c1, c2 Complex) Complex {
+	return NewComplex(c1.Real()+c2.Real(), c1.Imag()+c2.Imag())
+}
+
+// Sub returns the subtraction of two complex numbers
+func Sub(c1, c2 Complex) Complex {
+	return NewComplex(c1.Real()-c2.Real(), c1.Imag()-c2.Imag())
+}
+
+// Mult returns the multiplication of two complex numbers
+func Mult(c1, c2 Complex) Complex {
+	r := c1.Real()*c2.Real() - c1.Imag()*c2.Imag()
+	i := c1.Imag()*c2.Real() + c1.Real()*c2.Imag()
+	return NewComplex(r, i)
+}
+
+// Div returns the quotient of two complex numbers
+func Div(c1, c2 Complex) Complex {
+	f := c2.Real()*c2.Real() + c2.Imag()*c2.Imag()
+	r := (c1.Real()*c2.Real() + c1.Imag()*c2.Imag()) / f
+	i := (c1.Imag()*c2.Real() - c1.Real()*c2.Imag()) / f
+	return NewComplex(r, i)
+}
+
+// Conj returns the complex conjugate of the input complex number
+func Conj(c Complex) Complex {
+	return NewComplex(c.Real(), -c.Imag())
+}
+
+// Abs returns the absolute value of the input complex number
+func Abs(c Complex) float64 {
+	return math.Sqrt(c.Real()*c.Real() + c.Imag()*c.Imag())
+}
+
+// Exp returns 'e' raised to the power of the input complex number
+func Exp(c Complex) Complex {
+	a := math.Exp(c.Real())
+	bR := math.Cos(c.Imag())
+	bI := math.Sin(c.Imag())
+	return NewComplex(a*bR, a*bI)
+}


### PR DESCRIPTION
Hi everyone, I have created a first skeleton of the complex-numbers exercise tests with an example.
The README.md is generated via the configlet tool. I didn't yet write a gen.go because I'm not confident with the structure of the canonical data json https://github.com/exercism/problem-specifications/blob/master/exercises/complex-numbers/canonical-data.json, mostly with the input having either fields z1, z2 for binary operations or field z for unary operations.

Please let me know if the code is going in the good direction. I will be very happy to contribute with a new exercise