### PR TITLE
Fix descriptions in "error-handling" exercise

### DIFF
--- a/exercises/error-handling/.meta/description.md
+++ b/exercises/error-handling/.meta/description.md
@@ -29,11 +29,11 @@ There will be a few places in your Use function where errors may occur:
   the resource. If it is some other sort of error, return it from your `Use`
   function.
 
-* Calling the Frob function on the Resource returned from the ResourceOpener
+* Calling the `Frob` function on the Resource returned from the ResourceOpener
   function, it may **panic** with a FrobError (or another type of error). If it
   is indeed a FrobError you will have to call the Resource's `Defrob` function
   *using the panic FrobError's `.defrobTag` variable as input to the `Defrob`
   function*. Either way `Use` should return the error.
 
 * *Also note*: if the Resource was opened successfully make sure to call its
-  Close function no matter what (even if errors have occurred).
+  `Close` function no matter what (even if errors have occurred).

--- a/exercises/error-handling/common.go
+++ b/exercises/error-handling/common.go
@@ -3,7 +3,7 @@ package erratum
 import "io"
 
 // These are the support types and interface definitions used in the
-// implementation if your Use function. See the test suite file at
+// implementation of your Use function. See the test suite file at
 // for information on the expected implementation.
 //
 // Because this is part of the package "erratum", if your solution file


### PR DESCRIPTION
This PR fixes the following in the "error handling" exercise 
1. Small typo in comment of common.go
2. Missing code block formatting for function names in problem description