### PR TITLE
Census: add test for optional age

### DIFF
--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -83,6 +83,17 @@ func TestHasRequiredInfo(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "missing age",
+			resident: &Resident{
+				Name: "Rob Pike",
+				Age:  0,
+				Address: map[string]string{
+					"street": "Main St.",
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I noticed my solution that checked for age passed all of the tests, however the instructions state age is optional.

This PR adds a test case to ensure age is optional.