### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/booleans/.meta/config.json
+++ b/exercises/concept/booleans/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for booleans exercise",
   "authors": [
-    {
-      "github_username": "oanaOM",
-      "exercism_username": "oanaOM"
-    }
+    "oanaOM"
   ],
   "forked_from": [
     "csharp/booleans"

--- a/exercises/concept/chessboard/.meta/config.json
+++ b/exercises/concept/chessboard/.meta/config.json
@@ -1,19 +1,21 @@
 {
   "authors": [
-    {
-      "github_username": "brugnara",
-      "exercism_username": "brugnara"
-    },
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "brugnara",
+    "tehsphinx"
   ],
   "contributors": [],
-  "forked_from": ["Elixir/chessboard"],
+  "forked_from": [
+    "Elixir/chessboard"
+  ],
   "files": {
-    "solution": ["chessboard.go"],
-    "test": ["chessboard_test.go"],
-    "exemplar": [".meta/exemplar.go"]
+    "solution": [
+      "chessboard.go"
+    ],
+    "test": [
+      "chessboard_test.go"
+    ],
+    "exemplar": [
+      ".meta/exemplar.go"
+    ]
   }
 }

--- a/exercises/concept/comments/.meta/config.json
+++ b/exercises/concept/comments/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for comments exercise",
   "authors": [
-    {
-      "github_username": "nikimanoledaki",
-      "exercism_username": "niki-01"
-    }
+    "nikimanoledaki"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/conditionals/.meta/config.json
+++ b/exercises/concept/conditionals/.meta/config.json
@@ -1,15 +1,10 @@
 {
   "blurb": "TODO: add blurb for conditionals exercise",
   "authors": [
-    {
-      "github_username": "andres-zartab"
-    }
+    "andres-zartab"
   ],
   "contributors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "forked_from": [],
   "files": {

--- a/exercises/concept/constants/.meta/config.json
+++ b/exercises/concept/constants/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for constants exercise",
   "authors": [
-    {
-      "github_username": "jamessouth",
-      "exercism_username": "jamessouth"
-    }
+    "jamessouth"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/errors/.meta/config.json
+++ b/exercises/concept/errors/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for errors exercise",
   "authors": [
-    {
-      "github_username": "micuffaro",
-      "exercism_username": "micuffaro"
-    }
+    "micuffaro"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for lasagna exercise",
   "authors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "contributors": [
-    {
-      "github_username": "ekingery",
-      "exercism_username": "ekingery"
-    }
+    "ekingery"
   ],
   "forked_from": [
     "csharp/lucians-luscious-lasagna"

--- a/exercises/concept/maps/.meta/config.json
+++ b/exercises/concept/maps/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for maps exercise",
   "authors": [
-    {
-      "github_username": "chocopowwwa",
-      "exercism_username": "chocopowwwa"
-    }
+    "chocopowwwa"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/methods/.meta/config.json
+++ b/exercises/concept/methods/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for methods exercise",
   "authors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "contributors": [
-    {
-      "github_username": "oanaOM",
-      "exercism_username": "oanaOM"
-    }
+    "oanaOM"
   ],
   "forked_from": [
     "csharp/classes"

--- a/exercises/concept/numbers/.meta/config.json
+++ b/exercises/concept/numbers/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for numbers exercise",
   "authors": [
-    {
-      "github_username": "DavyJ0nes",
-      "exercism_username": "DavyJ0nes"
-    }
+    "DavyJ0nes"
   ],
   "contributors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/slices/.meta/config.json
+++ b/exercises/concept/slices/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for slices exercise",
   "authors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/strings-package/.meta/config.json
+++ b/exercises/concept/strings-package/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for strings-package exercise",
   "authors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/strings/.meta/config.json
+++ b/exercises/concept/strings/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for strings exercise",
   "authors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "contributors": [
-    {
-      "github_username": "oanaOM",
-      "exercism_username": "oanaOM"
-    }
+    "oanaOM"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/structs/.meta/config.json
+++ b/exercises/concept/structs/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for structs exercise",
   "authors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "contributors": [
-    {
-      "github_username": "oanaOM",
-      "exercism_username": "oanaOM"
-    }
+    "oanaOM"
   ],
   "forked_from": [
     "csharp/constructors"

--- a/exercises/concept/the-farm/.meta/config.json
+++ b/exercises/concept/the-farm/.meta/config.json
@@ -1,15 +1,18 @@
 {
   "authors": [
-    {
-      "github_username": "brugnara",
-      "exercism_username": "brugnara"
-    }
+    "brugnara"
   ],
   "contributors": [],
   "forked_from": [],
   "files": {
-    "solution": ["the_farm.go"],
-    "test": ["the_farm_test.go"],
-    "exemplar": [".meta/exemplar.go"]
+    "solution": [
+      "the_farm.go"
+    ],
+    "test": [
+      "the_farm_test.go"
+    ],
+    "exemplar": [
+      ".meta/exemplar.go"
+    ]
   }
 }

--- a/exercises/concept/time/.meta/config.json
+++ b/exercises/concept/time/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for time exercise",
   "authors": [
-    {
-      "github_username": "jamessouth",
-      "exercism_username": "jamessouth"
-    }
+    "jamessouth"
   ],
   "forked_from": [
     "csharp/datetimes"

--- a/exercises/concept/zero-value/.meta/config.json
+++ b/exercises/concept/zero-value/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "TODO: add blurb for zero-value exercise",
   "authors": [
-    {
-      "github_username": "jamessouth",
-      "exercism_username": "jamessouth"
-    }
+    "jamessouth"
   ],
   "contributors": [
-    {
-      "github_username": "tehsphinx",
-      "exercism_username": "tehsphinx"
-    }
+    "tehsphinx"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
