### PR TITLE
cars-assemble: Compare floats with threshold in test

### DIFF
--- a/exercises/concept/cars-assemble/cars_assemble_test.go
+++ b/exercises/concept/cars-assemble/cars_assemble_test.go
@@ -1,8 +1,11 @@
 package cars
 
 import (
+	"math"
 	"testing"
 )
+
+const FloatEqualityThreshold = 1e-9
 
 func TestCalculateProductionRatePerHour(t *testing.T) {
 	tests := []struct {
@@ -40,7 +43,7 @@ func TestCalculateProductionRatePerHour(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CalculateProductionRatePerHour(tt.speed)
-			if got != tt.want {
+			if math.Abs(got-tt.want) > FloatEqualityThreshold {
 				t.Errorf(
 					"CalculateProductionRatePerHour(%d) = %f, want %f",
 					tt.speed,


### PR DESCRIPTION
Split from https://github.com/exercism/go/pull/1510
On my machine tests failed because of a very small float difference, this is doing a more robust float comparison