### PR TITLE
fix fmt.printf example at strings indtroduction

### DIFF
--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -15,6 +15,6 @@ In Go floating point values are conveniently printed with Printf's verbs: `%g` (
 
 ```go
 f := 4.3242
-fmt.Printf("%.4", f)
+fmt.Printf("%.2f", f)
 // Output: 4.32
 ```


### PR DESCRIPTION
Fixed a fit.printf typo inside the example at the end of strings introduction. Provided example didn't work, now it does according to expected commented output