### PR TITLE
Cleanup the introduction for the numbers concept.

### DIFF
--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -1,9 +1,7 @@
 # Introduction
 
 Go contains basic numeric types that can represent sets of either integer or
-floating-point values. There a different types depending on the size of value
-you require and the architecture of the computer where the application is
-running (e.g. 32-bit and 64-bit).
+floating-point values.
 
 For the sake of this exercise you will only be dealing with:
 
@@ -15,13 +13,6 @@ For the sake of this exercise you will only be dealing with:
 
 - `float64`: e.g. `0.0`, `3.14`. Contains the set of all 64-bit floating-point
   numbers.
-
-For a full list of the available numeric types and more detail see the
-following resources:
-
-- [Go builtin type declarations][go-builtins]
-- [Digital Ocean - Understanding Data Types in Go][do-understanding-types]
-- [Arden Labs - Understanding Type in Go][arden-understanding-types]
 
 Go supports the standard set of arithmetic operators of `+`, `-`, `*`, `/`
 and `%` (remainder not modulo).
@@ -40,7 +31,3 @@ fmt.Printf("x is of type: %s\n", reflect.TypeOf(x))
 fmt.Printf("f is of type: %s\n", reflect.TypeOf(f))
 // Output: f is of type: float64
 ```
-
-[go-builtins]: https://github.com/golang/go/blob/master/src/builtin/builtin.go
-[do-understanding-types]: https://www.digitalocean.com/community/tutorials/understanding-data-types-in-go
-[arden-understanding-types]: https://www.ardanlabs.com/blog/2013/07/understanding-type-in-go.html


### PR DESCRIPTION
Remove links as the style guide discourages them (links should only be in the about).
Remove information that isn't needed for understanding the exercise.