### PR TITLE
Set online editor config

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,10 @@
   "active": true,
   "blurb": "Go is a compiled, open source programming language with a small, consistent syntax, a powerful standard library, and fantastic tooling. It's a great fit for web backends and command-line tools.",
   "ignore_pattern": "example(?!.*test)",
+  "online_editor": {
+    "indent_style": "tab",
+    "indent_size": 4
+  },
   "exercises": [
     {
       "slug": "gigasecond",


### PR DESCRIPTION
Closes https://github.com/exercism/research_experiment_1/issues/102.

In the issue above, it has been suggested that Go should use tabs for spacing, with a width of 4 spaces. When this is merged, the online editor for Go in the research website should respect this setting.