### PR TITLE
meetup: Rename type Weekschedule to WeekSchedule for consistency

### DIFF
--- a/exercises/meetup/meetup_test.go
+++ b/exercises/meetup/meetup_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 /* API
 package meetup
-type Weekschedule
+type WeekSchedule
 WeekSchedule First
 WeekSchedule Second
 WeekSchedule Third

--- a/exercises/robot-simulator/robot_simulator_test.go
+++ b/exercises/robot-simulator/robot_simulator_test.go
@@ -9,7 +9,7 @@ package robot
 //
 //    go test                      # run all tests
 //    go test -tags step1          # run just step 1 tests.
-//    go test -tags 'step1 step2'  # run step1 and step2 tests
+//    go test -tags step1,step2    # run step1 and step2 tests
 //
 // This source file contains step 1 tests only.  For other tests see
 // robot_simulator_step2_test.go and robot_simulator_step3_test.go.

--- a/exercises/robot-simulator/robot_simulator_test.go
+++ b/exercises/robot-simulator/robot_simulator_test.go
@@ -9,7 +9,7 @@ package robot
 //
 //    go test                      # run all tests
 //    go test -tags step1          # run just step 1 tests.
-//    go test -tags step1,step2    # run step1 and step2 tests
+//    go test -tags 'step1 step2'  # run step1 and step2 tests
 //
 // This source file contains step 1 tests only.  For other tests see
 // robot_simulator_step2_test.go and robot_simulator_step3_test.go.


### PR DESCRIPTION
The type WeekSchedule in the comment section of the meetup_test.go file
is misspelled as Weekschedule. When copying the API spec into the empty
metup.go, one has to fix this by hand. All other references to
WeekSchedule are correct.

Signed-off-by: Mariyan Dimitrov <mariyan.dimitrov@gmail.com>