### PR TITLE
annalyn-infiltration: add uses of 'true' and 'false' to examples

### DIFF
--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md
@@ -4,7 +4,9 @@ Booleans in Go are represented by the predeclared boolean type `bool`, which val
 It's a defined type.
 
 ```go
-var a bool
+var closed bool    // boolean variable 'closed' implicitly initialized with 'false'
+speeding := true   // boolean variable 'speeding' initialized with 'true'
+hasError := false  // boolean variable 'hasError' initialized with 'false' 
 ```
 
 Go supports three logical operators that can evaluate expressions down to Boolean values, returning either `true` or `false`.


### PR DESCRIPTION
Fixes: #1553 