### PR TITLE
Luhn: A new test case with odd number of digits

### DIFF
--- a/exercises/practice/luhn/cases_test.go
+++ b/exercises/practice/luhn/cases_test.go
@@ -85,6 +85,11 @@ var testCases = []struct {
 		true,
 	},
 	{
+		"valid number with an odd number of digits and non-zero first digit",
+		"109",
+		true,
+	},
+	{
 		"using ascii value for non-doubled non-digit isn't allowed",
 		"055b 444 285",
 		false,


### PR DESCRIPTION
A new positive test case with odd number of digits and non-zero first digit.
I have seen a solution which passes all the tests for Luhn containing odd number of digits and never reads the first digit.
It happens because in all such cases the first digit is zero .