### PR TITLE
wordy add check of using default 0 minus number

### DIFF
--- a/exercises/practice/wordy/cases_test.go
+++ b/exercises/practice/wordy/cases_test.go
@@ -150,4 +150,10 @@ var tests = []wordyTest{
 		false,
 		0,
 	},
+	{
+		"reject using default 0 minus number",
+		"What is minus 10?",
+		false,
+		0,
+	},
 }


### PR DESCRIPTION
Some solutions use 0 as the default value. The added test case can reject this scenario.