### PR TITLE
Some fixes for the concept tree

### DIFF
--- a/config.json
+++ b/config.json
@@ -89,9 +89,8 @@
           "constants"
         ],
         "prerequisites": [
-          "basics",
-          "comments",
-          "string-formatting"
+          "numbers",
+          "type-definitions"
         ],
         "status": "beta"
       },
@@ -118,9 +117,9 @@
           "time"
         ],
         "prerequisites": [
-          "basics",
           "string-formatting",
-          "numbers"
+          "numbers",
+          "multiple-return-values"
         ],
         "status": "beta"
       },
@@ -134,7 +133,7 @@
           "conditionals-if"
         ],
         "prerequisites": [
-          "constants"
+          "basics"
         ],
         "status": "beta"
       },
@@ -146,7 +145,6 @@
           "maps"
         ],
         "prerequisites": [
-          "basics",
           "conditionals-if",
           "numbers",
           "string-formatting",
@@ -189,7 +187,8 @@
           "errors"
         ],
         "prerequisites": [
-          "constants"
+          "string-formatting",
+          "multiple-return-values"
         ],
         "status": "wip"
       },

--- a/exercises/concept/booking-up-for-beauty/.meta/design.md
+++ b/exercises/concept/booking-up-for-beauty/.meta/design.md
@@ -23,6 +23,6 @@ The goal of this exercise is to teach the student how to use time in Go.
 
 ## Prerequisites
 
-- `basics`
+- `string-formatting`
 - `numbers`
-- `strings`
+- `multiple-return-values`

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -15,9 +15,9 @@ My suggestion is to copy C# `numbers` exercise: https://github.com/exercism/v3/t
 ## Concepts
 
 - `numbers`
+- `conditionals-if`
 - `type-conversion`
 
 ## Prerequisites
 
-- `constants`
-- `conditionals-if`
+- `basics`

--- a/exercises/concept/deep-thought/.meta/design.md
+++ b/exercises/concept/deep-thought/.meta/design.md
@@ -27,8 +27,8 @@ The Concepts this exercise unlocks are:
 
 ## Prerequisites
 
-- `constants`
-- `types`
+- `string-formatting`
+- `multiple-return-values`
 
 ## Representer
 

--- a/exercises/concept/savings-account/.meta/design.md
+++ b/exercises/concept/savings-account/.meta/design.md
@@ -19,9 +19,8 @@ The goal of this exercise is to teach the student about constants in Go.
 
 ## Prerequisites
 
-- `basics`
-- `comments`
-- `strings`
+- `numbers`
+- `type-definitions`
 
 ## Representer
 


### PR DESCRIPTION
Now that we have some more concepts, we can set the correct perquisites for the exercise that teaches (advanced) "constants". This will move it further down in the tree. Also by removing "constants" as prerequisite for "cars assemple" (since we now cover it in basics), the concepts in cars-assemble will take the correct place in the concept tree.

I also fixed the prereqs for the `time` exercise and the currently wip errors exercise.