### PR TITLE
Move tests_case.go from files.test to files.editor in all exercises

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -29,11 +29,13 @@
       "acronym.go"
     ],
     "test": [
-      "acronym_test.go",
-      "cases_test.go"
+      "acronym_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Julien Vanier",

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -21,11 +21,13 @@
       "all_your_base.go"
     ],
     "test": [
-      "all_your_base_test.go",
-      "cases_test.go"
+      "all_your_base_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -25,11 +25,13 @@
       "allergies.go"
     ],
     "test": [
-      "allergies_test.go",
-      "cases_test.go"
+      "allergies_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Jumpstart Lab Warm-up",

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -15,11 +15,13 @@
       "alphametics.go"
     ],
     "test": [
-      "alphametics_test.go",
-      "cases_test.go"
+      "alphametics_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -27,11 +27,13 @@
       "anagram.go"
     ],
     "test": [
-      "anagram_test.go",
-      "cases_test.go"
+      "anagram_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by the Extreme Startup game",

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -19,11 +19,13 @@
       "armstrong_numbers.go"
     ],
     "test": [
-      "armstrong_numbers_test.go",
-      "cases_test.go"
+      "armstrong_numbers_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -23,11 +23,13 @@
       "atbash_cipher.go"
     ],
     "test": [
-      "atbash_cipher_test.go",
-      "cases_test.go"
+      "atbash_cipher_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -21,11 +21,13 @@
       "binary_search.go"
     ],
     "test": [
-      "binary_search_test.go",
-      "cases_test.go"
+      "binary_search_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -26,11 +26,13 @@
       "bob.go"
     ],
     "test": [
-      "bob_test.go",
-      "cases_test.go"
+      "bob_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -17,11 +17,13 @@
       "book_store.go"
     ],
     "test": [
-      "book_store_test.go",
-      "cases_test.go"
+      "book_store_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -17,11 +17,13 @@
       "bowling.go"
     ],
     "test": [
-      "bowling_test.go",
-      "cases_test.go"
+      "bowling_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Bowling Game Kata at but UncleBob",

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -20,11 +20,13 @@
       "change.go"
     ],
     "test": [
-      "change_test.go",
-      "cases_test.go"
+      "change_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Software Craftsmanship - Coin Change Kata",

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -27,11 +27,13 @@
       "clock.go"
     ],
     "test": [
-      "clock_test.go",
-      "cases_test.go"
+      "clock_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Pairing session with Erin Drummond",

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -16,11 +16,13 @@
       "collatz_conjecture.go"
     ],
     "test": [
-      "collatz_conjecture_test.go",
-      "cases_test.go"
+      "collatz_conjecture_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -23,11 +23,13 @@
       "connect.go"
     ],
     "test": [
-      "connect_test.go",
-      "cases_test.go"
+      "connect_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -20,11 +20,13 @@
       "custom_set.go"
     ],
     "test": [
-      "custom_set_test.go",
-      "cases_test.go"
+      "custom_set_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -12,11 +12,13 @@
       "darts.go"
     ],
     "test": [
-      "darts_test.go",
-      "cases_test.go"
+      "darts_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -18,11 +18,13 @@
       "dominoes.go"
     ],
     "test": [
-      "dominoes_test.go",
-      "cases_test.go"
+      "dominoes_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -16,11 +16,13 @@
       "flatten_array.go"
     ],
     "test": [
-      "flatten_array_test.go",
-      "cases_test.go"
+      "flatten_array_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Interview Question",

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -19,11 +19,13 @@
       "forth.go"
     ],
     "test": [
-      "forth_test.go",
-      "cases_test.go"
+      "forth_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -24,11 +24,13 @@
       "gigasecond.go"
     ],
     "test": [
-      "gigasecond_test.go",
-      "cases_test.go"
+      "gigasecond_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -26,11 +26,13 @@
       "grains.go"
     ],
     "test": [
-      "grains_test.go",
-      "cases_test.go"
+      "grains_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -15,11 +15,13 @@
       "grep.go"
     ],
     "test": [
-      "grep_test.go",
-      "cases_test.go"
+      "grep_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Conversation with Nate Foster.",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -28,11 +28,13 @@
       "hamming.go"
     ],
     "test": [
-      "hamming_test.go",
-      "cases_test.go"
+      "hamming_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -19,11 +19,13 @@
       "isbn_verifier.go"
     ],
     "test": [
-      "isbn_verifier_test.go",
-      "cases_test.go"
+      "isbn_verifier_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -23,11 +23,13 @@
       "isogram.go"
     ],
     "test": [
-      "isogram_test.go",
-      "cases_test.go"
+      "isogram_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -26,7 +26,7 @@
     "example": [
       ".meta/example.go"
     ],
-    "editor" : [
+    "editor": [
       "cases_test.go"
     ]
   },

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -26,11 +26,13 @@
       "leap.go"
     ],
     "test": [
-      "leap_test.go",
-      "cases_test.go"
+      "leap_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -18,11 +18,13 @@
       "linked_list.go"
     ],
     "test": [
-      "linked_list_test.go",
-      "cases_test.go"
+      "linked_list_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Classic computer science topic"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -23,11 +23,13 @@
       "luhn.go"
     ],
     "test": [
-      "luhn_test.go",
-      "cases_test.go"
+      "luhn_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Luhn Algorithm on Wikipedia",

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -16,11 +16,13 @@
       "markdown.go"
     ],
     "test": [
-      "markdown_test.go",
-      "cases_test.go"
+      "markdown_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -25,11 +25,13 @@
       "matching_brackets.go"
     ],
     "test": [
-      "matching_brackets_test.go",
-      "cases_test.go"
+      "matching_brackets_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Ginna Baker"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -21,11 +21,13 @@
       "meetup.go"
     ],
     "test": [
-      "meetup_test.go",
-      "cases_test.go"
+      "meetup_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -22,11 +22,13 @@
       "nth_prime.go"
     ],
     "test": [
-      "nth_prime_test.go",
-      "cases_test.go"
+      "nth_prime_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "A variation on Problem 7 at Project Euler",

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -25,11 +25,13 @@
       "nucleotide_count.go"
     ],
     "test": [
-      "nucleotide_count_test.go",
-      "cases_test.go"
+      "nucleotide_count_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -23,11 +23,13 @@
       "pangram.go"
     ],
     "test": [
-      "pangram_test.go",
-      "cases_test.go"
+      "pangram_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -22,11 +22,13 @@
       "perfect_numbers.go"
     ],
     "test": [
-      "perfect_numbers_test.go",
-      "cases_test.go"
+      "perfect_numbers_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -28,11 +28,13 @@
       "phone_number.go"
     ],
     "test": [
-      "phone_number_test.go",
-      "cases_test.go"
+      "phone_number_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Event Manager by JumpstartLab",

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -20,11 +20,13 @@
       "pig_latin.go"
     ],
     "test": [
-      "pig_latin_test.go",
-      "cases_test.go"
+      "pig_latin_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -24,11 +24,13 @@
       "poker.go"
     ],
     "test": [
-      "poker_test.go",
-      "cases_test.go"
+      "poker_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by the training course from Udacity.",

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -25,11 +25,13 @@
       "prime_factors.go"
     ],
     "test": [
-      "prime_factors_test.go",
-      "cases_test.go"
+      "prime_factors_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -15,11 +15,13 @@
       "proverb.go"
     ],
     "test": [
-      "proverb_test.go",
-      "cases_test.go"
+      "proverb_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -15,11 +15,13 @@
       "rail_fence_cipher.go"
     ],
     "test": [
-      "rail_fence_cipher_test.go",
-      "cases_test.go"
+      "rail_fence_cipher_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -22,11 +22,13 @@
       "raindrops.go"
     ],
     "test": [
-      "raindrops_test.go",
-      "cases_test.go"
+      "raindrops_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -16,11 +16,13 @@
       "rectangles.go"
     ],
     "test": [
-      "rectangles_test.go",
-      "cases_test.go"
+      "rectangles_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -18,11 +18,13 @@
       "reverse_string.go"
     ],
     "test": [
-      "reverse_string_test.go",
-      "cases_test.go"
+      "reverse_string_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Introductory challenge to reverse an input string",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -23,11 +23,13 @@
       "rna_transcription.go"
     ],
     "test": [
-      "rna_transcription_test.go",
-      "cases_test.go"
+      "rna_transcription_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Hyperphysics",

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -25,11 +25,13 @@
       "roman_numerals.go"
     ],
     "test": [
-      "roman_numerals_test.go",
-      "cases_test.go"
+      "roman_numerals_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "The Roman Numeral Kata",

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -17,11 +17,13 @@
       "run_length_encoding.go"
     ],
     "test": [
-      "run_length_encoding_test.go",
-      "cases_test.go"
+      "run_length_encoding_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Wikipedia",

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -20,11 +20,13 @@
       "say.go"
     ],
     "test": [
-      "say_test.go",
-      "cases_test.go"
+      "say_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -17,11 +17,13 @@
       "scale_generator.go"
     ],
     "test": [
-      "scale_generator_test.go",
-      "cases_test.go"
+      "scale_generator_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -25,11 +25,13 @@
       "scrabble_score.go"
     ],
     "test": [
-      "scrabble_score_test.go",
-      "cases_test.go"
+      "scrabble_score_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by the Extreme Startup game",

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -26,11 +26,13 @@
       "secret_handshake.go"
     ],
     "test": [
-      "secret_handshake_test.go",
-      "cases_test.go"
+      "secret_handshake_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Bert, in Mary Poppins",

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -21,11 +21,13 @@
       "sieve.go"
     ],
     "test": [
-      "sieve_test.go",
-      "cases_test.go"
+      "sieve_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -21,11 +21,13 @@
       "space_age.go"
     ],
     "test": [
-      "space_age_test.go",
-      "cases_test.go"
+      "space_age_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -16,11 +16,13 @@
       "sublist.go"
     ],
     "test": [
-      "sublist_test.go",
-      "cases_test.go"
+      "sublist_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -23,11 +23,13 @@
       "sum_of_multiples.go"
     ],
     "test": [
-      "sum_of_multiples_test.go",
-      "cases_test.go"
+      "sum_of_multiples_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "A variation on Problem 1 at Project Euler",

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -21,11 +21,13 @@
       "transpose.go"
     ],
     "test": [
-      "transpose_test.go",
-      "cases_test.go"
+      "transpose_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -16,11 +16,13 @@
       "two_bucket.go"
     ],
     "test": [
-      "two_bucket_test.go",
-      "cases_test.go"
+      "two_bucket_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Water Pouring Problem",

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -25,11 +25,13 @@
       "variable_length_quantity.go"
     ],
     "test": [
-      "variable_length_quantity_test.go",
-      "cases_test.go"
+      "variable_length_quantity_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -25,11 +25,13 @@
       "word_count.go"
     ],
     "test": [
-      "word_count_test.go",
-      "cases_test.go"
+      "word_count_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -23,11 +23,13 @@
       "word_search.go"
     ],
     "test": [
-      "word_search_test.go",
-      "cases_test.go"
+      "word_search_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   }
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -22,11 +22,13 @@
       "wordy.go"
     ],
     "test": [
-      "wordy_test.go",
-      "cases_test.go"
+      "wordy_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -17,11 +17,13 @@
       "yacht.go"
     ],
     "test": [
-      "yacht_test.go",
-      "cases_test.go"
+      "yacht_test.go"
     ],
     "example": [
       ".meta/example.go"
+    ],
+    "editor": [
+      "cases_test.go"
     ]
   },
   "source": "James Kilfiger, using wikipedia",


### PR DESCRIPTION
This does the same as https://github.com/exercism/go/pull/1831, but to all exercises.

Fixes #1818 