### PR TITLE
Fix configlet lint issues

### DIFF
--- a/concepts/anonymous-functions/.meta/config.json
+++ b/concepts/anonymous-functions/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/application-timing/.meta/config.json
+++ b/concepts/application-timing/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/bytes/.meta/config.json
+++ b/concepts/bytes/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/channels/.meta/config.json
+++ b/concepts/channels/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/conditionals/.meta/config.json
+++ b/concepts/conditionals/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/context/.meta/config.json
+++ b/concepts/context/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/defer/.meta/config.json
+++ b/concepts/defer/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/duration/.meta/config.json
+++ b/concepts/duration/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/empty-interface/.meta/config.json
+++ b/concepts/empty-interface/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/floating-point/.meta/config.json
+++ b/concepts/floating-point/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/functions/.meta/config.json
+++ b/concepts/functions/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/goroutines/.meta/config.json
+++ b/concepts/goroutines/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/interfaces/.meta/config.json
+++ b/concepts/interfaces/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/iteration/.meta/config.json
+++ b/concepts/iteration/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/mutex/.meta/config.json
+++ b/concepts/mutex/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/nil/.meta/config.json
+++ b/concepts/nil/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/packages/.meta/config.json
+++ b/concepts/packages/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/panic/.meta/config.json
+++ b/concepts/panic/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/pointers/.meta/config.json
+++ b/concepts/pointers/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/recover/.meta/config.json
+++ b/concepts/recover/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/reflection/.meta/config.json
+++ b/concepts/reflection/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/runes/.meta/config.json
+++ b/concepts/runes/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/slices/.meta/config.json
+++ b/concepts/slices/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/type-assertion/.meta/config.json
+++ b/concepts/type-assertion/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/type-conversion/.meta/config.json
+++ b/concepts/type-conversion/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/variables/.meta/config.json
+++ b/concepts/variables/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/concepts/zero-values/.meta/config.json
+++ b/concepts/zero-values/.meta/config.json
@@ -1,5 +1,5 @@
 {
   "blurb": "TODO: add blurb",
-  "authors": [],
+  "authors": ["ErikSchierboom"],
   "contributors": []
 }

--- a/config.json
+++ b/config.json
@@ -1806,6 +1806,11 @@
       "uuid": "82cff17e-88cd-4707-a6d7-b5143251f029"
     },
     {
+      "name": "Range Iteration",
+      "slug": "range-iteration",
+      "uuid": "8f644992-59ec-4fff-8b40-36b5ed61404d"
+    },
+    {
       "name": "Slices",
       "slug": "slices",
       "uuid": "23e1c40a-300c-4a44-bc32-f3440a057216"


### PR DESCRIPTION
Addresses the configlet lint issues from #1485

Namely: one missing slug and a bunch of empty author entries.