### PR TITLE
Fix protein_translation_test

### DIFF
--- a/exercises/protein-translation/protein_translation_test.go
+++ b/exercises/protein-translation/protein_translation_test.go
@@ -1,6 +1,7 @@
 package protein
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -10,6 +11,9 @@ type codonCase struct {
 	expected      string
 	errorExpected error
 }
+
+var MockErrStop = errors.New("stop")
+var MockErrInvalidBase = errors.New("invalid base")
 
 var codonTestCases = []codonCase{
 	{
@@ -65,22 +69,22 @@ var codonTestCases = []codonCase{
 	{
 		"UAA",
 		"",
-		ErrStop,
+		MockErrStop,
 	},
 	{
 		"UAG",
 		"",
-		ErrStop,
+		MockErrStop,
 	},
 	{
 		"UGA",
 		"",
-		ErrStop,
+		MockErrStop,
 	},
 	{
 		"ABC",
 		"",
-		ErrInvalidBase,
+		MockErrInvalidBase,
 	},
 }
 


### PR DESCRIPTION
This PR creates mock variables for errors to compare with the returned error.

### Problem
Using the variable declared by the actual function may be a problem, because the error variable could be declared with nil value, making every test to pass, when they shouldn't.

### Issue
https://github.com/exercism/go/issues/1361