### PR TITLE
Add exercises' extra files to editor

### DIFF
--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -28,6 +28,9 @@
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "common.go"
     ]
   }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "board.go"
     ]
   }
 }

--- a/exercises/practice/paasio/.meta/config.json
+++ b/exercises/practice/paasio/.meta/config.json
@@ -27,6 +27,9 @@
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "interface.go"
     ]
   },
   "source": "Brian Matsuo",

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -26,6 +26,9 @@
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "interfaces.go"
     ]
   }
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -26,6 +26,9 @@
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "defs.go"
     ]
   },
   "source": "Inspired by an interview question at a famous company."

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cipher.go"
     ]
   },
   "source": "Substitution Cipher at Wikipedia",


### PR DESCRIPTION
While I was looking at `simple-cipher` using the editor, I was a bit frustrated I couldn't see an extra file that I was supposed to see, so I added it to the editor. I also went ahead and checked other exercises on the track that are in a similar situation and would benefit from having other files showing up in the editor.