### PR TITLE
Remove links from switch concept introduction.

### DIFF
--- a/concepts/conditionals-switch/about.md
+++ b/concepts/conditionals-switch/about.md
@@ -1,10 +1,13 @@
 # About
 
-Like other languages, Go also provides a [`switch` statement][switch_statement]. Switch statements are a shorter way to write long `if ... else if` statements.
+Like other languages, Go also provides a [`switch` statement][switch_statement].
+Switch statements are a shorter way to write long `if ... else if` statements.
 
 ## Basic usage
 
-To make a switch, we start by using the keyword `switch` followed by a value or expression. We then declare each one of the conditions with the `case` keyword. We can also declare a `default` case, that will run when none of the previous `case` conditions matched:
+To make a switch, we start by using the keyword `switch` followed by a value or expression.
+We then declare each one of the conditions with the `case` keyword.
+We can also declare a `default` case, that will run when none of the previous `case` conditions matched:
 
 ```go
 operatingSystem := "windows"
@@ -18,7 +21,7 @@ case "macos":
     // do something if the operating system is macos
 default:
     // do something if the operating system is none of the above
-} 
+}
 ```
 
 If we want to run the same piece of code for several cases, we can group them together in a single `case`, separating them with a `,`:
@@ -33,12 +36,13 @@ case "macos":
     // do something if the operating system is macos
 default:
     // do something if the operating system is none of the above
-} 
+}
 ```
 
-## Cases with boolean expressions 
+## Cases with boolean expressions
 
-One interesting thing about switch statements, is that the value after the `switch` keyword can be omitted, and we can have boolean conditions for each `case`. This effectively can be a shorter way to write complex `if ... else` statements:
+One interesting thing about switch statements, is that the value after the `switch` keyword can be omitted, and we can have boolean conditions for each `case`.
+This effectively can be a shorter way to write complex `if ... else` statements:
 
 ```go
 age := 21
@@ -55,7 +59,9 @@ default:
 
 ## Fallthrough
 
-When the condition in a `case` matches, the corresponding code will run and Go will not evaluate the other `case` conditions by default. We can make use of the `fallthrough` keyword to tell Go to evaluate the other `case` conditions. Take this example:
+When the condition in a `case` matches, the corresponding code will run and Go will not evaluate the other `case` conditions by default.
+We can make use of the `fallthrough` keyword to tell Go to evaluate the other `case` conditions.
+Take this example:
 
 ```go
 age := 21

--- a/concepts/conditionals-switch/introduction.md
+++ b/concepts/conditionals-switch/introduction.md
@@ -1,6 +1,10 @@
 # Introduction
 
-Like other languages, Go also provides a [`switch` statement][switch_statement]. Switch statements are a shorter way to write long `if ... else if` statements. To make a switch, we start by using the keyword `switch` followed by a value or expression. We then declare each one of the conditions with the `case` keyword. We can also declare a `default` case, that will run when none of the previous `case` conditions matched:
+Like other languages, Go also provides a `switch` statement.
+Switch statements are a shorter way to write long `if ... else if` statements.
+To make a switch, we start by using the keyword `switch` followed by a value or expression.
+We then declare each one of the conditions with the `case` keyword.
+We can also declare a `default` case, that will run when none of the previous `case` conditions matched:
 
 ```go
 operatingSystem := "windows"
@@ -14,7 +18,7 @@ case "macos":
     // do something if the operating system is macos
 default:
     // do something if the operating system is none of the above
-} 
+}
 ```
 
 One interesting thing about switch statements, is that the value after the `switch` keyword can be omitted, and we can have boolean conditions for each `case`:
@@ -31,8 +35,3 @@ default:
     // do something else for every other case
 }
 ```
-
-To learn more about this topic, check [Go by Example: Switch][go_by_example_switch] or [Tour of Go: Switch][switch_statement].
-
-[switch_statement]: https://tour.golang.org/flowcontrol/9
-[go_by_example_switch]: https://gobyexample.com/switch


### PR DESCRIPTION
Per the style guide we shouldn't link to external docs in the introduction, this cleans it up.

Whilst I was here I added line breaks in the paragraphs to be one sentence per line to minimise future diffs and make comparisons easier