### PR TITLE
Update doc links

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -5,7 +5,7 @@ Fans of Go (called *gophers*) describe Go as having the expressiveness of dynami
 The language is open source, and was started by engineers at Google.
 It's written using a C-style syntax, has statically typed variables, manages memory using garbage collection, and is compiled into stand-alone executables.
 
-Go is noted for the [concurrent programming features](https://golang.org/doc/effective_go.html#concurrency) built into the language core, the networking packages in the standard library ([such as a web server](https://golang.org/pkg/net/http/)), fast compilation and execution speed.
-Its simple, minimalistic and consistent language design make for a delightful experience, while the abundant and thoughtful tooling addresses traditional problems such as [consistent formatting](https://godoc.org/github.com/golang/go/src/cmd/gofmt) and [documentation](http://godoc.org/golang.org/x/tools/cmd/godoc).
+Go is noted for the [concurrent programming features](https://golang.org/doc/effective_go.html#concurrency) built into the language core, the networking packages in the standard library ([such as a web server](https://pkg.go.dev/net/http)), fast compilation and execution speed.
+Its simple, minimalistic and consistent language design make for a delightful experience, while the abundant and thoughtful tooling addresses traditional problems such as [consistent formatting](https://pkg.go.dev/cmd/gofmt?utm_source=godoc) and [documentation](https://pkg.go.dev/golang.org/x/tools/cmd/godoc?utm_source=godoc).
 
 The home page for Go is [golang.org](https://golang.org/), and there is an excellent interactive tutorial at [tour.golang.org](https://tour.golang.org/).

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -6,6 +6,6 @@ The language is open source, and was started by engineers at Google.
 It's written using a C-style syntax, has statically typed variables, manages memory using garbage collection, and is compiled into stand-alone executables.
 
 Go is noted for the [concurrent programming features](https://golang.org/doc/effective_go.html#concurrency) built into the language core, the networking packages in the standard library ([such as a web server](https://pkg.go.dev/net/http)), fast compilation and execution speed.
-Its simple, minimalistic and consistent language design make for a delightful experience, while the abundant and thoughtful tooling addresses traditional problems such as [consistent formatting](https://pkg.go.dev/cmd/gofmt?utm_source=godoc) and [documentation](https://pkg.go.dev/golang.org/x/tools/cmd/godoc?utm_source=godoc).
+Its simple, minimalistic and consistent language design make for a delightful experience, while the abundant and thoughtful tooling addresses traditional problems such as [consistent formatting](https://pkg.go.dev/cmd/gofmt) and [documentation](https://pkg.go.dev/golang.org/x/tools/cmd/godoc).
 
 The home page for Go is [golang.org](https://golang.org/), and there is an excellent interactive tutorial at [tour.golang.org](https://tour.golang.org/).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -6,7 +6,7 @@ Exercism provides exercises and feedback but can be difficult to jump into for t
 * [Go By Example](https://gobyexample.com/)
 * [Effective Go](https://golang.org/doc/effective_go.html)
 * [Go Language Specification](http://golang.org/ref/spec)
-* [Go Standard Library](http://golang.org/pkg/)
+* [Go Standard Library](https://pkg.go.dev/std)
 * [Go Resources](http://golang.org/help)
 * [StackOverflow](http://stackoverflow.com/questions/tagged/go)
 * [Awesome Go](https://github.com/avelino/awesome-go): [E-Books](https://github.com/avelino/awesome-go#e-books) and [Tutorials](https://github.com/avelino/awesome-go#tutorials)

--- a/exercises/shared/.docs/cli.md
+++ b/exercises/shared/.docs/cli.md
@@ -10,7 +10,7 @@ Once none of the tests are skipped and they are all passing, you can submit your
 For further reading there is an introduction to [testing in Go][testing-in-go] including on how to write tests yourself.
 
 [docs-go-test]: https://golang.org/cmd/go/#hdr-Test_packages
-[docs-exercism-cli]: https://exercism.io/cli
+[docs-exercism-cli]: https://exercism.org/docs/using/solving-exercises/working-locally
 [docs-run-unit-tests-visual-studio-code]: https://code.visualstudio.com/docs/languages/go#_test
 [docs-run-unit-tests-goland]: https://www.jetbrains.com/help/go/performing-tests.html
 [testing-in-go]: ../../../reference/testing.md

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -6,6 +6,6 @@ When a test fails, a message is displayed describing what went wrong and for whi
 fmt.Println("Debug message")
 ```
 
-[fmt-println]: https://golang.org/pkg/fmt/#Println
+[fmt-println]: https://pkg.go.dev/fmt#Println
 
 Note: When debugging with the in-browser editor, using e.g. `fmt.Print` will not add a newline after the output which can provoke a bug in `go test --json` and result in messed up test output.


### PR DESCRIPTION
Fixes #1483 

I found most of the documentation to be up-to-date. The only thing worth changing was some links, https://pkg.go.dev is the new home for package documentation in go, replacing the old https://golang.org/pkg. Although old links redirect properly, it's probably best to have the right links directly listed.

I did the same for a reference to exercism.io and converted it to the right link on exercism.org. 