### PR TITLE
Fix the track distance in test case

### DIFF
--- a/exercises/concept/need-for-speed/need_for_speed_test.go
+++ b/exercises/concept/need-for-speed/need_for_speed_test.go
@@ -142,7 +142,7 @@ func TestCanFinish(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "Car can finish the track distance just before battery drained.",
+			name: "Car can finish the track distance just as the battery is drained.",
 			car: Car{
 				speed:        5,
 				batteryDrain: 5,


### PR DESCRIPTION
With a speed of 5, car can be driven 20 times before battery drains. So
the track distance to test CanFinish just before battery drained should
be 100.