### PR TITLE
census: made TestDelete to indicate wrong map value

### DIFF
--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -135,7 +135,7 @@ func TestDelete(t *testing.T) {
 			test.resident.Delete()
 
 			if test.resident.Name != "" || test.resident.Age != 0 || test.resident.Address != nil {
-				t.Errorf("resident.Delete() = %v, want %v", test.resident, test.want)
+				t.Errorf("resident.Delete() = %#v, want %#v", test.resident, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
When solving Census task I've got a bit confused trying to understand test failure reason:
```
PS C:\Users\iavto\Documents\exercism_tasks\go\census> go test
--- FAIL: TestDelete (0.00s)
    --- FAIL: TestDelete/no_data_collected (0.00s)
        census_test.go:138: resident.Delete() = &{ 0 map[]}, want &{ 0 map[]}
    --- FAIL: TestDelete/all_data_collected (0.00s)
        census_test.go:138: resident.Delete() = &{ 0 map[]}, want &{ 0 map[]}
    --- FAIL: TestDelete/some_data_collected (0.00s)
        census_test.go:138: resident.Delete() = &{ 0 map[]}, want &{ 0 map[]}
```
The actual object seems to be the same as expected but the test failed for some reason. I browsed tests' code and found TestDelete expects the Delete method to set `Address` field to `nil` but I had it set to a new map. I changed the test output to indicate such an issue, now it looks this way:
```
PS C:\Users\iavto\Documents\exercism_tasks\go\census> go test
--- FAIL: TestDelete (0.00s)
    --- FAIL: TestDelete/no_data_collected (0.00s)
        census_test.go:138: resident.Delete() = &census.Resident{Name:"", Age:0, Address:map[string]string{}}, want &census.Resident{Name:"", Age:0, Address:map[string]string(nil)}
    --- FAIL: TestDelete/all_data_collected (0.00s)
        census_test.go:138: resident.Delete() = &census.Resident{Name:"", Age:0, Address:map[string]string{}}, want &census.Resident{Name:"", Age:0, Address:map[string]string(nil)}
    --- FAIL: TestDelete/some_data_collected (0.00s)
        census_test.go:138: resident.Delete() = &census.Resident{Name:"", Age:0, Address:map[string]string{}}, want &census.Resident{Name:"", Age:0, Address:map[string]string(nil)}
```