### PR TITLE
bob: update cases to reflect more inclusive language

### DIFF
--- a/exercises/bob/cases_test.go
+++ b/exercises/bob/cases_test.go
@@ -1,8 +1,8 @@
 package bob
 
 // Source: exercism/problem-specifications
-// Commit: ca79943 Bob: Fix grammatical error in testdata (#1319)
-// Problem Specifications Version: 1.4.0
+// Commit: [33m1904e91[m Bob: Cleans up language on a couple of test cases
+// Problem Specifications Version: 1.5.0
 
 var testCases = []struct {
 	description string

--- a/exercises/bob/cases_test.go
+++ b/exercises/bob/cases_test.go
@@ -1,7 +1,7 @@
 package bob
 
 // Source: exercism/problem-specifications
-// Commit: [33m1904e91[m Bob: Cleans up language on a couple of test cases
+// Commit: 1904e91 Bob: Cleans up language on a couple of test cases
 // Problem Specifications Version: 1.5.0
 
 var testCases = []struct {

--- a/exercises/bob/cases_test.go
+++ b/exercises/bob/cases_test.go
@@ -41,7 +41,7 @@ var testCases = []struct {
 	},
 	{
 		"talking forcefully",
-		"Let's go make out behind the gym!",
+		"Hi there!",
 		"Whatever.",
 	},
 	{
@@ -51,7 +51,7 @@ var testCases = []struct {
 	},
 	{
 		"forceful question",
-		"WHAT THE HELL WERE YOU THINKING?",
+		"WHAT'S GOING ON?",
 		"Calm down, I know what I'm doing!",
 	},
 	{


### PR DESCRIPTION
This PR updates the `bob` cases to reflect more inclusive language that before. For details please see: https://github.com/exercism/problem-specifications/issues/1630