### PR TITLE
variable_length_quantity: fix missing error handling in tests

### DIFF
--- a/exercises/variable-length-quantity/.meta/gen.go
+++ b/exercises/variable-length-quantity/.meta/gen.go
@@ -121,7 +121,7 @@ var encodeTestCases = []struct {
 var decodeTestCases = []struct {
 	description string
 	input			[]byte
-	output			[]uint32 // nil slice indicates error expected.
+	output			[]uint32
 	errorExpected	bool
 }{ {{range .J.Groups}} {{range .Cases}}
 	{{if .PropertyMatch "decode"}} {

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -15,8 +15,8 @@ func TestDecodeVarint(t *testing.T) {
 			if !tc.errorExpected {
 				t.Fatalf("FAIL: case %d | %s\nexpected %#v got error: %q\n", i, tc.description, tc.output, err)
 			}
-		case tc.output == nil:
-			t.Fatalf("FAIL: case %d | %s\nexpected error, got %#v\n", i, tc.description, o)
+		case tc.errorExpected && err == nil:
+			t.Fatalf("FAIL: case %d | %s\nexpected error, got %#v\n", i, tc.description, err)
 		case !reflect.DeepEqual(o, tc.output):
 			t.Fatalf("FAIL: case %d | %s\nexpected\t%#v\ngot\t\t%#v\n", i, tc.description, tc.output, o)
 		}


### PR DESCRIPTION
Remove old and misleading comment in gen.go

As no test result expects nil it should be safe to skip checking that and
handle when error is nil despite errorExpected is true.

Closes #1328