### PR TITLE
minesweeper: add test cases

### DIFF
--- a/exercises/minesweeper/minesweeper_test.go
+++ b/exercises/minesweeper/minesweeper_test.go
@@ -117,6 +117,13 @@ var validBoards = []string{
 }
 
 var badBoards = []string{
+	// One border
+	`
++++`,
+	// Unaligned borders
+	`
+++
++`,
 	// Unaligned
 	`
 +-+
@@ -130,6 +137,24 @@ var badBoards = []string{
 +-----+
 *   * |
 +-- --+`,
+
+	// Mine on corner
+	`
++-----*
+|   * |
++-----+`,
+
+	// Mine on upper border
+	`
++--*--+
+|   * |
++-----+`,
+
+	// Mine on left border
+	`
++-----+
+*   * |
++-----+`,
 
 	// Unknown characters
 	`


### PR DESCRIPTION
Hello all,

While working on the "Minesweeper" exercise I noticed that the solution that I wrote (https://exercism.io/tracks/go/exercises/minesweeper/solutions/670a1d754f8b41f481b1d30cd26348b8) was covering some additional edge cases that are not taken into account in the current version of the tests:
- Border composed of one line instead of two
- Unaligned borders: one border longer than the other
- Mine on one corner only, on the upper border only and on the left border only.

My idea is enrich the test suite with few additional cases for the badBoards. Would it make sense to you to add them?