### PR TITLE
Fixing Test / Main Packaging

### DIFF
--- a/exercises/concept/cars-assemble/cars_assemble_test.go
+++ b/exercises/concept/cars-assemble/cars_assemble_test.go
@@ -1,7 +1,6 @@
 package cars
 
 import (
-	"numbers"
 	"testing"
 )
 
@@ -40,7 +39,7 @@ func TestCalculateProductionRatePerHour(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := numbers.CalculateProductionRatePerHour(tt.speed)
+			got := CalculateProductionRatePerHour(tt.speed)
 			if got != tt.want {
 				t.Errorf(
 					"CalculateProductionRatePerHour(%d) = %f, want %f",
@@ -88,7 +87,7 @@ func TestCalculateProductionRatePerMinute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := numbers.CalculateProductionRatePerMinute(tt.speed)
+			got := CalculateProductionRatePerMinute(tt.speed)
 			if got != tt.want {
 				t.Errorf(
 					"CalculateWorkingItemsRate(%d) = %d, want %d",


### PR DESCRIPTION
Test seems to expect the 'system under test' to be in a numbers package, but it's in a `cars` package, same as the test -- when working on this locally, the simplest thing seemed to be to remove the import and drop the qualified method names, which was in keeping with the way `savings-account` was written. There are other paths, but this is simple.