### PR TITLE
welcome-to-tech-palace: Fix `strings.ReplaceAll()` link in hints

### DIFF
--- a/exercises/concept/welcome-to-tech-palace/.docs/hints.md
+++ b/exercises/concept/welcome-to-tech-palace/.docs/hints.md
@@ -18,7 +18,7 @@
 
 ## 3. Clean up old marketing messages
 
-- There is a function to [replace strings within a `string`][replace].
+- There is a function to [replace strings within a `string`][replace-all].
 - There is a function to [trim leading and trailing spaces from a `string`][trim-space].
 
 [strings-package]: https://pkg.go.dev/strings


### PR DESCRIPTION
Noticed this when going trough the hints on the exercise.