### PR TITLE
fix: removed doubled up wording in exercises

### DIFF
--- a/concepts/pointers/about.md
+++ b/concepts/pointers/about.md
@@ -27,7 +27,7 @@ Similarly, when we need to change the value in the piece of memory of `a`, we ca
 a = 3
 ```
 
-The piece of memory that is associated with `a` will now will now be storing the value `3`.
+The piece of memory that is associated with `a` will now be storing the value `3`.
 
 ## Pointers
 

--- a/concepts/pointers/introduction.md
+++ b/concepts/pointers/introduction.md
@@ -27,7 +27,7 @@ Similarly, when we need to change the value in the piece of memory of `a`, we ca
 a = 3
 ```
 
-The piece of memory that is associated with `a` will now will now be storing the value `3`.
+The piece of memory that is associated with `a` will now be storing the value `3`.
 
 ## Pointers
 

--- a/exercises/concept/election-day/.docs/introduction.md
+++ b/exercises/concept/election-day/.docs/introduction.md
@@ -27,7 +27,7 @@ Similarly, when we need to change the value in the piece of memory of `a`, we ca
 a = 3
 ```
 
-The piece of memory that is associated with `a` will now will now be storing the value `3`.
+The piece of memory that is associated with `a` will now be storing the value `3`.
 
 ## Pointers
 


### PR DESCRIPTION
## What
fix: removed doubled up wording in exercises