### PR TITLE
Changed a rectangles test case to check bottom edge too

### DIFF
--- a/exercises/rectangles/cases_test.go
+++ b/exercises/rectangles/cases_test.go
@@ -91,9 +91,9 @@ var testCases = []struct {
 			"    |",
 			"+-+-+",
 			"| | -",
-			"+-+-+",
+			"+|+-+",
 		},
-		expected: 1,
+		expected: 0,
 	},
 	{
 		description: "rectangles can be of different sizes",


### PR DESCRIPTION
I was able to pass tests without checking the bottom edge of rectangles.

This test case tweak ensures the bottom edge is checked.