### PR TITLE
Add Hints to chessboard exercise.

### DIFF
--- a/exercises/concept/chessboard/.docs/hints.md
+++ b/exercises/concept/chessboard/.docs/hints.md
@@ -5,10 +5,26 @@
 - An [integer value][integers] can be defined as one or more consecutive digits.
 - A [map value][maps] stores key-value data
 
-## 1. Count how many squares are occupied iterating over the slices and maps
+## 1. Given a Chessboard and a Rank, count how many squares are occupied
 
-- You can iterate a [map][maps], checking the value.
+- You can iterate a [map][maps]
+- Check if the value is true. If it is increment. This is to count pieces.
 - You have to [explicitly return an integer][return] from a function.
+
+## 2. Given a Chessboard and a File, count how many squares are occupied
+
+- You'll first need to check the file is within range.
+- Loop over the chessboard.
+- Add one if the square is occupied.
+
+## 3. Count how many squares are present in the given chessboard
+
+- There are many ways to solve this.
+- This should return how many squares are configured in a chess-board.
+
+## 4. Count how many squares are occupied in the given chessboard
+
+- Get the CountInRank for all ranks in the chessboard.
 
 [functions]: https://golang.org/ref/spec#Function_declarations
 [return]: https://golang.org/ref/spec#Return_statements


### PR DESCRIPTION
The goalng chessboard exercise seems to be dependent on the participant, being aware of what is being asked.

I was not. To be honest the language of the entire exercise seems confusing, but I've chosen to focus on hints I think might help.

To do this, I based on pre-conceptions from reading:

- [blackjack hints](https://raw.githubusercontent.com/exercism/go/195e6fe65866ea8940d198e0451937a63a83ce91/exercises/concept/blackjack/.docs/hints.md)
- [blackjack instructions](https://raw.githubusercontent.com/exercism/go/195e6fe65866ea8940d198e0451937a63a83ce91/exercises/concept/blackjack/.docs/instructions.md)

I might be misunderstanding that hint headings should match instruction headings. Right now the hints for this exercise seem repetitious,

If someone cannot understand a challenge. It might be difficult for them to know what to complete.

I Did not find test output particularly helpful with this. Perhaps it could output the chessboard with the expectation, so that participants have some idea about each case. This might help visual learners, and I am happy to expand on, or adjust the scope of this PR to include that as well.