### PR TITLE
README: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ find low hanging typo problems. [#570](https://github.com/exercism/go/pull/570) 
 
 ## Contributing Guide
 
-Please be familiar with the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
+Please be familiar with the [contributing guide](https://github.com/exercism/legacy-docs/tree/main/contributing-to-language-tracks)
 in the docs repository.  This describes some great ways to get involved.
-In particular, please read the [Pull Request Guidelines](https://github.com/exercism/docs/blob/master/contributing/pull-request-guidelines.md) before opening a pull request.
+In particular, please read the [Pull Request Guidelines](https://github.com/exercism/legacy-docs/blob/main/contributing/pull-request-guidelines.md) before opening a pull request.
 
 ## Exercism Go style
 


### PR DESCRIPTION
I see that those are legacy documentation, but it is better than broken links I think.