### PR TITLE
Weather forecast: Remove non-SI unit from examples

### DIFF
--- a/exercises/concept/weather-forecast/.docs/introduction.md
+++ b/exercises/concept/weather-forecast/.docs/introduction.md
@@ -11,8 +11,8 @@ Comments should precede packages as well as exported identifiers, for example ex
 A package-level variable can look like this:
 
 ```go
-// TemperatureFahrenheit represents a certain temperature in degrees Fahrenheit.
-var TemperatureFahrenheit float64
+// TemperatureCelsius represents a certain temperature in degrees Celsius.
+var TemperatureCelsius float64
 ```
 
 ## Package comments


### PR DESCRIPTION
Units of measurement on Exercism must be SI or SI-derived units according to the style guide: https://exercism.org/docs/building/markdown/style-guide