### PR TITLE
robot-name: change test structure for bonus fix

### DIFF
--- a/exercises/robot-name/common_test.go
+++ b/exercises/robot-name/common_test.go
@@ -1,0 +1,26 @@
+package robotname
+
+import (
+	"regexp"
+	"testing"
+)
+
+var namePat = regexp.MustCompile(`^[A-Z]{2}\d{3}$`)
+var seen = map[string]int{}
+
+func New() *Robot { return new(Robot) }
+
+// getName is a test helper function to facilitate optionally checking for seen
+// robot names.
+func (r *Robot) getName(t testing.TB, expectSeen bool) string {
+	newName, err := r.Name()
+	if err != nil {
+		t.Fatalf("Name() returned unexpected error: %v", err)
+	}
+	_, chk := seen[newName]
+	if !expectSeen && chk {
+		t.Fatalf("Name %s reissued after %d robots.", newName, len(seen))
+	}
+	seen[newName] = 0
+	return newName
+}

--- a/exercises/robot-name/robot_name_test.go
+++ b/exercises/robot-name/robot_name_test.go
@@ -1,29 +1,10 @@
+// +build !bonus
+
 package robotname
 
 import (
-	"regexp"
 	"testing"
 )
-
-var namePat = regexp.MustCompile(`^[A-Z]{2}\d{3}$`)
-var seen = map[string]int{}
-
-func New() *Robot { return new(Robot) }
-
-// getName is a test helper function to facilitate optionally checking for seen
-// robot names.
-func (r *Robot) getName(t testing.TB, expectSeen bool) string {
-	newName, err := r.Name()
-	if err != nil {
-		t.Fatalf("Name() returned unexpected error: %v", err)
-	}
-	_, chk := seen[newName]
-	if !expectSeen && chk {
-		t.Fatalf("Name %s reissued after %d robots.", newName, len(seen))
-	}
-	seen[newName] = 0
-	return newName
-}
 
 func TestNameValid(t *testing.T) {
 	n := New().getName(t, false)


### PR DESCRIPTION
Bonus test fails on proposed test command - `go test -tags bonus`
It's happens because we are taking all available robot names in bonus test, so base test fails
I have changed test structure - moved common parts to separate file and added exclusion build tag to base tests, so running the command `go test -tags bonus` executes only bonus test.