### PR TITLE
Fix slices concept about to be superset of introduction.

### DIFF
--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -3,7 +3,9 @@
 Slices in Go are similar to lists or arrays in other languages.
 They hold a number of elements of a specific type (or interface).
 
-Slices in Go are based on arrays. Arrays have a fixed size. A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
+Slices in Go are based on arrays.
+Arrays have a fixed size.
+A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
 
 A slice is written like `[]T` with `T` being the type of the elements in the slice:
 

--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -14,7 +14,7 @@ var empty []int                 // an empty slice
 withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
 ```
 
-You can get/set an element at a given zero-based index using square-bracket notation:
+You can get or set an element at a given zero-based index using square-bracket notation:
 
 ```go
 withData[1] = 5

--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -1,6 +1,7 @@
 # About
 
-Slices in Go are similar to lists or arrays in other languages. They hold a number of elements of a specific type (or interface).
+Slices in Go are similar to lists or arrays in other languages.
+They hold a number of elements of a specific type (or interface).
 
 Slices in Go are based on arrays. Arrays have a fixed size. A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
 

--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -27,6 +27,9 @@ If you don't specify an ending index, it defaults to the length of the slice.
 
 ```go
 newSlice := withData[2:4] // newSlice == []int{2,3}
+newSlice := withData[:2]  // newSlice == []int{0,1,2}
+newSlice := withData[2:]  // newSlice == []int{2,3,4,5}
+newSlice := withData[:]   // newSlice == []int{0,1,2,3,4,5}
 ```
 
 ## Indexes in slices

--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -1,5 +1,31 @@
 # About
 
+Slices in Go are similar to lists or arrays in other languages. They hold a number of elements of a specific type (or interface).
+
+Slices in Go are based on arrays. Arrays have a fixed size. A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
+
+A slice is written like `[]T` with `T` being the type of the elements in the slice:
+
+```go
+var empty []int                 // an empty slice
+withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
+```
+
+You can get/set an element at a given zero-based index using square-bracket notation:
+
+```go
+withData[1] = 5
+x := withData[1] // x is now 5
+```
+
+You can create a new slice from an existing slice by getting a range of elements, once again using square-bracket notation, but specifying both a starting (inclusive) and ending (exclusive) index.
+If you don't specify a starting index, it defaults to 0.
+If you don't specify an ending index, it defaults to the length of the slice.
+
+```go
+newSlice := withData[2:4] // newSlice == []int{2,3}
+```
+
 ## Indexes in slices
 
 Working with indexes of slices should always be protected in some way by a check that makes sure the index actually exists.

--- a/concepts/slices/introduction.md
+++ b/concepts/slices/introduction.md
@@ -11,7 +11,7 @@ var empty []int                 // an empty slice
 withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
 ```
 
-You can get/set an element at a given zero-based index using square-bracket notation:
+You can get or set an element at a given zero-based index using square-bracket notation:
 
 ```go
 withData[1] = 5
@@ -24,4 +24,7 @@ If you don't specify an ending index, it defaults to the length of the slice.
 
 ```go
 newSlice := withData[2:4] // newSlice == []int{2,3}
+newSlice := withData[:2]  // newSlice == []int{0,1,2}
+newSlice := withData[2:]  // newSlice == []int{2,3,4,5}
+newSlice := withData[:]   // newSlice == []int{0,1,2,3,4,5}
 ```


### PR DESCRIPTION
There's a lot of good info in the about page for the concept, but it didn't cover any of the information from the introduction.
This fixes that by copying the introduciton into the about, making it a superset rather than a completely different doc