### PR TITLE
prime-factors: accept order-independent results

### DIFF
--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -9,7 +9,8 @@ import (
 func TestPrimeFactors(t *testing.T) {
 	for _, test := range tests {
 		actual := Factors(test.input)
-		sort.Sort(ascending(actual))
+		sort.Slice(actual, ascending(actual))
+		sort.Slice(test.expected, ascending(test.expected))
 		if !reflect.DeepEqual(actual, test.expected) {
 			t.Fatalf("FAIL %s\nFactors(%d) = %#v;\nexpected %#v",
 				test.description, test.input,
@@ -27,8 +28,8 @@ func BenchmarkPrimeFactors(b *testing.B) {
 	}
 }
 
-type ascending []int64
-
-func (l ascending) Len() int             { return len(l) }
-func (l ascending) Swap(ii, jj int)      { l[ii], l[jj] = l[jj], l[ii] }
-func (l ascending) Less(ii, jj int) bool { return l[ii] < l[jj] }
+func ascending(list []int64) func(int, int) bool {
+	return func(ii, jj int) bool {
+		return list[ii] < list[jj]
+	}
+}

--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -1,15 +1,15 @@
 package prime
 
-// Return prime factors in increasing order
-
 import (
 	"reflect"
+	"sort"
 	"testing"
 )
 
 func TestPrimeFactors(t *testing.T) {
 	for _, test := range tests {
 		actual := Factors(test.input)
+		sort.Sort(ascending(actual))
 		if !reflect.DeepEqual(actual, test.expected) {
 			t.Fatalf("FAIL %s\nFactors(%d) = %#v;\nexpected %#v",
 				test.description, test.input,
@@ -26,3 +26,9 @@ func BenchmarkPrimeFactors(b *testing.B) {
 		}
 	}
 }
+
+type ascending []int64
+
+func (l ascending) Len() int             { return len(l) }
+func (l ascending) Swap(ii, jj int)      { l[ii], l[jj] = l[jj], l[ii] }
+func (l ascending) Less(ii, jj int) bool { return l[ii] < l[jj] }

--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -29,7 +29,7 @@ func BenchmarkPrimeFactors(b *testing.B) {
 }
 
 func ascending(list []int64) func(int, int) bool {
-	return func(ii, jj int) bool {
-		return list[ii] < list[jj]
+	return func(i, j int) bool {
+		return list[i] < list[j]
 	}
 }


### PR DESCRIPTION
Fix #1295 

Simple sort implementation applied to the list of primes before testing for equality. 