### PR TITLE
largest-series-product: move cases_test.go from tests to editor

### DIFF
--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -21,11 +21,13 @@
       "largest_series_product.go"
     ],
     "test": [
-      "largest_series_product_test.go",
-      "cases_test.go"
+      "largest_series_product_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor" : [
+      "cases_test.go"
     ]
   },
   "source": "A variation on Problem 8 at Project Euler",


### PR DESCRIPTION
The exercise "Largest Series Product" is one of the exercises currently having problems updating, as discussed in https://github.com/exercism/go/issues/1818

This is an experimental PR to see if moving the `cases_test.go` from `files.test` to `files.editor` fixes the update problem while showing the `cases_test.go` file to the student.

cc @junedev 