### PR TITLE
Remove the links from the methods concepts introduction

### DIFF
--- a/concepts/methods/introduction.md
+++ b/concepts/methods/introduction.md
@@ -1,6 +1,7 @@
 # Introduction
 
-A [method][methods] is a function with a special _receiver_ argument. The receiver appears in its own argument list between `func` keyword and the name of the method.
+A method is a function with a special _receiver_ argument.
+The receiver appears in its own argument list between `func` keyword and the name of the method.
 
 ```go
 func (receiver type) MethodName(parameters) (returnTypes){
@@ -49,11 +50,3 @@ fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
 // Output: Width: 10, Height: 10
 
 ```
-
-You can find several examples [here][pointers_receivers]. Also checkout this short tutorial about [methods][methods_tutorial].
-
-Remember: a method is just a function with a receiver argument.
-
-[methods]: https://tour.golang.org/methods/1
-[pointers_receivers]: https://tour.golang.org/methods/4
-[methods_tutorial]: https://www.callicoder.com/golang-methods-tutorial/


### PR DESCRIPTION
The style guide says that these should only be in the about docs.