### PR TITLE
Added apostrophe test case

### DIFF
--- a/exercises/word-count/cases_test.go
+++ b/exercises/word-count/cases_test.go
@@ -69,4 +69,9 @@ var testCases = []struct {
 		",\n,one,\n ,two \n 'three'",
 		Frequency{"one": 1, "three": 1, "two": 1},
 	},
+	{
+		"multiple apostrophes treated as normal punctuation",
+		"''hey''",
+		Frequency{"hey": 1},
+	},
 }


### PR DESCRIPTION
This is a localized version of a change I discussed with the [main problem-specs repo](https://github.com/exercism/problem-specifications/pull/1628). They told me that, due to their lockdown, I should bring this to the language-specific repositories. 

Effectively, the problem states that contractions ("can't", "won't", etc.) should treat apostrophes as part of the word, but rule 3 states:

> 3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are ignored

As such, I've added a very simple case testing that normal apostrophes are removed. I have a Python solution that passes all other tests but fails this one. If requested, I can try to draft something up in Go that will help showcase the problem.

Thanks!