### PR TITLE
Remove references to exercises from concept docs.

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -3,7 +3,7 @@
 The Basics concept introduced [Go](https://golang.org) as a statically typed, compiled programming language. 
 The language is often referred to as Golang because of its domain name, golang.org, but the proper name is Go.
 
-The Basics concept and corresponding exercises introduced three major language features: Packages, Functions, and Variables.
+The Basics concept introduced three major language features: Packages, Functions, and Variables.
 
 ## Packages
 

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -3,7 +3,7 @@
 The Basics concept introduced [Go](https://golang.org) as a statically typed, compiled programming language. 
 The language is often referred to as Golang because of its domain name, golang.org, but the proper name is Go.
 
-The Basics concept introduced three major language features: Packages, Functions, and Variables.
+The Basics concept introduces three major language features: Packages, Functions, and Variables.
 
 ## Packages
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -4,7 +4,7 @@
 Go is syntactically similar to C.
 The language is often referred to as Golang because of its domain name, golang.org, but the proper name is Go.
 
-The Basics concept and corresponding exercises will introduce three major language features: Packages, Functions, and Variables.
+The Basics concept will introduce three major language features: Packages, Functions, and Variables.
 
 ## Packages
 

--- a/concepts/comments/about.md
+++ b/concepts/comments/about.md
@@ -10,7 +10,8 @@ Documentation comments are about `what` the thing does and contains, whereas oth
 
 ## Comments for exported identifiers
 
-Documentation comments should precede packages as well as [exported identifier][exported identifiers]s, for example exported functions, methods, package variables, constants, and structs, which you will learn more about in the next exercises. Comments written for packages and exported identifiers are useful for the users who import and use these packages.
+Documentation comments should precede packages as well as [exported identifier][exported identifiers]s, for example exported functions, methods, package variables, constants, and structs, which you will learn more about in further concepts.
+Comments written for packages and exported identifiers are useful for the users who import and use these packages.
 
 Note, however, that identifiers (such as variables) that are declared inside of functions and methods are private and do not necessarily require comments for the users of the packages.
 

--- a/concepts/comments/introduction.md
+++ b/concepts/comments/introduction.md
@@ -1,3 +1,3 @@
 # Introduction
 
-In the previous exercise, we saw that there are two ways to write comments in Go: single-line comments that are preceded by `//`, and multiline comment blocks that are wrapped with `/*` and `*/`.
+In the previous concept, we saw that there are two ways to write comments in Go: single-line comments that are preceded by `//`, and multiline comment blocks that are wrapped with `/*` and `*/`.

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -5,7 +5,7 @@ floating-point values. There a different types depending on the size of value
 you require and the architecture of the computer where the application is
 running (e.g. 32-bit and 64-bit).
 
-For the sake of this exercise you will only be dealing with:
+In this concept you will only be dealing with:
 
 - `int`: e.g. `0`, `255`, `2147483647`. A signed integer that is at least 32
   bits in size (value range of: -2147483648 through 2147483647). But this will

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -5,7 +5,7 @@ floating-point values. There a different types depending on the size of value
 you require and the architecture of the computer where the application is
 running (e.g. 32-bit and 64-bit).
 
-In this concept you will only be dealing with:
+This concept will concentrate on two number types:
 
 - `int`: e.g. `0`, `255`, `2147483647`. A signed integer that is at least 32
   bits in size (value range of: -2147483648 through 2147483647). But this will

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -3,7 +3,7 @@
 Go contains basic numeric types that can represent sets of either integer or
 floating-point values.
 
-For the sake of this conceptt you will only be dealing with:
+This concept will concentrate on two number types:
 
 - `int`: e.g. `0`, `255`, `2147483647`. A signed integer that is at least 32
   bits in size (value range of: -2147483648 through 2147483647). But this will

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -3,7 +3,7 @@
 Go contains basic numeric types that can represent sets of either integer or
 floating-point values.
 
-For the sake of this exercise you will only be dealing with:
+For the sake of this conceptt you will only be dealing with:
 
 - `int`: e.g. `0`, `255`, `2147483647`. A signed integer that is at least 32
   bits in size (value range of: -2147483648 through 2147483647). But this will

--- a/concepts/pointers/about.md
+++ b/concepts/pointers/about.md
@@ -153,7 +153,9 @@ fmt.Println(ages)
 
 The same applies when changing an existing item in a slice.
 
-However, actions that return a new slice like `append` are a special case and **might not** modify the slice outside of the function. This is due to the way slices work internally, but we won't cover this in detail in this exercise, as this is a more advanced topic. If you are really curious you can read more about this in [Go Blog: Mechanics of 'append'][mechanics-of-append]
+However, actions that return a new slice like `append` are a special case and **might not** modify the slice outside of the function.
+This is due to the way slices work internally, but we won't cover this in detail, as this is a more advanced topic.
+If you are really curious you can read more about this in [Go Blog: Mechanics of 'append'][mechanics-of-append]
 
 ## Pointer arithmetic
 

--- a/concepts/pointers/introduction.md
+++ b/concepts/pointers/introduction.md
@@ -153,6 +153,8 @@ fmt.Println(ages)
 
 The same applies when changing an existing item in a slice.
 
-However, actions that return a new slice like `append` are a special case and **might not** modify the slice outside of the function. This is due to the way slices work internally, but we won't cover this in detail in this exercise, as this is a more advanced topic. If you are really curious you can read more about this in [Go Blog: Mechanics of 'append'][mechanics-of-append]
+However, actions that return a new slice like `append` are a special case and **might not** modify the slice outside of the function.
+This is due to the way slices work internally, but we won't cover this in detail, as this is a more advanced topic.
+If you are really curious you can read more about this in [Go Blog: Mechanics of 'append'][mechanics-of-append]
 
 [mechanics-of-append]: https://go.dev/blog/slices

--- a/concepts/range-iteration/introduction.md
+++ b/concepts/range-iteration/introduction.md
@@ -3,7 +3,7 @@
 In Go, you can iterate a `slice` using `for` but you could also use
 `range`. `Range` allows you to also iterate through a `map` or a
 `channel`. While iterating over a `channel` is out of the
-scope for this exercise, you will find useful to iterate over a `map`.
+scope for this concept, you will find useful to iterate over a `map`.
 
 Every iteration returns two values: the index/key and a copy of the element at
 that index/key.

--- a/concepts/time/about.md
+++ b/concepts/time/about.md
@@ -4,7 +4,7 @@ A [`Time`][time] in Go is a type describing a moment in time. The date and time 
 
 The [`time.Parse`][parse] function parses strings into `Time` types using the particular format string `Mon Jan 2 15:04:05 -0700 MST 2006`. More on how this works can be found [here][article].
 
-The `time` package includes another type, `Duration`, representing elapsed time, plus support for locations/time zones, timers, and other related functionality that will be covered in a later exercise.
+The `time` package includes another type, `Duration`, representing elapsed time, plus support for locations/time zones, timers, and other related functionality that will be covered in a concept.
 
 [time]: https://golang.org/pkg/time/#Time
 [now]: https://golang.org/pkg/time/#Now

--- a/concepts/time/about.md
+++ b/concepts/time/about.md
@@ -4,7 +4,7 @@ A [`Time`][time] in Go is a type describing a moment in time. The date and time 
 
 The [`time.Parse`][parse] function parses strings into `Time` types using the particular format string `Mon Jan 2 15:04:05 -0700 MST 2006`. More on how this works can be found [here][article].
 
-The `time` package includes another type, `Duration`, representing elapsed time, plus support for locations/time zones, timers, and other related functionality that will be covered in a concept.
+The `time` package includes another type, `Duration`, representing elapsed time, plus support for locations/time zones, timers, and other related functionality that will be covered in another concept.
 
 [time]: https://golang.org/pkg/time/#Time
 [now]: https://golang.org/pkg/time/#Now


### PR DESCRIPTION
Fixes #1581

Note that there's still a reference right now in the functions concept, I'll address that in PR#1720 to avoid merge conflicts