### PR TITLE
two-bucket: add another unsolvable test case to bonus set

### DIFF
--- a/exercises/two-bucket/bonus_test.go
+++ b/exercises/two-bucket/bonus_test.go
@@ -13,6 +13,10 @@ var noSolutionCases = []bucketTestCase{
 		"No solution case 2",
 		3, 6, 1, "one", "", 0, 0, true,
 	},
+	{
+		"No solution case 3",
+		6, 8, 3, "one", "", 0, 0, true,
+	},
 }
 
 func TestSolve_bonus(t *testing.T) {


### PR DESCRIPTION
The existing two test cases can be addressed by checking that

```
if largerCapacity%smallerCapacity == 0 && goal%smallerCapacity != 0 {
```

but this is incomplete. the addition of this test case requires consideration of the GCD between values as in

```
       bucketsGcd := gcd(bucketOne, bucketTwo)
       if bucketsGcd > gcd(bucketsGcd, goal) {
```
(or an entirely different approach based on checking states within the main step-performing loop)