### PR TITLE
🤖 Add labels append file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,80 @@
+- name: "README/discrepancy"
+  description: ""
+  color: "d93f0b"
+
+- name: "README/inadequate"
+  description: ""
+  color: "d93f0b"
+
+- name: "bug"
+  description: ""
+  color: "fc2929"
+
+- name: "dependencies"
+  description: "Pull requests that update a dependency file"
+  color: "0366d6"
+
+- name: "duplicate"
+  description: ""
+  color: "cccccc"
+
+- name: "enhancement"
+  description: ""
+  color: "84b6eb"
+
+- name: "good first issue"
+  description: ""
+  color: "7057ff"
+
+- name: "hacktoberfest"
+  description: ""
+  color: "cc8744"
+
+- name: "help wanted"
+  description: ""
+  color: "5319e7"
+
+- name: "in-progress"
+  description: ""
+  color: "9FDB12"
+
+- name: "invalid"
+  description: ""
+  color: "e6e6e6"
+
+- name: "on hold"
+  description: ""
+  color: "d4c5f9"
+
+- name: "per-exercise"
+  description: ""
+  color: "0052cc"
+
+- name: "pinned"
+  description: ""
+  color: "fef2c0"
+
+- name: "problem-spec"
+  description: "Needs updating to pass updated problem specifications"
+  color: "0846af"
+
+- name: "question"
+  description: ""
+  color: "cc317c"
+
+- name: "test suite"
+  description: ""
+  color: "f9d0c4"
+
+- name: "v3"
+  description: ""
+  color: "13B0D1"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"
+
+- name: "wontfix"
+  description: ""
+  color: "ffffff"
+


### PR DESCRIPTION
This PR adds a `.appends/.github/labels.yml` file, which contains all the labels that are currently used in this repo. The `.github/labels.yml` file will contain the full list of labels that this repo can use, which will be a combination of the `.appends/.github/labels.yml` file and a centrally-managed `labels.yml` file.

We'll automatically sync any changes, which allows us to guarantee that all the track repositories will have a pre-determined set of labels, augmented with any custom labels defined in the `.appends/.github/labels.yml` file. This syncing will be done by another (automatically-synced) workflow, which we will add in a later PR.

## Tracking

https://github.com/exercism/v3-launch/issues/41