### PR TITLE
add new hacktoberfest label

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -51,6 +51,10 @@
   description: ""
   color: "cc8744"
 
+- name: "hacktoberfest-accepted"
+  description: "Makes an individual PR count towards the hacktoberfest goal"
+  color: "a6692d"
+
 - name: "help wanted"
   description: ""
   color: "5319e7"


### PR DESCRIPTION
This is on hold until I can get confirmation that using only this label without opting in the whole repo actually works.

Update: DJ confirmed this works. By providing the `hacktoberfest-accepted` label we can mark indivial PRs so they count for Hacktoberfest without setting hacktoberfest as topic for the repo. The label cannot be applied if its not in the appends (it will be removed) so that is why this change is needed.