### PR TITLE
party-robot go.mod using wrong module

### DIFF
--- a/exercises/concept/party-robot/go.mod
+++ b/exercises/concept/party-robot/go.mod
@@ -1,3 +1,3 @@
-module strings
+module partyrobot
 
 go 1.13


### PR DESCRIPTION
`module string` is incorrect and thus `go test` is not running tests properly. 
Switched to `module partyrobot` based off `packack partyrobot` in party_robot.go