### PR TITLE
savings-account: change status to `wip`

### DIFF
--- a/config.json
+++ b/config.json
@@ -93,7 +93,7 @@
           "numbers",
           "type-definitions"
         ],
-        "status": "beta"
+        "status": "wip"
       },
       {
         "slug": "blackjack",


### PR DESCRIPTION
The current implementation does not really make for an interesting exercise. There is a lack of story and the only thing the student is asked to do is to return constant values.

See https://github.com/exercism/go/blob/main/exercises/concept/savings-account/.meta/exemplar.go and https://github.com/exercism/go/blob/main/exercises/concept/savings-account/.docs/instructions.md

We can try to improve this exercise later or deprecate it in favor of another exercise.