### PR TITLE
space-age: add missing type in downloaded file

### DIFF
--- a/exercises/space-age/space_age.go
+++ b/exercises/space-age/space_age.go
@@ -1,1 +1,3 @@
 package space
+
+type Planet string


### PR DESCRIPTION
There was a missing declaration of type *Planet* in the stub file of the exercise **space-age**. Thus when running tests on downloaded exercise, the code failed to compile. This change fixes that issue.

See #1293 for more info.