### PR TITLE
variable-length-quantity: add test for bytes not fitting 32 bits

### DIFF
--- a/exercises/practice/variable-length-quantity/.meta/example.go
+++ b/exercises/practice/variable-length-quantity/.meta/example.go
@@ -3,6 +3,7 @@ package variablelengthquantity
 import "errors"
 
 var ErrUnterminatedSequence = errors.New("unterminated sequence")
+var ErrTooLong = errors.New("sequence too long for 32 bits")
 
 // encodeInt returns the varint encoding of x.
 func encodeInt(x uint32) []byte {
@@ -59,6 +60,9 @@ func decodeInt(buf []byte) (x uint32, n int, err error) {
 
 	var b byte
 	for n, b = range buf {
+		if x>>(32-7) != 0 {
+			return x, 0, ErrTooLong
+		}
 		x <<= 7
 		x |= uint32(b) & 0x7f
 		if (b & 0x80) == 0 {

--- a/exercises/practice/variable-length-quantity/cases_test.go
+++ b/exercises/practice/variable-length-quantity/cases_test.go
@@ -141,6 +141,12 @@ var decodeTestCases = []struct {
 		false,
 	},
 	{
+		"value not fitting in 32 bits causes error",
+		[]byte{0x9f, 0xff, 0xff, 0xff, 0x7f},
+		[]uint32{},
+		true,
+	},
+	{
 		"incomplete sequence causes error",
 		[]byte{0xff},
 		[]uint32{},


### PR DESCRIPTION
I expected this to be covered but it was not.
Instructions make the student assume that values fit in uint32 but I think it's good to detect the situation.
Similar to how invalid VLQ sequences are.