### PR TITLE
space-age: update cases_test.go

### DIFF
--- a/exercises/space-age/cases_test.go
+++ b/exercises/space-age/cases_test.go
@@ -6,7 +6,7 @@ package space
 
 var testCases = []struct {
 	description string
-	planet      Planet
+	planet      string
 	seconds     float64
 	expected    float64
 }{


### PR DESCRIPTION
`Planet` is not defined as a type. Change it to be `string`.