### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello_world.go
+++ b/exercises/practice/hello-world/hello_world.go
@@ -1,15 +1,6 @@
-// This is a "stub" file.  It's a little start on your solution.
-// It's not a complete solution though; you have to write some code.
-
-// Package greeting should have a package comment that summarizes what it's about.
-// https://golang.org/doc/effective_go.html#commentary
 package greeting
 
-// HelloWorld should have a comment documenting it.
+// HelloWorld greets the world.
 func HelloWorld() string {
-	// Write some code here to pass the test suite.
-	// Then remove all the stock comments.
-	// They're here to help you get started but they only clutter a finished solution.
-	// If you leave them in, reviewers may protest!
-	return ""
+	return "Goodbye, Mars!"
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46