### PR TITLE
Improve instructions for AnniversaryDate

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.docs/hints.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/hints.md
@@ -20,9 +20,9 @@
 
 - Convert the given string to a `Time` then format the answer string accordingly, using the appropriate [methods][time] to extract the needed constituents.
 
-## 5. Return the anniversary date
+## 5. Return the anniversary date of the salon's opening
 
-- Create a `Time` of the anniversary date.
+- Create a `Time` of the anniversary date of the salon's opening for the current year.
 
 [time]: https://golang.org/pkg/time/#pkg-index
 [time.parse]: https://golang.org/pkg/time/#Parse

--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -40,11 +40,13 @@ Description("7/25/2019 13:45:00")
 // Output: "You have an appointment on Thursday, July 25, 2019, at 13:45."
 ```
 
-## 5. Return the anniversary date
+## 5. Return the anniversary date of the salon's opening
 
-Implement the `AnniversaryDate` function that returns this year's anniversary date:
+Implement the `AnniversaryDate` function that returns the anniversary date of the salon's opening for the current year.
 
+Assuming the current year is 2020:
 ```go
 AnniversaryDate()
+
 // Output: 2020-09-15
 ```


### PR DESCRIPTION
Make `AnniversaryDate` instructions a bit more explicit / intuitive. As it currently stands, which specific anniversary is undefined and ambiguous.