### PR TITLE
tournament_test: Integrate implicit type assertion to var declaration

### DIFF
--- a/exercises/tournament/tournament_test.go
+++ b/exercises/tournament/tournament_test.go
@@ -127,11 +127,10 @@ func TestTallyError(t *testing.T) {
 	for _, s := range errorTestCases {
 		reader := strings.NewReader(s)
 		var buffer bytes.Buffer
-		err := Tally(reader, &buffer)
+		var err error = Tally(reader, &buffer)
 		if err == nil {
 			t.Fatalf("Tally for input %q should have failed but didn't.", s)
 		}
-		var _ error = err
 	}
 }
 


### PR DESCRIPTION
The unnamed error variable was used to verify the function's return type. However, it's a bit confusing literally. Integrating it back to the variable declaration statement makes it clearer.