### PR TITLE
Use %q to make white space differences visible

### DIFF
--- a/exercises/tournament/tournament_test.go
+++ b/exercises/tournament/tournament_test.go
@@ -117,7 +117,7 @@ func TestTallyHappy(t *testing.T) {
 				tt.description, err)
 		}
 		if actual != tt.expected {
-			t.Fatalf("Tally for input named %q was expected to return...\n%s\n...but returned...\n%s",
+			t.Fatalf("Tally for input named %q was expected to return...\n\n%q\n\n...but returned...\n\n%q",
 				tt.description, tt.expected, actual)
 		}
 	}


### PR DESCRIPTION
Some student complained that the tests failed but he couldn't see any
difference between "expected" and "actual".
After looking into the issue (by changing the %s to %q in this test), I
see that an extra "\n" was appended to the result, which is hard to tell
from the output.