### PR TITLE
Fix matrix test variable type

### DIFF
--- a/exercises/practice/matrix/.meta/example.go
+++ b/exercises/practice/matrix/.meta/example.go
@@ -11,7 +11,7 @@ import (
 
 type Matrix [][]int
 
-func New(s string) (Matrix, error) {
+func New(s string) (*Matrix, error) {
 	var err error
 	lines := strings.Split(s, "\n")
 	m := make(Matrix, len(lines))
@@ -28,7 +28,7 @@ func New(s string) (Matrix, error) {
 		}
 		m[i] = row
 	}
-	return m, nil
+	return &m, nil
 }
 
 func (m *Matrix) Set(row, col, val int) (ok bool) {

--- a/exercises/practice/matrix/matrix_test.go
+++ b/exercises/practice/matrix/matrix_test.go
@@ -271,7 +271,7 @@ func BenchmarkNew(b *testing.B) {
 	if testing.Short() {
 		b.Skip("skipping benchmark in short mode.")
 	}
-	var matrix Matrix
+	var matrix *Matrix
 	for i := 0; i < b.N; i++ {
 		var err error
 		matrix, err = New("1 2 3 10 11\n4 5 6 11 12\n7 8 9 12 13\n 8 7 6 13 14")


### PR DESCRIPTION
In the matrix exercise, the function New is expected to return a tuple with the types `*Matrix, error`.
However, in the `BenchmarkNew` test, the matrix variable defined a variable of type `Matrix`. It causes compilation errors due to type mismatch. 

This PR proposes a test code fix. It is also related to other open PR #1431.

Thanks.