### PR TITLE
Add cases_test.go to editor

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -29,7 +29,8 @@
       "acronym.go"
     ],
     "test": [
-      "acronym_test.go"
+      "acronym_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -21,7 +21,8 @@
       "all_your_base.go"
     ],
     "test": [
-      "all_your_base_test.go"
+      "all_your_base_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -25,7 +25,8 @@
       "allergies.go"
     ],
     "test": [
-      "allergies_test.go"
+      "allergies_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -15,7 +15,8 @@
       "alphametics.go"
     ],
     "test": [
-      "alphametics_test.go"
+      "alphametics_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -27,7 +27,8 @@
       "anagram.go"
     ],
     "test": [
-      "anagram_test.go"
+      "anagram_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -19,7 +19,8 @@
       "armstrong_numbers.go"
     ],
     "test": [
-      "armstrong_numbers_test.go"
+      "armstrong_numbers_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -23,7 +23,8 @@
       "atbash_cipher.go"
     ],
     "test": [
-      "atbash_cipher_test.go"
+      "atbash_cipher_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -21,7 +21,8 @@
       "binary_search.go"
     ],
     "test": [
-      "binary_search_test.go"
+      "binary_search_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -26,7 +26,8 @@
       "bob.go"
     ],
     "test": [
-      "bob_test.go"
+      "bob_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -17,7 +17,8 @@
       "book_store.go"
     ],
     "test": [
-      "book_store_test.go"
+      "book_store_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -17,7 +17,8 @@
       "bowling.go"
     ],
     "test": [
-      "bowling_test.go"
+      "bowling_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -20,7 +20,8 @@
       "change.go"
     ],
     "test": [
-      "change_test.go"
+      "change_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -27,7 +27,8 @@
       "clock.go"
     ],
     "test": [
-      "clock_test.go"
+      "clock_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -16,7 +16,8 @@
       "collatz_conjecture.go"
     ],
     "test": [
-      "collatz_conjecture_test.go"
+      "collatz_conjecture_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -23,7 +23,8 @@
       "connect.go"
     ],
     "test": [
-      "connect_test.go"
+      "connect_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -20,7 +20,8 @@
       "custom_set.go"
     ],
     "test": [
-      "custom_set_test.go"
+      "custom_set_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -12,7 +12,8 @@
       "darts.go"
     ],
     "test": [
-      "darts_test.go"
+      "darts_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -18,7 +18,8 @@
       "dominoes.go"
     ],
     "test": [
-      "dominoes_test.go"
+      "dominoes_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -16,7 +16,8 @@
       "flatten_array.go"
     ],
     "test": [
-      "flatten_array_test.go"
+      "flatten_array_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -19,7 +19,8 @@
       "forth.go"
     ],
     "test": [
-      "forth_test.go"
+      "forth_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -24,7 +24,8 @@
       "gigasecond.go"
     ],
     "test": [
-      "gigasecond_test.go"
+      "gigasecond_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -26,7 +26,8 @@
       "grains.go"
     ],
     "test": [
-      "grains_test.go"
+      "grains_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -15,7 +15,8 @@
       "grep.go"
     ],
     "test": [
-      "grep_test.go"
+      "grep_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -28,7 +28,8 @@
       "hamming.go"
     ],
     "test": [
-      "hamming_test.go"
+      "hamming_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -19,7 +19,8 @@
       "isbn_verifier.go"
     ],
     "test": [
-      "isbn_verifier_test.go"
+      "isbn_verifier_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -23,7 +23,8 @@
       "isogram.go"
     ],
     "test": [
-      "isogram_test.go"
+      "isogram_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -21,7 +21,8 @@
       "largest_series_product.go"
     ],
     "test": [
-      "largest_series_product_test.go"
+      "largest_series_product_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -26,7 +26,8 @@
       "leap.go"
     ],
     "test": [
-      "leap_test.go"
+      "leap_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -18,7 +18,8 @@
       "linked_list.go"
     ],
     "test": [
-      "linked_list_test.go"
+      "linked_list_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -23,7 +23,8 @@
       "luhn.go"
     ],
     "test": [
-      "luhn_test.go"
+      "luhn_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -16,7 +16,8 @@
       "markdown.go"
     ],
     "test": [
-      "markdown_test.go"
+      "markdown_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -25,7 +25,8 @@
       "matching_brackets.go"
     ],
     "test": [
-      "matching_brackets_test.go"
+      "matching_brackets_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -21,7 +21,8 @@
       "meetup.go"
     ],
     "test": [
-      "meetup_test.go"
+      "meetup_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -22,7 +22,8 @@
       "nth_prime.go"
     ],
     "test": [
-      "nth_prime_test.go"
+      "nth_prime_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -25,7 +25,8 @@
       "nucleotide_count.go"
     ],
     "test": [
-      "nucleotide_count_test.go"
+      "nucleotide_count_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -23,7 +23,8 @@
       "pangram.go"
     ],
     "test": [
-      "pangram_test.go"
+      "pangram_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -22,7 +22,8 @@
       "perfect_numbers.go"
     ],
     "test": [
-      "perfect_numbers_test.go"
+      "perfect_numbers_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -28,7 +28,8 @@
       "phone_number.go"
     ],
     "test": [
-      "phone_number_test.go"
+      "phone_number_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -20,7 +20,8 @@
       "pig_latin.go"
     ],
     "test": [
-      "pig_latin_test.go"
+      "pig_latin_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -24,7 +24,8 @@
       "poker.go"
     ],
     "test": [
-      "poker_test.go"
+      "poker_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -25,7 +25,8 @@
       "prime_factors.go"
     ],
     "test": [
-      "prime_factors_test.go"
+      "prime_factors_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -15,7 +15,8 @@
       "proverb.go"
     ],
     "test": [
-      "proverb_test.go"
+      "proverb_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -15,7 +15,8 @@
       "rail_fence_cipher.go"
     ],
     "test": [
-      "rail_fence_cipher_test.go"
+      "rail_fence_cipher_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -22,7 +22,8 @@
       "raindrops.go"
     ],
     "test": [
-      "raindrops_test.go"
+      "raindrops_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -16,7 +16,8 @@
       "rectangles.go"
     ],
     "test": [
-      "rectangles_test.go"
+      "rectangles_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -18,7 +18,8 @@
       "reverse_string.go"
     ],
     "test": [
-      "reverse_string_test.go"
+      "reverse_string_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -23,7 +23,8 @@
       "rna_transcription.go"
     ],
     "test": [
-      "rna_transcription_test.go"
+      "rna_transcription_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -25,7 +25,8 @@
       "roman_numerals.go"
     ],
     "test": [
-      "roman_numerals_test.go"
+      "roman_numerals_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -17,7 +17,8 @@
       "run_length_encoding.go"
     ],
     "test": [
-      "run_length_encoding_test.go"
+      "run_length_encoding_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -20,7 +20,8 @@
       "say.go"
     ],
     "test": [
-      "say_test.go"
+      "say_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -17,7 +17,8 @@
       "scale_generator.go"
     ],
     "test": [
-      "scale_generator_test.go"
+      "scale_generator_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -25,7 +25,8 @@
       "scrabble_score.go"
     ],
     "test": [
-      "scrabble_score_test.go"
+      "scrabble_score_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -26,7 +26,8 @@
       "secret_handshake.go"
     ],
     "test": [
-      "secret_handshake_test.go"
+      "secret_handshake_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -21,7 +21,8 @@
       "sieve.go"
     ],
     "test": [
-      "sieve_test.go"
+      "sieve_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -21,7 +21,8 @@
       "space_age.go"
     ],
     "test": [
-      "space_age_test.go"
+      "space_age_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -16,7 +16,8 @@
       "sublist.go"
     ],
     "test": [
-      "sublist_test.go"
+      "sublist_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -23,7 +23,8 @@
       "sum_of_multiples.go"
     ],
     "test": [
-      "sum_of_multiples_test.go"
+      "sum_of_multiples_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -21,7 +21,8 @@
       "transpose.go"
     ],
     "test": [
-      "transpose_test.go"
+      "transpose_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -16,7 +16,8 @@
       "two_bucket.go"
     ],
     "test": [
-      "two_bucket_test.go"
+      "two_bucket_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -25,7 +25,8 @@
       "variable_length_quantity.go"
     ],
     "test": [
-      "variable_length_quantity_test.go"
+      "variable_length_quantity_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -25,7 +25,8 @@
       "word_count.go"
     ],
     "test": [
-      "word_count_test.go"
+      "word_count_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -23,7 +23,8 @@
       "word_search.go"
     ],
     "test": [
-      "word_search_test.go"
+      "word_search_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -22,7 +22,8 @@
       "wordy.go"
     ],
     "test": [
-      "wordy_test.go"
+      "wordy_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -17,7 +17,8 @@
       "yacht.go"
     ],
     "test": [
-      "yacht_test.go"
+      "yacht_test.go",
+      "cases_test.go"
     ],
     "example": [
       ".meta/example.go"


### PR DESCRIPTION
Add `cases_test.go` to `files.test` on practice exercises that have it.  This is intended as a temporary fix to allow students to see the test cases in the editor, while waiting on some improvements to the test runner which will make this irrelevant.