### PR TITLE
Cleanup methods concept in the same way that we did for the exercise.

### DIFF
--- a/concepts/methods/about.md
+++ b/concepts/methods/about.md
@@ -8,14 +8,21 @@ func (receiver type) MethodName(parameters) (returnTypes){
 }
 ```
 
-You can only define a method with a receiver whose type is defined in the same package as the method. The receiver can be either a struct type or a non-struct type as in the example below.
+You can only define a method with a receiver whose type is defined in the same package as the method.
 
 ```go
-type Name string
-
-func (s Name) Greetings() string {
-	return fmt.Sprintf("Welcome %s !", s)
+type Person {
+	Name string
 }
+
+func (p Person) Greetings() string {
+	return fmt.Sprintf("Welcome %s !", p.Name)
+}
+
+s := Person{Name: "Bronson"}
+fmt.Println(s.Greetings())
+// Output: Welcome Bronson !
+
 ```
 
 Methods with a value receiver operate on a copy of the value passed to it, meaning that any modification done to the receiver inside the method is not visible to the caller.
@@ -31,15 +38,13 @@ func (r *rect) squareIt() {
 	r.height = r.width
 }
 
-func main() {
-	r := rect{width: 10, height: 20}
-	fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-	// Output: Width: 10, Height: 20
+r := rect{width: 10, height: 20}
+fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
+// Output: Width: 10, Height: 20
 
-	r.squareIt()
-	fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-	// Output: Width: 10, Height: 10
-}
+r.squareIt()
+fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
+// Output: Width: 10, Height: 10
 ```
 
 You can find several examples [here][pointers_receivers]. Also checkout this short tutorial about [methods][methods_tutorial].

--- a/concepts/methods/introduction.md
+++ b/concepts/methods/introduction.md
@@ -8,25 +8,29 @@ func (receiver type) MethodName(parameters) (returnTypes){
 }
 ```
 
-You can only define a method with a receiver whose type is defined in the same package as the method. The receiver can be either a struct type or a non-struct type as in the example below.
+You can only define a method with a receiver whose type is defined in the same package as the method.
 
 ```go
-type Name string
-
-func (s Name) Greetings() string {
-	return fmt.Sprintf("Welcome %s !", s)
+type Person {
+    Name string
 }
 
-func main() {
-	s := Name("Bronson")
-	fmt.Println(s.Greetings())
+func (p Person) Greetings() string {
+	return fmt.Sprintf("Welcome %s !", p.Name)
 }
+
+
+s := Person{Name: "Bronson"}
+fmt.Println(s.Greetings())
 // Output: Welcome Bronson !
 ```
 
 Methods with a value receiver operate on a copy of the value passed to it, meaning that any modification done to the receiver inside the method is not visible to the caller.
 
-You can declare methods with pointer receivers in order to modify the value to which the receiver points. Such modifications are visible to the caller or the method as well.
+You can declare methods with pointer receivers in order to modify the value to which the receiver points.
+Such modifications are visible to the caller or the method as well.
+This is done by prefixing the type name with a `*`, for example with the `rect` type, a pointer reciever would be declared as `*rect`.
+Such modifications are visible to the caller of the method as well.
 
 ```go
 type rect struct {
@@ -36,15 +40,14 @@ func (r *rect) squareIt() {
 	r.height = r.width
 }
 
-func main() {
-	r := rect{width: 10, height: 20}
-	fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-	// Output: Width: 10, Height: 20
+r := rect{width: 10, height: 20}
+fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
+// Output: Width: 10, Height: 20
 
-	r.squareIt()
-	fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-	// Output: Width: 10, Height: 10
-}
+r.squareIt()
+fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
+// Output: Width: 10, Height: 10
+
 ```
 
 You can find several examples [here][pointers_receivers]. Also checkout this short tutorial about [methods][methods_tutorial].

--- a/exercises/concept/elons-toys/.docs/introduction.md
+++ b/exercises/concept/elons-toys/.docs/introduction.md
@@ -52,7 +52,7 @@ All the methods we have seen so far have a value receiver which means they on a 
 You can declare methods with pointer receivers in order to modify the value to which the receiver points.
 This is done by prefixing the type name with a `*`.
 For example with the `rect` type, a pointer reciever would be declared as `*rect`.
-Such modifications are visible to the caller or the method as well.
+Such modifications are visible to the caller of the method as well.
 
 ```go
 type rect struct {


### PR DESCRIPTION
This does the following changes:
 * Remove main() function where not needed
 * Describe how to use pointer recievers in methods as well as just giving examples
 * Remove non-struct types which have not yet been explained
 * Fix a small typo I spotted in the exercise.

Fixes #1626