### PR TITLE
Fix typo in Lasagna Master test name

### DIFF
--- a/exercises/concept/lasagna-master/lasagna-master_test.go
+++ b/exercises/concept/lasagna-master/lasagna-master_test.go
@@ -174,7 +174,7 @@ type scaleRecipeTest struct {
 	expected []float64
 }
 
-func TestScaleRecipeTest(t *testing.T) {
+func TestScaleRecipe(t *testing.T) {
 	tests := []scaleRecipeTest{
 		scaleRecipeTest{
 			name:     "scales up correctly",


### PR DESCRIPTION
Rediscovering Exercism after V3 has gone live. I was around for the V2 migration but got side-tracked since unfortunately.

In any case, this is a straightforward typo.