### PR TITLE
Fix the typo in the test output function name

### DIFF
--- a/exercises/concept/annalyns-infiltration/annalyns_infiltration_test.go
+++ b/exercises/concept/annalyns-infiltration/annalyns_infiltration_test.go
@@ -241,7 +241,7 @@ func TestCanFreePrisoner(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if got := CanFreePrisoner(tt.knightIsAwake, tt.archerIsAwake, tt.prisonerIsAwake, tt.dogIsPresent); got != tt.expected {
-				t.Errorf("CanSignalPrisoner(%v,%v,%v,%v) = %v; want %v", tt.knightIsAwake, tt.archerIsAwake, tt.prisonerIsAwake, tt.dogIsPresent, got, tt.expected)
+				t.Errorf("CanFreePrisoner(%v,%v,%v,%v) = %v; want %v", tt.knightIsAwake, tt.archerIsAwake, tt.prisonerIsAwake, tt.dogIsPresent, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
The output of 'CanFreePrisoner' tests has the wrong function name mentioned. Correcting it so that the test outputs are not confusing.