### PR TITLE
matrix: fix test instruction

### DIFF
--- a/exercises/practice/matrix/matrix_test.go
+++ b/exercises/practice/matrix/matrix_test.go
@@ -3,7 +3,7 @@
 //
 // 1. Implement the type Matrix
 //
-// 2. Write a method with signature: New(s string) (Matrix, error)
+// 2. Write a method with signature: New(s string) (*Matrix, error)
 //
 // 3. Decorate the Matrix type, with three methods:
 //      - Cols() [][]int


### PR DESCRIPTION
This instruction might induce students in error., as `New` must return a pointer to Matrix.