### PR TITLE
Fixed the formatting verb in printing floating point

### DIFF
--- a/exercises/concept/party-robot/.docs/introduction.md
+++ b/exercises/concept/party-robot/.docs/introduction.md
@@ -15,6 +15,6 @@ In Go floating point values are conveniently printed with Printf's verbs: `%g` (
 
 ```go
 f := 4.3242
-fmt.Printf("%.4", f)
+fmt.Printf("%.2f", f)
 // Output: 4.32
 ```


### PR DESCRIPTION
There was a syntax error and wrong width specified in the example to print floating point numbers. Fixed it.