### PR TITLE
elons-toys: remove unnecessary dependency from go.mod

### DIFF
--- a/exercises/concept/elons-toys/go.mod
+++ b/exercises/concept/elons-toys/go.mod
@@ -2,4 +2,3 @@ module elon
 
 go 1.13
 
-require github.com/google/go-cmp v0.5.3


### PR DESCRIPTION
This dependency is not being used and so it's best to remove it.

This extra dependency is causing the test runner to fail:

```console
$ go test -json .
go: github.com/google/go-cmp@v0.5.3: missing go.sum entry; to add it:
        go mod download github.com/google/go-cmp
go: github.com/google/go-cmp@v0.5.3: missing go.sum entry; to add it:
        go mod download github.com/google/go-cmp
```

Removing the dependency from `go.mod` solves the issue and makes the tests run as expected.