### PR TITLE
Add pointers, range-iteration and functions prerequisites to exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -151,7 +151,8 @@
           "conditionals-if",
           "numbers",
           "strings",
-          "conditionals-switch"
+          "conditionals-switch",
+          "functions"
         ],
         "status": "beta"
       },
@@ -194,7 +195,8 @@
         "prerequisites": [
           "structs",
           "string-formatting",
-          "type-definitions"
+          "type-definitions",
+          "pointers"
         ],
         "status": "beta"
       },
@@ -234,7 +236,8 @@
           "runes"
         ],
         "prerequisites": [
-          "slices"
+          "slices",
+          "range-iteration"
         ],
         "status": "beta"
       },
@@ -283,10 +286,19 @@
         "concepts": [
           "zero-values"
         ],
-        "prerequisites": [ "maps", "structs", "numbers", "string-formatting", "booleans", "methods", "slices", "conditionals-if" ],
+        "prerequisites": [
+          "maps",
+          "structs",
+          "numbers",
+          "string-formatting",
+          "booleans",
+          "methods",
+          "slices",
+          "conditionals-if",
+          "pointers"
+        ],
         "status": "beta"
       },
-
       {
         "name": "Welcome To Tech Palace!",
         "slug": "welcome-to-tech-palace",

--- a/config.json
+++ b/config.json
@@ -236,7 +236,10 @@
           "runes"
         ],
         "prerequisites": [
+          "strings",
+          "conditionals-if",
           "slices",
+          "maps",
           "range-iteration"
         ],
         "status": "beta"

--- a/exercises/concept/census/.meta/design.md
+++ b/exercises/concept/census/.meta/design.md
@@ -22,7 +22,15 @@ The goal of this exercise is to teach the student about the zero value of Go's t
 
 ## Prerequisites
 
-- `types`
+- `maps`
+- `structs`
+- `numbers`
+- `string-formatting`
+- `booleans`
+- `methods`
+- `slices`
+- `conditionals-if`
+- `pointers`
 
 ## Representer
 

--- a/exercises/concept/gross-store/.meta/design.md
+++ b/exercises/concept/gross-store/.meta/design.md
@@ -23,9 +23,11 @@ The goal is to introduce the student to maps.
 
 ## Prerequisites
 
-- `basics`
-- `numbers`
 - `conditionals-if`
+- `numbers`
+- `strings`
+- `conditionals-switch`
+- `functions`
 
 ## Representer
 

--- a/exercises/concept/logs-logs-logs/.meta/design.md
+++ b/exercises/concept/logs-logs-logs/.meta/design.md
@@ -18,10 +18,11 @@ The goal of this exercise is to teach the student about runes.
 
 ## Prerequisites
 
+- `strings`
 - `conditionals-if`
+- `slices`
 - `maps`
 - `range-iteration`
-- `strings`
 
 ## Analyzer
 


### PR DESCRIPTION
Fixes #1749

@junedev Is this what you had in mind?

When editing I noticed some of the prerequisites in `design.md` didn't match the prerequisites in the `config.json`. I made them match by copying the pre-requisites in `config.json` and putting them in `design.md`. Let me know if I was supposed to do this. Didn't find anything against it in [the documentation](https://exercism.org/docs/building/tracks/concept-exercises). The only exercise for which I didn't do this was "logs-logs-logs", since the `design.md` file was changed just 1 day ago and I'm not sure which list of prerequisites is correct, if the one on `config.json` or the one in `design.md`.

