### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/anonymous-functions/about.md
+++ b/concepts/anonymous-functions/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on anonymous-functions concept

--- a/concepts/anonymous-functions/introduction.md
+++ b/concepts/anonymous-functions/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for anonymous-functions concept

--- a/concepts/application-timing/about.md
+++ b/concepts/application-timing/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on application-timing concept

--- a/concepts/application-timing/introduction.md
+++ b/concepts/application-timing/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for application-timing concept

--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -1,3 +1,5 @@
+# About
+
 Booleans in Go are represented by the `bool` type, which values can be either `true` or `false`.
 
 Go supports three [boolean operators][logical operators]: `!` (NOT), `&&` (AND), and `||` (OR).

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Go supports the three logical operators `&&` (AND), `||` (OR), and `!` (NOT).
 
 Conditionals in Go are similar to conditionals in other languages. The underlying type of any conditional operation is the `bool` type, which can have the value of `true` or `false`. Conditionals are often used as flow control mechanisms to check for various conditions. For checking a particular case an `if` statement can be used, which executes its code if the underlying condition is `true` like this:

--- a/concepts/bytes/about.md
+++ b/concepts/bytes/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on bytes concept

--- a/concepts/bytes/introduction.md
+++ b/concepts/bytes/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for bytes concept

--- a/concepts/channels/about.md
+++ b/concepts/channels/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on channels concept

--- a/concepts/channels/introduction.md
+++ b/concepts/channels/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for channels concept

--- a/concepts/comments/about.md
+++ b/concepts/comments/about.md
@@ -1,3 +1,5 @@
+# About
+
 Go supports two types of [comments][comments]. Single line comments are preceded by `//` and multiline comments are inserted between `/*` and `*/`.
 
 ## Documentation comments

--- a/concepts/comments/introduction.md
+++ b/concepts/comments/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 In the previous exercise, we saw that there are two ways to write comments in Go: single-line comments that are preceded by `//`, and multiline comment blocks that are wrapped with `/*` and `*/`.

--- a/concepts/conditionals-if/about.md
+++ b/concepts/conditionals-if/about.md
@@ -1,3 +1,5 @@
+# About
+
 Conditionals in Go are similar to conditionals in other languages. The underlying type of any conditional operation is the `bool` type, which can have the value of `true` or `false`. Conditionals are often used as flow control mechanisms to check for various conditions. For checking a particular case an [`if` statement][if_statement] can be used, which executes its code if the underlying condition is `true` like this:
 
 ```go

--- a/concepts/conditionals-if/introduction.md
+++ b/concepts/conditionals-if/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 ## conditionals-if

--- a/concepts/conditionals-switch/about.md
+++ b/concepts/conditionals-switch/about.md
@@ -1,3 +1,5 @@
+# About
+
 Go also provides a [`switch` statement][switch_statement] for more advanced scenarios. It can be used to switch on a variable's content or as a replacement for `if ... else if` statements. There is a third application for `switch` statements which will be introduced later: the `type switch`. A switch statement can have a `default` case which is executed if no other case applies.
 
 If there are three or more cases in a single `if` (e.g. `if ... else if ... else`), it should be replaced by a `switch` statement. A `switch` with a single case should be replaced by an `if` statement.

--- a/concepts/conditionals-switch/introduction.md
+++ b/concepts/conditionals-switch/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 ## conditionals-if

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -1,6 +1,6 @@
 # About
 
-### Type Conversion
+## Type Conversion
 
 For more information on Type Conversion please see
 [A Tour of Go: Type Conversions][type-conversion]

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -1,3 +1,5 @@
+# About
+
 ### Type Conversion
 
 For more information on Type Conversion please see

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Go contains basic numeric types that can represent sets of either integer or
 floating-point values. There a different types depending on the size of value
 you require and the architecture of the computer where the application is

--- a/concepts/constants/about.md
+++ b/concepts/constants/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on constants concept

--- a/concepts/constants/introduction.md
+++ b/concepts/constants/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 In Go, a constant is a simple, unchanging value assigned to a name with the `const` keyword:

--- a/concepts/context/about.md
+++ b/concepts/context/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on context concept

--- a/concepts/context/introduction.md
+++ b/concepts/context/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for context concept

--- a/concepts/defer/about.md
+++ b/concepts/defer/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on defer concept

--- a/concepts/defer/introduction.md
+++ b/concepts/defer/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for defer concept

--- a/concepts/duration/about.md
+++ b/concepts/duration/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on duration concept

--- a/concepts/duration/introduction.md
+++ b/concepts/duration/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for duration concept

--- a/concepts/empty-interface/about.md
+++ b/concepts/empty-interface/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on empty-interface concept

--- a/concepts/empty-interface/introduction.md
+++ b/concepts/empty-interface/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for empty-interface concept

--- a/concepts/errors-handling/about.md
+++ b/concepts/errors-handling/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on errors-handling concept

--- a/concepts/errors-handling/introduction.md
+++ b/concepts/errors-handling/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for errors-handling concept

--- a/concepts/errors/about.md
+++ b/concepts/errors/about.md
@@ -1,4 +1,4 @@
-## Errors
+# Errors
 
 References to append:
 

--- a/concepts/errors/introduction.md
+++ b/concepts/errors/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 An `error` is a built-in interface type in the Go language.
 
 In other languages, whether or not a function will throw an exception is unknown.

--- a/concepts/floating-point/about.md
+++ b/concepts/floating-point/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on floating-point concept

--- a/concepts/floating-point/introduction.md
+++ b/concepts/floating-point/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for floating-point concept

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -1,3 +1,5 @@
+# About
+
 Functions in Go are considered [first class citizens][first-class-functions] making them very powerful. They can be used as:
 
 - [public and private][public-vs-private] functions of a package

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 ## packages

--- a/concepts/goroutines/about.md
+++ b/concepts/goroutines/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on goroutines concept

--- a/concepts/goroutines/introduction.md
+++ b/concepts/goroutines/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for goroutines concept

--- a/concepts/interfaces/about.md
+++ b/concepts/interfaces/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on interfaces concept

--- a/concepts/interfaces/introduction.md
+++ b/concepts/interfaces/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for interfaces concept

--- a/concepts/iteration/about.md
+++ b/concepts/iteration/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on iteration concept

--- a/concepts/iteration/introduction.md
+++ b/concepts/iteration/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for iteration concept

--- a/concepts/maps/about.md
+++ b/concepts/maps/about.md
@@ -1,3 +1,5 @@
+# About
+
 In go, `map` is a built-in data type that represent hash table. In other programming language, you might know map as `dict` or associative array or a key/value store. If you're not familiar with such concept, map you can think `map` like a dictionary, which every word is the `key` and the definition is the `element` of the map.
 
 > Before we begin, I'd like to point you to [go spec for map][gospec-map] and [go blog for map][goblog-map] to dig further into `map`.

--- a/concepts/maps/introduction.md
+++ b/concepts/maps/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In go, `map` is a built-in data type that maps keys to values. In other programming language, you might be familiar with the concept of `map` as a dictionary, hash table, key/value store or an associative array.
 
 Syntactically, `map` looks like this:

--- a/concepts/methods/about.md
+++ b/concepts/methods/about.md
@@ -1,3 +1,5 @@
+# About
+
 A [method][methods] is a function with a special _receiver_ argument. The receiver appears in its own argument list between `func` keyword and the name of the method.
 
 ```go

--- a/concepts/methods/introduction.md
+++ b/concepts/methods/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A [method][methods] is a function with a special _receiver_ argument. The receiver appears in its own argument list between `func` keyword and the name of the method.
 
 ```go

--- a/concepts/mutex/about.md
+++ b/concepts/mutex/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on mutex concept

--- a/concepts/mutex/introduction.md
+++ b/concepts/mutex/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for mutex concept

--- a/concepts/nil/about.md
+++ b/concepts/nil/about.md
@@ -1,4 +1,4 @@
-## Zero Values
+# Zero Values
 
 Unlike some other languages, Go has no empty/null/undefined state for uninitialized variables. Every type has a [zero value][zero_values] that uninitialized variables will hold upon declaration.
 

--- a/concepts/nil/introduction.md
+++ b/concepts/nil/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go, uninitialized variables and their elements are given default values.
 
 These default values are called the zero values for their respective types:

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -1,6 +1,6 @@
 # About
 
-### Type Conversion
+## Type Conversion
 
 For more information on Type Conversion please see
 [A Tour of Go: Type Conversions][type-conversion]

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -1,3 +1,5 @@
+# About
+
 ### Type Conversion
 
 For more information on Type Conversion please see

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 ## numbers

--- a/concepts/packages/about.md
+++ b/concepts/packages/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Go an application is organized in packages. A package is a collection of source files located in the same folder. All source files in a folder must have the same package name at the top of the file. The package is preferred to be the same as the folder it is located in.
 
 ```go

--- a/concepts/packages/introduction.md
+++ b/concepts/packages/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 ## packages

--- a/concepts/panic/about.md
+++ b/concepts/panic/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on panic concept

--- a/concepts/panic/introduction.md
+++ b/concepts/panic/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for panic concept

--- a/concepts/pointers/about.md
+++ b/concepts/pointers/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on pointers concept

--- a/concepts/pointers/introduction.md
+++ b/concepts/pointers/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for pointers concept

--- a/concepts/range-iteration/about.md
+++ b/concepts/range-iteration/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on range-iteration concept

--- a/concepts/range-iteration/introduction.md
+++ b/concepts/range-iteration/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for range-iteration concept

--- a/concepts/recover/about.md
+++ b/concepts/recover/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on recover concept

--- a/concepts/recover/introduction.md
+++ b/concepts/recover/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for recover concept

--- a/concepts/reflection/about.md
+++ b/concepts/reflection/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on reflection concept

--- a/concepts/reflection/introduction.md
+++ b/concepts/reflection/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for reflection concept

--- a/concepts/runes/about.md
+++ b/concepts/runes/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on runes concept

--- a/concepts/runes/introduction.md
+++ b/concepts/runes/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for runes concept

--- a/concepts/select/about.md
+++ b/concepts/select/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on select concept

--- a/concepts/select/introduction.md
+++ b/concepts/select/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for select concept

--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -1,3 +1,5 @@
+# About
+
 ## Indexes in slices
 
 Working with indexes of slices should always be protected in some way by a check that makes sure the index actually exists.

--- a/concepts/slices/introduction.md
+++ b/concepts/slices/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Slices in Go are similar to lists or arrays in other languages. They hold a number of elements of a specific type (or interface).
 
 Slices in Go are based on arrays. Arrays have a fixed size. A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.

--- a/concepts/strings-package/about.md
+++ b/concepts/strings-package/about.md
@@ -1,3 +1,5 @@
+# About
+
 ### Source code encoding
 
 Source code files in Go are always `UTF-8` encoded. This makes it very easy to use special characters in strings.

--- a/concepts/strings-package/about.md
+++ b/concepts/strings-package/about.md
@@ -1,5 +1,5 @@
 # About
 
-### Source code encoding
+## Source code encoding
 
 Source code files in Go are always `UTF-8` encoded. This makes it very easy to use special characters in strings.

--- a/concepts/strings-package/introduction.md
+++ b/concepts/strings-package/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `string` in Go is a sequence of `bytes`, which doesn't necessarily have to represent characters.
 That being said, `UTF-8` is a central part of `strings` in Go. It is easy to convert a string to `runes` (`UTF-8` characters) or iterate over `runes` in a string.
 This makes dealing with different languages or other special characters in Go very simple.

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -1,3 +1,5 @@
+# About
+
 A `string` in Go is an immutable sequence of bytes. Strings may contain arbitrary bytes but usually they contain human-readable text.
 Text strings are conventionally interpreted as UTF-8 encoded sequence of Unicode code points (runes) which will be explained in a future exercise.
 A `string` value can be written as a string literal, which is a sequence of bytes enclosed in double quotes:

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `string` in Go is an immutable sequence of bytes. Strings may contain arbitrary bytes but usually they contain human-readable text.
 Text strings are conventionally interpreted as UTF-8 encoded sequence of Unicode code points (runes) which will be explained in a future exercise.
 A `string` value can be written as a string literal, which is a sequence of bytes enclosed in double quotes:

--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Go, a `struct` is a sequence of named elements called _fields_, each field having a name and type. The name of a field must be unique within the struct. `Structs` can be compared with the _class_ in the Object Oriented Programming paradigm.
 
 You create a new struct by using the `struct` keyword and explicty define the name and type of the fields as shown in the example below. An `empty struct` is a struct with all fields set to their own zero values.

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go, a `struct` is a sequence of named elements called _fields_, each field having a name and type. The name of a field must be unique within the struct. `Structs` can be compared with the _class_ in the Object Oriented Programming paradigm.
 
 You create a new struct by using the `struct` keyword, a **_built-in type_**, and explicty define the name and type of the fields as shown in the example below.

--- a/concepts/time/about.md
+++ b/concepts/time/about.md
@@ -1,3 +1,5 @@
+# About
+
 A [`Time`][time] in Go is a type describing a moment in time. The date and time information can be accessed, compared, and manipulated through its methods, but there are also some functions called on the `time` package itself. The current date and time can be retrieved through the [`time.Now`][now] function.
 
 The [`time.Parse`][parse] function parses strings into `Time` types using the particular format string `Mon Jan 2 15:04:05 -0700 MST 2006`. More on how this works can be found [here][article].

--- a/concepts/time/introduction.md
+++ b/concepts/time/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go, functionality for working with times is provided by the `time` package. The types and methods in this package allow us to manipulate times, get the current time, determine elapsed time, parse times from strings, and more.
 
 To work with time, you will usually call a method on a `Time` instance, but there are also some functions called on the `time` package itself.

--- a/concepts/type-assertion/about.md
+++ b/concepts/type-assertion/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on type-assertion concept

--- a/concepts/type-assertion/introduction.md
+++ b/concepts/type-assertion/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for type-assertion concept

--- a/concepts/type-conversion/about.md
+++ b/concepts/type-conversion/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on type-conversion concept

--- a/concepts/type-conversion/introduction.md
+++ b/concepts/type-conversion/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for type-conversion concept

--- a/concepts/variables/about.md
+++ b/concepts/variables/about.md
@@ -1,3 +1,5 @@
+# About
+
 Go is a statically-typed language, which means that everything has a type at compile-time. Assigning a value to a name is referred to as defining a variable. A variable can be defined either by explicitly specifying its type, or by assigning a value to have the Go compiler infer its type based on the assigned value.
 
 ```go

--- a/concepts/variables/about.md
+++ b/concepts/variables/about.md
@@ -17,7 +17,7 @@ count = 2  // Update to new value
 // count = false
 ```
 
-### Integers
+## Integers
 
 TODO: decide what to do with this section
 

--- a/concepts/variables/introduction.md
+++ b/concepts/variables/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go an application is organized in packages. A package is a collection of source files located in the same folder. All source files in a folder must have the same package name at the top of the file. The package name is preferred to be the same as the folder it is located in.
 
 ```go

--- a/concepts/zero-value/about.md
+++ b/concepts/zero-value/about.md
@@ -1,4 +1,4 @@
-## Zero Values
+# Zero Values
 
 Unlike some other languages, Go has no empty/null/undefined state for uninitialized variables. Every type has a [zero value][zero_values] that uninitialized variables will hold upon declaration.
 

--- a/concepts/zero-value/introduction.md
+++ b/concepts/zero-value/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 ## zero-value

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Fans of Go (called *gophers*) describe Go as having the expressiveness of dynamic languages like Python or Ruby, with the performance of compiled languages like C or C++.
 
 The language is open source, and was started by engineers at Google.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 Follow the instructions for your system on the installation page at [golang.org](http://golang.org/doc/install).
 
 Exercism supports Go 1.2 and higher.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Go for the first time. These resources can help you get started:
 
 * [A Tour of Go](http://tour.golang.org)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -4,11 +4,11 @@ There are many great free online resources to help you get started with Go inclu
 * [How to Write Go Code](https://golang.org/doc/code.html)
 * [Effective Go](https://golang.org/doc/effective_go.html)
 
-### Books
+## Books
 * [Go Bootcamp](http://www.golangbootcamp.com/book/)
 
-### Blogposts
+## Blogposts
 * [Resources for new Go programmers](http://dave.cheney.net/resources-for-new-go-programmers)
 
-### Organizations
+## Organizations
 * [GoBridge](http://golangbridge.org)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 There are many great free online resources to help you get started with Go including:
 * [How to Write Go Code](https://golang.org/doc/code.html)
 * [Effective Go](https://golang.org/doc/effective_go.html)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -7,11 +7,11 @@ $ cd exercism/project/directory/go/leap
 $ go test
 ```
 
-### Running benchmarks
+## Running benchmarks
 
 Most exercises contain benchmarks, that you can use to determine how changes to your solution affect its performance. To run the benchmarks for an exercise use the command `go test -v --bench . --benchmem` inside the exercise directory.
 
-### Testable examples
+## Testable examples
 
 [Example tests](https://blog.golang.org/examples) are used in some exercises and
 are run alongside the standard exercise tests. These examples are used for

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Go exercises within your exercism project directory can be run by changing to the exercise directory, and running `go test`.
 
 ```bash

--- a/exercises/concept/basics/.docs/hints.md
+++ b/exercises/concept/basics/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - An [integer value][integers] can be defined as one or more consecutive digits.

--- a/exercises/concept/basics/.docs/instructions.md
+++ b/exercises/concept/basics/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 You have four tasks, all related to the time spent cooking the lasagna.

--- a/exercises/concept/basics/.docs/introduction.md
+++ b/exercises/concept/basics/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Packages
 
 ## Functions

--- a/exercises/concept/basics/.meta/design.md
+++ b/exercises/concept/basics/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in Go.

--- a/exercises/concept/booleans/.docs/hints.md
+++ b/exercises/concept/booleans/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - There are three [boolean operators][logical operators] to work with boolean values.

--- a/exercises/concept/booleans/.docs/instructions.md
+++ b/exercises/concept/booleans/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you'll be implementing the quest logic for a new RPG game a friend is developing. The game's main character is Annalyn, a brave girl with a fierce and loyal pet dog. Unfortunately, disaster strikes, as her best friend was kidnapped while searching for berries in the forest. Annalyn will try to find and free her best friend, optionally taking her dog with her on this quest.
 
 After some time spent following her best friend's trail, she finds the camp in which her best friend is imprisoned. It turns out there are two kidnappers: a mighty knight and a cunning archer.

--- a/exercises/concept/booleans/.docs/introduction.md
+++ b/exercises/concept/booleans/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Booleans in Go are represented by the predeclared boolean type `bool`, which values can be either `true` or `false`.
 It's a defined type.
 

--- a/exercises/concept/booleans/.meta/design.md
+++ b/exercises/concept/booleans/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `bool` type and its two values.

--- a/exercises/concept/comments/.docs/hints.md
+++ b/exercises/concept/comments/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - A [documentation comment][comment] should be written directly before the entity that it is describing, start with the name of what it is describing, take the form of a sentence, and end with a period.

--- a/exercises/concept/comments/.docs/instructions.md
+++ b/exercises/concept/comments/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, your task is to help a weather station manage their weather forecasting program.
 
 ## 1. Document package weather

--- a/exercises/concept/comments/.docs/introduction.md
+++ b/exercises/concept/comments/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In the previous exercise, we saw that there are two ways to write comments in Go: single-line comments that are preceded by `//`, and multiline comment blocks that are wrapped with `/*` and `*/`.
 
 ## Documentation comments

--- a/exercises/concept/comments/.meta/design.md
+++ b/exercises/concept/comments/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the rules about comments in Go.

--- a/exercises/concept/conditionals/.docs/hints.md
+++ b/exercises/concept/conditionals/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 Conditionals are used to check for certain conditions and/or criteria. The most basic way of performing a conditional operation is using a single `if` statement.

--- a/exercises/concept/conditionals/.docs/instructions.md
+++ b/exercises/concept/conditionals/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise we will simulate the first turn of a [Blackjack](https://en.wikipedia.org/wiki/Blackjack) game.
 
 You will receive two cards and will be able to see the face up card of the dealer. All cards are represented using a string such as "ace", "king", "three", "two", etc. The values of each card are:

--- a/exercises/concept/conditionals/.docs/introduction.md
+++ b/exercises/concept/conditionals/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Conditionals If
 
 ## Conditionals Switch

--- a/exercises/concept/conditionals/.meta/design.md
+++ b/exercises/concept/conditionals/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Conditionals in Go.

--- a/exercises/concept/constants/.docs/after.md
+++ b/exercises/concept/constants/.docs/after.md
@@ -1,3 +1,5 @@
+# After
+
 Constants in Go are simple, [unchanging values][const] created with the `const` keyword. Constants may be given an explicit type:
 
 ```go

--- a/exercises/concept/constants/.docs/hints.md
+++ b/exercises/concept/constants/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - [Constants][const]

--- a/exercises/concept/constants/.docs/instructions.md
+++ b/exercises/concept/constants/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you will establish some constants to be used in the operation of a bank.
 
 You have five tasks:

--- a/exercises/concept/constants/.docs/introduction.md
+++ b/exercises/concept/constants/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go, a constant is a simple, unchanging value assigned to a name with the `const` keyword:
 
 ```go

--- a/exercises/concept/constants/.meta/design.md
+++ b/exercises/concept/constants/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student about constants in Go.

--- a/exercises/concept/errors/.docs/hints.md
+++ b/exercises/concept/errors/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## Errors
 
 ## Hints to write:

--- a/exercises/concept/errors/.docs/instructions.md
+++ b/exercises/concept/errors/.docs/instructions.md
@@ -1,4 +1,4 @@
-## Errors
+# Errors
 
 In this exercise, we will be implementing the programming logic in a package `deepthought`,
 which checks whether an input equals to the absolute answer to life, the universe and everything.

--- a/exercises/concept/errors/.docs/introduction.md
+++ b/exercises/concept/errors/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 An `error` is a built-in interface type in the Go language.
 
 In other languages, whether or not a function will throw an exception is unknown.

--- a/exercises/concept/maps/.docs/hints.md
+++ b/exercises/concept/maps/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - [Go by example map][gobyexample-map]

--- a/exercises/concept/maps/.docs/instructions.md
+++ b/exercises/concept/maps/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 A friend of you has an old wholesale store called **Gross Store**, the name came from the quantity of the item that the store sell, it's all in [gross unit][gross-unit]. Your friend asked you to implement a point of sale (POS) system for his store, **but first, you want to build a prototype for it, in your prototype, your system will only record the quantity**. Your friend gave you a list of measurements to help you:
 
 | Unit               | Score |

--- a/exercises/concept/maps/.docs/introduction.md
+++ b/exercises/concept/maps/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In go, `map` is a built-in data type that maps keys to values. In other programming language, you might be familiar with the concept of `map` as a dictionary, hash table, key/value store or an associative array.
 
 Syntactically, `map` looks like this:

--- a/exercises/concept/maps/.meta/design.md
+++ b/exercises/concept/maps/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal is to introduce the student to maps.

--- a/exercises/concept/methods/.docs/hints.md
+++ b/exercises/concept/methods/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Drive a car
 
 - Add a field to the `Car` struct that keeps track of the driven distance

--- a/exercises/concept/methods/.docs/instructions.md
+++ b/exercises/concept/methods/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Note: This exercise is a continuation of the `structs` exercise.
 
 In this exercise you'll be organizing races between various types of remote controlled cars. Each car has its own speed and battery drain characteristics.

--- a/exercises/concept/methods/.docs/introduction.md
+++ b/exercises/concept/methods/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A [method][methods] is a function with a special _receiver_ argument. The receiver appears in its own argument list between `func` keyword and the name of the method.
 
 ```go

--- a/exercises/concept/methods/.meta/design.md
+++ b/exercises/concept/methods/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student about `methods` in Go.

--- a/exercises/concept/numbers/.docs/hints.md
+++ b/exercises/concept/numbers/.docs/hints.md
@@ -1,4 +1,4 @@
-## Arithmetic Operators in Go
+# Arithmetic Operators in Go
 
 Below shows the set of arithmetic operators available in Go in use:
 

--- a/exercises/concept/numbers/.docs/instructions.md
+++ b/exercises/concept/numbers/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be writing code to analyse the production of an
 assembly line in a car factory. The assembly line's speed can range from `0`
 (off) to `10` (maximum).

--- a/exercises/concept/numbers/.docs/introduction.md
+++ b/exercises/concept/numbers/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Numbers
 
 ## Conditionals

--- a/exercises/concept/numbers/.meta/design.md
+++ b/exercises/concept/numbers/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student how to deal with numbers in Go.

--- a/exercises/concept/slices/.docs/hints.md
+++ b/exercises/concept/slices/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - slices in Go are zero-based. The first index in a slice is `0`.

--- a/exercises/concept/slices/.docs/instructions.md
+++ b/exercises/concept/slices/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 As a magician-to-be, Elyse needs to practice some basics. She has a stack of cards that she wants to manipulate.
 
 To make things a bit easier she only uses the cards 1 to 10.

--- a/exercises/concept/slices/.docs/introduction.md
+++ b/exercises/concept/slices/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Slices in Go are similar to lists or arrays in other languages. They hold a number of elements of a specific type (or interface).
 
 Slices in Go are based on arrays. Arrays have a fixed size. A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.

--- a/exercises/concept/slices/.meta/design.md
+++ b/exercises/concept/slices/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the basics on how to work with slices in Go.

--- a/exercises/concept/strings-package/.docs/hints.md
+++ b/exercises/concept/strings-package/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Strings in Go are based on `[]byte`. For example getting a substring works the same as getting a subslice.

--- a/exercises/concept/strings-package/.docs/instructions.md
+++ b/exercises/concept/strings-package/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be processing log-lines.
 
 Each log line is a string formatted as follows: `"[<LEVEL>]: <MESSAGE>"`.

--- a/exercises/concept/strings-package/.docs/introduction.md
+++ b/exercises/concept/strings-package/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `string` in Go is a sequence of `bytes`, which doesn't necessarily have to represent characters.
 That being said, `UTF-8` is a central part of `strings` in Go. It is easy to convert a string to `runes` (`UTF-8` characters) or iterate over `runes` in a string.
 This makes dealing with different languages or other special characters in Go very simple.

--- a/exercises/concept/strings-package/.meta/design.md
+++ b/exercises/concept/strings-package/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student about the strings package.

--- a/exercises/concept/strings/.docs/instructions.md
+++ b/exercises/concept/strings/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Once there was an eccentric programmer living in a strange house with barred windows.
 One day he accepted a job from an online job board to build a party robot. The
 robot is supposed to greet people and help them to their seats. The first edition

--- a/exercises/concept/strings/.docs/introduction.md
+++ b/exercises/concept/strings/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 A `string` in Go is an immutable sequence of bytes. Strings may contain arbitrary bytes but usually they contain human-readable text.
 Text strings are conventionally interpreted as UTF-8 encoded sequence of Unicode code points (runes) which will be explained in a future exercise.
 A `string` value can be written as a string literal, which is a sequence of bytes enclosed in double quotes:

--- a/exercises/concept/strings/.meta/design.md
+++ b/exercises/concept/strings/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the basics on `strings` in Go. Focusses on formatting.

--- a/exercises/concept/structs/.docs/hints.md
+++ b/exercises/concept/structs/.docs/hints.md
@@ -1,4 +1,4 @@
-## General
+# General
 
 A `struct` is a sequence of named elements, called fields, each one having a name and a type.
 

--- a/exercises/concept/structs/.docs/hints.md
+++ b/exercises/concept/structs/.docs/hints.md
@@ -2,22 +2,22 @@
 
 A `struct` is a sequence of named elements, called fields, each one having a name and a type.
 
-### 1. Creating a new remote controlled car
+## 1. Creating a new remote controlled car
 
 - Instantiate a new [struct][struct] and fill the fields except `distance`.
 - Create a function that returns the type of the newly created struct and update the fields accordingly
 
-### 2. Creating a race track
+## 2. Creating a race track
 
 - Define a new [struct][struct] with 1 field
 - Create a function that returns the type of the new created struct and updates the fields accordingly
 
-### 3. Drive the car
+## 3. Drive the car
 
 - Add a new field to keep track of the distance driven
 - You need to check if there is enough battery to drive the car
 
-### 4. Check if a remote controlled car can finish a race
+## 4. Check if a remote controlled car can finish a race
 
 - You need to calculate the maximum distance a car can drive
 - We assume that the cars' battery is charged to 100% initially

--- a/exercises/concept/structs/.docs/instructions.md
+++ b/exercises/concept/structs/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be organizing races between various types of remote controlled cars. Each car has its own speed and battery drain characteristics.
 
 Cars start with full (100%) batteries. Each time you drive the car using the remote control, it covers the car's speed in meters and decreases the remaining battery percentage by its battery drain.

--- a/exercises/concept/structs/.docs/introduction.md
+++ b/exercises/concept/structs/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go, a `struct` is a sequence of named elements called _fields_, each field having a name and type. The name of a field must be unique within the struct. `Structs` can be compared with the _class_ in the Object Oriented Programming paradigm.
 
 You create a new struct by using the `struct` keyword, a **_built-in type_**, and explicty define the name and type of the fields as shown in the example below.

--- a/exercises/concept/structs/.meta/design.md
+++ b/exercises/concept/structs/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what `structs` are

--- a/exercises/concept/time/.docs/hints.md
+++ b/exercises/concept/time/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - [Use the methods found in the time package.][time]

--- a/exercises/concept/time/.docs/instructions.md
+++ b/exercises/concept/time/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be working on an appointment scheduler for a beauty salon that opened on September 15th in 2012.
 
 You have five tasks, which will all involve appointment dates.

--- a/exercises/concept/time/.docs/introduction.md
+++ b/exercises/concept/time/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Go, functionality for working with times is provided by the `time` package. The types and methods in this package allow us to manipulate times, get the current time, determine elapsed time, parse times from strings, and more.
 
 To work with time, you will usually call a method on a `Time` instance, but there are also some functions called on the `time` package itself.

--- a/exercises/concept/time/.meta/design.md
+++ b/exercises/concept/time/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student how to use time in Go.

--- a/exercises/concept/zero-value/.docs/hints.md
+++ b/exercises/concept/zero-value/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - To [return][returns] a value from a function in Go, use the keyword `return` followed by the value:

--- a/exercises/concept/zero-value/.docs/instructions.md
+++ b/exercises/concept/zero-value/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, we will write some simple functions that return zero values for various Go types. Some types
 you might not have seen before. They will be introduced in detail in later exercises.
 

--- a/exercises/concept/zero-value/.docs/introduction.md
+++ b/exercises/concept/zero-value/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Zero Value
 
 ## Nil

--- a/exercises/concept/zero-value/.meta/design.md
+++ b/exercises/concept/zero-value/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student about `nil` and other zero values.

--- a/exercises/practice/accumulate/.meta/description.md
+++ b/exercises/practice/accumulate/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Implement the `accumulate` operation, which, given a collection and an
 operation to perform on each element of the collection, returns a new
 collection containing the result of applying that operation to each element of

--- a/exercises/practice/all-your-base/.docs/instructions.append.md
+++ b/exercises/practice/all-your-base/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Assumptions:
 1. Zero is always represented in outputs as [0] instead of [].

--- a/exercises/practice/alphametics/.docs/instructions.append.md
+++ b/exercises/practice/alphametics/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Define a single Go func, Solve, which accepts a puzzle string which may have zero
 or more + operators, and one == operator; Solve should attempt to solve the alphametics puzzle

--- a/exercises/practice/book-store/.docs/instructions.append.md
+++ b/exercises/practice/book-store/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Define a single Go func, Cost, which calculates the cost
 for a given list of books based on the defined discounts.

--- a/exercises/practice/dominoes/.docs/instructions.append.md
+++ b/exercises/practice/dominoes/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Define a single Go func, MakeChain, which accepts a slice
 of dominoes and attempts to construct a legal chain of dominoes.

--- a/exercises/practice/error-handling/.docs/instructions.append.md
+++ b/exercises/practice/error-handling/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 Testing for specific error types may be performed by
 [type assertions](https://golang.org/ref/spec#Type_assertions). You may also
 need to look at

--- a/exercises/practice/error-handling/.meta/description.md
+++ b/exercises/practice/error-handling/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Implement various kinds of error handling and resource management.
 
 An important point of programming is how to handle errors and close resources

--- a/exercises/practice/grep/.docs/instructions.append.md
+++ b/exercises/practice/grep/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 In package grep, Define a single Go func, Search, which accepts a pattern string,
 a slice of flags which are strings, and a slice of filename strings.

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 You may be wondering about the `cases_test.go` file. We explain it in the
 [leap exercise][leap-exercise-readme].
 

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 You will see a `cases_test.go` file in this exercise. This holds the test
 cases used in the `leap_test.go`. You can mostly ignore this file.
 

--- a/exercises/practice/linked-list/.meta/description.md
+++ b/exercises/practice/linked-list/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Implement a doubly linked list.
 
 Like an array, a linked list is a simple linear data structure. Several

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Implementation
 
 You should define a custom type 'DNA' with a function 'Counts' that outputs two values: 

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Concurrency vs Parallelism
 
 Go supports concurrency via "[goroutines](https://golangbot.com/goroutines/)"

--- a/exercises/practice/perfect-numbers/.docs/instructions.append.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Define
 ```type Classification```

--- a/exercises/practice/phone-number/.meta/description.md
+++ b/exercises/practice/phone-number/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Clean up user-entered phone numbers so that they can be sent SMS messages.
 
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.

--- a/exercises/practice/poker/.docs/instructions.append.md
+++ b/exercises/practice/poker/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 Your function will receive an array of strings. Each string represents
 a hand composed of 5 cards separated by spaces. A card is represented
 by a number and its suit.

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Simple Stub
+# Simple Stub
 
 The raindrops.go "stub file" contains only one line with the correct
 package name and nothing more.  This will be the usual pattern for future

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-### Bonus exercise
+## Bonus exercise
 
 Once you get `go test` passing, try `go test -tags bonus`.  This uses a *build
 tag* to enable a test that wasn't previously enabled. Build tags control which

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ### Bonus exercise
 
 Once you get `go test` passing, try `go test -tags bonus`.  This uses a *build

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Define two functions: (Two? Yes, sometimes we ask more out of Go.)
 

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -16,7 +16,7 @@ But wait, maybe you ask a reasonable question: Why is the function
 called **Unsafe** First?  If you are interested, read on for a bonus
 exercise.
 
-### Bonus exercise:
+## Bonus exercise:
 
 Once you get `go test` passing, try `go test -tags asktoomuch`.  This
 uses a *build tag* to enable a test that wasn't enabled before. Build

--- a/exercises/practice/simple-cipher/.docs/instructions.append.md
+++ b/exercises/practice/simple-cipher/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 The definition of the Cipher interface is located in
 [cipher.go](./cipher.go).

--- a/exercises/practice/simple-cipher/.meta/description.md
+++ b/exercises/practice/simple-cipher/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Implement a simple shift cipher like Caesar and a more secure
 substitution cipher.
 

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Simple Stub
 
 The space_age.go "stub file" contains only one line with the correct

--- a/exercises/practice/tree-building/.meta/description.md
+++ b/exercises/practice/tree-building/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Some web-forums have a tree layout, so posts are presented as a tree. However
 the posts are typically stored in a database as an unsorted set of records. Thus
 when presenting the posts to the user the tree structure has to be

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Constant Declarations
+# Constant Declarations
 
 In this exercise you are asked to declare a series of constants used to identify
 different types of triangles. Pick the data type you think works best for this

--- a/exercises/practice/two-bucket/.docs/instructions.append.md
+++ b/exercises/practice/two-bucket/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 In package twobucket, implement a Go func, Solve, with
 the following signature:

--- a/exercises/practice/two-bucket/.docs/instructions.append.md
+++ b/exercises/practice/two-bucket/.docs/instructions.append.md
@@ -18,7 +18,7 @@ Solve should also return an error when a solution cannot be found,
 but this error relates only to the bonus exercise below, so you may
 ignore that error case for your initial solution.
 
-### Bonus exercise
+## Bonus exercise
 
 Once you get `go test` passing, try `go test -tags bonus`.  This uses a *build
 tag* to enable tests that were not previously enabled. Build tags control which

--- a/exercises/practice/zebra-puzzle/.docs/instructions.append.md
+++ b/exercises/practice/zebra-puzzle/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Implementation
+# Implementation
 
 Define a single function, SolvePuzzle, which returns a solution
 containing two strings, whose values are the answers to the

--- a/reference/defer.md
+++ b/reference/defer.md
@@ -4,7 +4,7 @@ In Go the `defer` statement defers the execution of a function until the surroun
 The deferred call's arguments are evaluated immediately, but the function call is not executed until the surrounding function returns.
 This is a very simple, yet very powerful concept enabling clean code and preventing a lot of bugs from happening in the first place.
 
-### Without Defer
+## Without Defer
 
 In this example all data is being read from a file with a typical read loop. Then the file needs to be closed.
 In this case that means calling `f.Close` in 3 different places.
@@ -48,7 +48,7 @@ If the function needs extending possibly with another case that returns early,
 the developer has to remember to call `f.Close` in that case as well or the file descriptor will not be closed.
 This is a typical example where `defer` makes the code cleaner and easier to maintain, thereby preventing future bugs.
 
-### Using Defer
+## Using Defer
 
 The defer statement is used right after the file was opened successfully. First the error needs to be checked in case
 `os.Open` failed and then `defer f.Close()` is used to make sure the file is closed when the function returns -
@@ -90,7 +90,7 @@ func readFile(file string) ([]byte, error) {
 Extending this function with more functionality does not require to think about closing the file any more.
 That has been taken care of.
 
-### Pro Tip
+## Pro Tip
 
 The trick of using `defer` successfully lies in scoping functions accordingly.
 If defer does not fit in, restructuring should be considered.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
