### PR TITLE
census: remove unneeded brace and space

### DIFF
--- a/exercises/concept/census/.docs/instructions.md
+++ b/exercises/concept/census/.docs/instructions.md
@@ -91,6 +91,4 @@ residents := []*Resident{resident1, resident2}
 
 Count(residents)
 // => 1
-}
-
 ```


### PR DESCRIPTION
I was looking through the Census exercise on the site and noticed this unneeded brace and space in the example code snippet. I much have forgotten to remove it in #1500.