### PR TITLE
clock: Correct test message (Subtract, not Add)

### DIFF
--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -89,7 +89,7 @@ func TestSubtractMinutesStringless(t *testing.T) {
 		}
 		want := New(wantHour, wantMin)
 		if got := New(a.h, a.m).Subtract(a.a); !reflect.DeepEqual(got, want) {
-			t.Fatalf("New(%d, %d).Add(%d) = %v, want %v",
+			t.Fatalf("New(%d, %d).Subtract(%d) = %v, want %v",
 				a.h, a.m, a.a, got, want)
 		}
 	}


### PR DESCRIPTION
Consider a student who is not quite ready to do `Subtract`, so the
student has `Subtract` return the same clock unaltered, then runs the
tests to see what happens. The student will see the following:

    --- FAIL: TestSubtractMinutesStringless (0.00s)
        clock_test.go:92: New(10, 3).Add(3) = 10:03, want 10:00

But it is not true that the test should want 10:00 after adding 3
minutes to 10:03. Instead, the test should want 10:00 after subtracting
3 minutes from 10:03.

This is also apparent from the name of the test,
TestSubtractMinutesStringless.