### PR TITLE
Fix analyns infiltration description

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/exemplar.go
+++ b/exercises/concept/annalyns-infiltration/.meta/exemplar.go
@@ -15,7 +15,7 @@ func CanSignalPrisoner(archerIsAwake, prisonerIsAwake bool) bool {
 	return !archerIsAwake && prisonerIsAwake
 }
 
-// CanFreePrisoner can be executed if prisoner is awake and the other 3 characters are asleep
+// CanFreePrisoner can be executed if prisoner is awake and the other 2 characters are asleep
 // or if Annalyn's pet dog is with her and the archer is sleeping
 func CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent bool) bool {
 	return !knightIsAwake && !archerIsAwake && prisonerIsAwake || !archerIsAwake && petDogIsPresent

--- a/exercises/concept/annalyns-infiltration/.meta/exemplar.go
+++ b/exercises/concept/annalyns-infiltration/.meta/exemplar.go
@@ -10,12 +10,12 @@ func CanSpy(knightIsAwake, archerIsAwake, prisonerIsAwake bool) bool {
 	return knightIsAwake || archerIsAwake || prisonerIsAwake
 }
 
-// CanSignalPrisoner can be executed if prisoner is awake and the archer is sleeping
+// CanSignalPrisoner can be executed if the prisoner is awake and the archer is sleeping
 func CanSignalPrisoner(archerIsAwake, prisonerIsAwake bool) bool {
 	return !archerIsAwake && prisonerIsAwake
 }
 
-// CanFreePrisoner can be executed if prisoner is awake and the other 2 characters are asleep
+// CanFreePrisoner can be executed if the prisoner is awake and the other 2 characters are asleep
 // or if Annalyn's pet dog is with her and the archer is sleeping
 func CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent bool) bool {
 	return !knightIsAwake && !archerIsAwake && prisonerIsAwake || !archerIsAwake && petDogIsPresent

--- a/exercises/concept/annalyns-infiltration/annalyns_infiltration.go
+++ b/exercises/concept/annalyns-infiltration/annalyns_infiltration.go
@@ -10,12 +10,12 @@ func CanSpy(knightIsAwake, archerIsAwake, prisonerIsAwake bool) bool {
 	panic("Please implement the CanSpy() function")
 }
 
-// CanSignalPrisoner can be executed if prisoner is awake and the archer is sleeping
+// CanSignalPrisoner can be executed if the prisoner is awake and the archer is sleeping
 func CanSignalPrisoner(archerIsAwake, prisonerIsAwake bool) bool {
 	panic("Please implement the CanSignalPrisoner() function")
 }
 
-// CanFreePrisoner can be executed if prisoner is awake and the other 2 characters are asleep
+// CanFreePrisoner can be executed if the prisoner is awake and the other 2 characters are asleep
 // or if Annalyn's pet dog is with her and the archer is sleeping
 func CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent bool) bool {
 	panic("Please implement the CanFreePrisoner() function")

--- a/exercises/concept/annalyns-infiltration/annalyns_infiltration.go
+++ b/exercises/concept/annalyns-infiltration/annalyns_infiltration.go
@@ -15,7 +15,7 @@ func CanSignalPrisoner(archerIsAwake, prisonerIsAwake bool) bool {
 	panic("Please implement the CanSignalPrisoner() function")
 }
 
-// CanFreePrisoner can be executed if prisoner is awake and the other 3 characters are asleep
+// CanFreePrisoner can be executed if prisoner is awake and the other 2 characters are asleep
 // or if Annalyn's pet dog is with her and the archer is sleeping
 func CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent bool) bool {
 	panic("Please implement the CanFreePrisoner() function")


### PR DESCRIPTION
The comment of the function `CanFreePrisoner` talks about "the prisoner [...] and the other 3 characters". But there are only two other characters.

I also took the opportunity to add missing articles to make the comments more consistent ("the prisoner", "the archer", and "the knight").