### PR TITLE
Cars assemble enhance test output

### DIFF
--- a/exercises/concept/cars-assemble/cars_assemble.go
+++ b/exercises/concept/cars-assemble/cars_assemble.go
@@ -3,13 +3,13 @@ package cars
 // CalculateProductionRatePerHour for the assembly line, taking into account
 // its success rate
 func CalculateProductionRatePerHour(speed int) float64 {
-	panic("not implemented")
+	panic("CalculateProductionRatePerHour not implemented")
 }
 
 // CalculateProductionRatePerMinute describes how many working items are
 // produced by the assembly line every minute
 func CalculateProductionRatePerMinute(speed int) int {
-	panic("not implemented")
+	panic("CalculateProductionRatePerMinute not implemented")
 }
 
 // successRate is used to calculate the ratio of an item being created without

--- a/exercises/concept/cars-assemble/cars_assemble_test.go
+++ b/exercises/concept/cars-assemble/cars_assemble_test.go
@@ -93,7 +93,7 @@ func TestCalculateProductionRatePerMinute(t *testing.T) {
 			got := CalculateProductionRatePerMinute(tt.speed)
 			if got != tt.want {
 				t.Errorf(
-					"CalculateWorkingItemsRate(%d) = %d, want %d",
+					"CalculateProductionRatePerMinute(%d) = %d, want %d",
 					tt.speed,
 					got,
 					tt.want,


### PR DESCRIPTION
Add function name to the panic message and fix the function name typo in the test failure error message.