### PR TITLE
Increase timeout for golangci to 5m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  timeout: 5m
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
Default is 1m which leads to some flaky tests