### PR TITLE
Mention `import "fmt"` in debug.md

### DIFF
--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -3,6 +3,7 @@
 When a test fails, a message is displayed describing what went wrong and for which input. You can also use the fact that [console output][fmt-println] will be shown too. You can write to the console using:
 
 ```go
+import "fmt"
 fmt.Println("Debug message")
 ```
 


### PR DESCRIPTION
Closes https://github.com/exercism/go/issues/1694

Is this enough? It would have been enough to help me out. I hit this problem too as a total Golang noob. I didn't know how to write imports so first I wrote `import fmt` and hit a weird error about "expected string, got newline" 😁 

I think for people that wrote software before it will be obvious that the imports go at the top of the file usually, but the `fmt.Println` calls can go anywhere, right? I don't think it's necessary to spell out explicitly.