### PR TITLE
Have card-tricks only use int type

### DIFF
--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -9,7 +9,7 @@ To make things a bit easier she only uses the cards 1 to 10.
 Return the card at position `index` from the given stack.
 
 ```go
-GetItem([]uint8{1, 2, 4, 1}, 2)
+GetItem([]int{1, 2, 4, 1}, 2)
 // Output: 4
 ```
 
@@ -21,8 +21,8 @@ Note that this will also change the input slice which is ok.
 ```go
 index := 2
 new_card := 6
-SetItem([]uint8{1, 2, 4, 1}, index, new_card)
-// Output: []uint8{1, 2, 6, 1}
+SetItem([]int{1, 2, 4, 1}, index, new_card)
+// Output: []int{1, 2, 6, 1}
 ```
 
 ## 3. Create a stack of cards

--- a/exercises/concept/card-tricks/.meta/design.md
+++ b/exercises/concept/card-tricks/.meta/design.md
@@ -27,7 +27,7 @@ The goal of this exercise is to teach the student the basics on how to work with
 ## Prerequisites
 
 - `iteration`: fill a slice (Not yet available: `range iteration`)
-- `numbers`: integers (uint8 and int) to represent cards
+- `numbers`: integers (`int`) to represent cards
 - `conditionals-if`: mostly to check for existing indexes
 
 ## Implementing

--- a/exercises/concept/card-tricks/.meta/exemplar.go
+++ b/exercises/concept/card-tricks/.meta/exemplar.go
@@ -2,7 +2,7 @@ package cards
 
 // GetItem retrieves an item from a slice at given position. The second return value indicates whether
 // a the given index existed in the slice or not.
-func GetItem(slice []uint8, index int) (uint8, bool) {
+func GetItem(slice []int, index int) (int, bool) {
 	if len(slice) <= index || index < 0 {
 		return 0, false
 	}
@@ -11,7 +11,7 @@ func GetItem(slice []uint8, index int) (uint8, bool) {
 
 // SetItem writes an item to a slice at given position overwriting an existing value.
 // If the index is out of range it is be appended.
-func SetItem(slice []uint8, index int, value uint8) []uint8 {
+func SetItem(slice []int, index int, value int) []int {
 	if len(slice) <= index || index < 0 {
 		return append(slice, value)
 	}

--- a/exercises/concept/card-tricks/.meta/exemplar.go
+++ b/exercises/concept/card-tricks/.meta/exemplar.go
@@ -11,7 +11,7 @@ func GetItem(slice []int, index int) (int, bool) {
 
 // SetItem writes an item to a slice at given position overwriting an existing value.
 // If the index is out of range it is be appended.
-func SetItem(slice []int, index int, value int) []int {
+func SetItem(slice []int, index, value int) []int {
 	if len(slice) <= index || index < 0 {
 		return append(slice, value)
 	}

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -8,7 +8,7 @@ func GetItem(slice []int, index int) (int, bool) {
 
 // SetItem writes an item to a slice at given position overwriting an existing value.
 // If the index is out of range it is be appended.
-func SetItem(slice []int, index int, value int) []int {
+func SetItem(slice []int, index, value int) []int {
 	panic("Please implement the SetItem function")
 }
 

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -2,13 +2,13 @@ package cards
 
 // GetItem retrieves an item from a slice at given position. The second return value indicates whether
 // a the given index existed in the slice or not.
-func GetItem(slice []uint8, index int) (uint8, bool) {
+func GetItem(slice []int, index int) (int, bool) {
 	panic("Please implement the GetItem function")
 }
 
 // SetItem writes an item to a slice at given position overwriting an existing value.
 // If the index is out of range it is be appended.
-func SetItem(slice []uint8, index int, value uint8) []uint8 {
+func SetItem(slice []int, index int, value int) []int {
 	panic("Please implement the SetItem function")
 }
 

--- a/exercises/concept/card-tricks/card_tricks_test.go
+++ b/exercises/concept/card-tricks/card_tricks_test.go
@@ -7,19 +7,19 @@ import (
 
 func TestGetItem(t *testing.T) {
 	type args struct {
-		slice []uint8
+		slice []int
 		index int
 	}
 	tests := []struct {
 		name   string
 		args   args
-		want   uint8
+		want   int
 		wantOk bool
 	}{
 		{
 			name: "Retrieve item from slice by index",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 4,
 			},
 			want:   8,
@@ -28,7 +28,7 @@ func TestGetItem(t *testing.T) {
 		{
 			name: "Get first item from slice",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 0,
 			},
 			want:   5,
@@ -37,7 +37,7 @@ func TestGetItem(t *testing.T) {
 		{
 			name: "Get last item from slice",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 7,
 			},
 			want:   9,
@@ -46,7 +46,7 @@ func TestGetItem(t *testing.T) {
 		{
 			name: "Index out of bounds",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 8,
 			},
 			want:   0,
@@ -55,7 +55,7 @@ func TestGetItem(t *testing.T) {
 		{
 			name: "Negative index",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: -1,
 			},
 			want:   0,
@@ -86,59 +86,59 @@ func TestGetItem(t *testing.T) {
 
 func TestSetItem(t *testing.T) {
 	type args struct {
-		slice []uint8
+		slice []int
 		index int
-		value uint8
+		value int
 	}
 	tests := []struct {
 		name string
 		args args
-		want []uint8
+		want []int
 	}{
 		{
 			name: "Overwrite an existing item",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 4,
 				value: 1,
 			},
-			want: []uint8{5, 2, 10, 6, 1, 7, 0, 9},
+			want: []int{5, 2, 10, 6, 1, 7, 0, 9},
 		},
 		{
 			name: "Overwrite first item",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 0,
 				value: 8,
 			},
-			want: []uint8{8, 2, 10, 6, 8, 7, 0, 9},
+			want: []int{8, 2, 10, 6, 8, 7, 0, 9},
 		},
 		{
 			name: "Overwrite last item",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 7,
 				value: 8,
 			},
-			want: []uint8{5, 2, 10, 6, 8, 7, 0, 8},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 8},
 		},
 		{
 			name: "Index out of bounds",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 8,
 				value: 8,
 			},
-			want: []uint8{5, 2, 10, 6, 8, 7, 0, 9, 8},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 9, 8},
 		},
 		{
 			name: "Negative index",
 			args: args{
-				slice: []uint8{5, 2, 10, 6, 8, 7, 0, 9},
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: -1,
 				value: 8,
 			},
-			want: []uint8{5, 2, 10, 6, 8, 7, 0, 9, 8},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 9, 8},
 		},
 		{
 			name: "Slice is nill",
@@ -147,7 +147,7 @@ func TestSetItem(t *testing.T) {
 				index: 7,
 				value: 8,
 			},
-			want: []uint8{8},
+			want: []int{8},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #1600 

None of the concepts teach about `uint8` and there is no real reason to confuse the students so we will just use `int` type everywhere in this exercise.