### PR TITLE
Added test for three levels nesting for tree-building exercise

### DIFF
--- a/exercises/tree-building/tree_test.go
+++ b/exercises/tree-building/tree_test.go
@@ -61,6 +61,31 @@ var successTestCases = []struct {
 		},
 	},
 	{
+		name: "three levels of nesting",
+		input: []Record{
+			{ID: 2, Parent: 1},
+			{ID: 1, Parent: 0},
+			{ID: 3, Parent: 2},
+			{ID: 0},
+		},
+		expected: &Node{
+			ID: 0,
+			Children: []*Node{
+				{
+					ID: 1,
+					Children: []*Node{
+						{
+							ID: 2,
+							Children: []*Node{
+								{ID: 3},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		name: "more than two children",
 		input: []Record{
 			{ID: 3, Parent: 0},


### PR DESCRIPTION
Closes: #1261 
Added test to check for three levels of nesting to guard against edge cases that only work with two or fewer levels of nesting.