### PR TITLE
allergies: make tests not care about the order of elements

### DIFF
--- a/exercises/practice/allergies/allergies_test.go
+++ b/exercises/practice/allergies/allergies_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAllergies(t *testing.T) {
 	for _, test := range listTests {
-		if actual := Allergies(test.score); !reflect.DeepEqual(actual, test.expected) && (len(actual) > 0 || len(test.expected) > 0) {
+		if actual := Allergies(test.score); !sameSliceElements(actual, test.expected) {
 			t.Fatalf("FAIL: Allergies(%d): expected %#v, actual %#v", test.score, test.expected, actual)
 		} else {
 			t.Logf("PASS: Allergic to %#v", test.expected)
@@ -52,4 +52,28 @@ func BenchmarkAllergicTo(b *testing.B) {
 			}
 		}
 	}
+}
+
+// stringSet is a set of strings
+type stringSet map[string]bool
+
+// sameSliceElements checks if the slices have the same number of elements
+// regardless of their order
+func sameSliceElements(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	return reflect.DeepEqual(sliceSet(a), sliceSet(b))
+}
+
+// sliceSet creates a new stringSet from a slice of strings
+func sliceSet(list []string) stringSet {
+	set := make(stringSet)
+
+	for _, elem := range list {
+		set[elem] = true
+	}
+
+	return set
 }


### PR DESCRIPTION
There are some solutions for this exercise that produce the right list of allergies Tom is allergic to, but do not produce them in the same order as the tests expect:

```
allergies_test.go:11: FAIL: Allergies(255): expected []string{"eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"}, actual []string{"shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats", "eggs", "peanuts"}
--- FAIL: TestAllergies (0.00s)
```

The `actual` list and the `expected` list contain the same elements, just ordered differently.

This PR makes the tests see if the lists have the same elements, regardless of their order. I think it's reasonable to allow for the elements to be ordered differently than the expected. The instructions mention returning a list of "all the allergens Tom is allergic to" without specifying any order.