### PR TITLE
robot_name: Add checks for name length in tests

### DIFF
--- a/exercises/practice/robot-name/bonus_test.go
+++ b/exercises/practice/robot-name/bonus_test.go
@@ -7,16 +7,23 @@ import "testing"
 var maxNames = 26 * 26 * 10 * 10 * 10
 
 func TestCollisions(t *testing.T) {
+	var name string
 	// Test uniqueness for new robots.
 	for i := len(seen); i <= maxNames-600000; i++ {
-		_ = New().getName(t, false)
+		name = New().getName(t, false)
+		if len(name) != 5 {
+			t.Fatalf("names should have 5 characters: name '%s' has %d character(s)", name, len(name))
+		}
 	}
 
 	// Test that names aren't recycled either.
 	r := New()
 	for i := len(seen); i < maxNames; i++ {
 		r.Reset()
-		_ = r.getName(t, false)
+		name = r.getName(t, false)
+		if len(name) != 5 {
+			t.Fatalf("names should have 5 characters: name '%s' has %d character(s)", name, len(name))
+		}
 	}
 
 	// Test that name exhaustion is handled more or less correctly.

--- a/exercises/practice/robot-name/common_test.go
+++ b/exercises/practice/robot-name/common_test.go
@@ -18,6 +18,10 @@ func (r *Robot) getName(t testing.TB, expectSeen bool) string {
 	if err != nil {
 		t.Fatalf("Name() returned unexpected error: %v", err)
 	}
+	if len(newName) != 5 {
+		t.Fatalf("names should have 5 characters: name '%s' has %d character(s)", newName, len(newName))
+	}
+
 	_, chk := seen[newName]
 	if !expectSeen && chk {
 		t.Fatalf("Name %s reissued after %d robots.", newName, len(seen))


### PR DESCRIPTION
The problem description states that names should have 5 characters:

> The first time you boot them up, a random name is generated in the format of two uppercase letters followed by three digits, such as RX837 or BC811.

However, it is possible to have solutions passing both the normal tests and the bonus ones that do not respect this rule, like this solution [robot_name.zip](https://github.com/exercism/go/files/6444309/robot_name.zip)

This PR adds those checks both to the regular tests and the bonus ones. From the solutions I've tested, these checks seem to have no major impact on how long the tests take to run.

Another thing that we probably should also verify is that the name actually starts with 2 letters and 3 digits. Probably we can include this check only in the regular tests, just so we don't impact the performance of the bonus tests too much.
