### PR TITLE
Review concept links

### DIFF
--- a/concepts/arithmetic-operators/links.json
+++ b/concepts/arithmetic-operators/links.json
@@ -5,10 +5,10 @@
     },
     {
       "url": "https://golang.org/ref/spec#Arithmetic_operators",
-      "description": "Spec: Arithmetic operators"
+      "description": "Go Language Spec: Arithmetic operators"
     },
     {
       "url": "https://golang.org/ref/spec#IncDec_statements",
-      "description": "Spec: IncDec statements"
+      "description": "Go Language Spec: IncDec statements"
     }
 ]

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -8,23 +8,27 @@
     "description": "A Tour of Go"
   },
   {
-    "url": "https://golang.org/ref/spec#Function_declarations",
-    "description": "Function Declarations"
+    "url": "https://gobyexample.com/",
+    "description": "Go by Example"
   },
   {
-    "url": "https://golang.org/ref/spec#Calls",
-    "description": "Calls"
+    "url": "https://golang.org/doc/effective_go.html",
+    "description": "Effective Go"
   },
   {
-    "url": "https://golang.org/ref/spec#Return_statements",
-    "description": "Return Statements"
+    "url": "https://play.golang.org/",
+    "description": "Go Playground"
   },
   {
-    "url": "https://golang.org/ref/spec#Operators",
-    "description": "Operators"
+    "url": "https://pkg.go.dev/",
+    "description": "Go Packages"
   },
   {
-    "url": "https://golang.org/ref/spec#Integer_literals",
-    "description": "Integers"
+    "url": "https://github.com/avelino/awesome-go",
+    "description": "Awesome Go"
+  },
+  {
+    "url": "https://golang.org/ref/spec",
+    "description": "Go Language Specification"
   }
 ]

--- a/concepts/booleans/links.json
+++ b/concepts/booleans/links.json
@@ -1,7 +1,14 @@
 [
   {
-    "url": "https://golang.org/ref/spec#Logical_operators",
-    "description": "logical operators"
+    "url": "https://golangdocs.com/booleans-in-golang",
+    "description": "Article: Booleans in Golang"
   },
-  { "url": "https://golang.org/ref/spec#Operators", "description": "operators" }
+  {
+    "url": "https://golang.org/ref/spec#Logical_operators",
+    "description": "Go Language Spec: Logical Operators"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Operators",
+    "description": "Go Language Spec: Operators"
+  }
 ]

--- a/concepts/comments/links.json
+++ b/concepts/comments/links.json
@@ -1,20 +1,18 @@
 [
   {
-    "url": "https://golang.org/cmd/go/#hdr-Show_documentation_for_package_or_symbol",
-    "description": "godoc"
+    "url": "https://golang.org/doc/effective_go#commentary",
+    "description": "Effective Go: Commentary"
   },
-  { "url": "https://pkg.go.dev/", "description": "go packages" },
   {
     "url": "https://dave.cheney.net/practical-go/presentations/qcon-china.html#_dont_comment_bad_code_rewrite_it",
-    "description": "less comments"
+    "description": "Blog Post: Don’t comment bad code, rewrite it"
   },
   {
-    "url": "https://www.ardanlabs.com/blog/2014/03/exportedunexported-identifiers-in-go.html",
-    "description": "exported identifiers"
+    "url": "https://pkg.go.dev/cmd/go#hdr-Show_documentation_for_package_or_symbol",
+    "description": "Go tools: godoc"
   },
-  { "url": "https://github.com/golang/lint", "description": "golint" },
   {
-    "url": "https://golang.org/doc/effective_go.html",
-    "description": "effective go"
+    "url": "https://github.com/golang/lint",
+    "description": "Go tools: golint"
   }
 ]

--- a/concepts/comparison/links.json
+++ b/concepts/comparison/links.json
@@ -1,10 +1,10 @@
 [
   {
     "url": "https://golang.org/ref/spec#Comparison_operators",
-    "description": "Language Spec: Comparison Operators"
+    "description": "Go Language Spec: Comparison Operators"
   },
   {
     "url": "https://medium.com/golangspec/comparison-operators-in-go-910d9d788ec0",
-    "description": "Comparison Operators in Go"
+    "description": "Article: Comparison Operators in Go"
   }
 ]

--- a/concepts/conditionals-if/links.json
+++ b/concepts/conditionals-if/links.json
@@ -1,10 +1,18 @@
 [
   {
-    "url": "https://golang.org/ref/spec#If_statements",
-    "description": "if_statement"
+    "url": "https://gobyexample.com/if-else",
+    "description": "Go by Example: If/Else"
   },
   {
-    "url": "https://gobyexample.com/if-else",
-    "description": "go_by_example_if"
+    "url": "https://tour.golang.org/flowcontrol/7",
+    "description": "A Tour of Go: If and else"
+  },
+  {
+    "url": "https://golang.org/doc/effective_go#if",
+    "description": "Effective Go: If"
+  },
+  {
+    "url": "https://golang.org/ref/spec#If_statements",
+    "description": "Go Language Spec: If Statements"
   }
 ]

--- a/concepts/conditionals-switch/links.json
+++ b/concepts/conditionals-switch/links.json
@@ -1,11 +1,15 @@
 [
   {
     "url": "https://tour.golang.org/flowcontrol/9",
-    "description": "Tour of Go: Switch"
+    "description": "A Tour of Go: Switch"
   },
   {
     "url": "https://gobyexample.com/switch",
     "description": "Go by Example: Switch"
+  },
+  {
+    "url": "https://golang.org/doc/effective_go#switch",
+    "description": "Effective Go: Switch"
   },
   {
     "url": "https://golang.org/ref/spec#Switch_statements",

--- a/concepts/constants/links.json
+++ b/concepts/constants/links.json
@@ -1,1 +1,18 @@
-[]
+[
+    {
+        "url": "https://tour.golang.org/basics/15",
+        "description": "A Tour of Go: Constants"
+    },
+    {
+        "url": "https://gobyexample.com/constants",
+        "description": "Go by Example: Constants"
+    },
+    {
+        "url": "https://go.dev/blog/constants",
+        "description": "Go Dev Blog: Constants"
+    },
+    {
+        "url": "https://golang.org/ref/spec#Constants",
+        "description": "Go Language Spec: Constants"
+    }
+]

--- a/concepts/floating-point-numbers/links.json
+++ b/concepts/floating-point-numbers/links.json
@@ -1,6 +1,14 @@
 [
   {
     "url": "https://golangdocs.com/floating-point-numbers-in-golang",
-    "description": "Floating-Point Numbers in GoLang"
+    "description": "Article: Floating-Point Numbers in GoLang"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Floating-point_literals",
+    "description": "Go Language Spec: Floating-point literals"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Numeric_types",
+    "description": "Go Language Spec: Numeric Types"
   }
 ]

--- a/concepts/functions/links.json
+++ b/concepts/functions/links.json
@@ -1,18 +1,14 @@
 [
   {
-    "url": "https://golang.org/ref/spec#Exported_identifiers",
-    "description": "public-vs-private"
-  },
-  {
-    "url": "https://golang.org/ref/spec#Return_statements",
-    "description": "return"
-  },
-  {
     "url": "https://tour.golang.org/basics/4",
-    "description": "A tour of Go: functions"
+    "description": "A Tour of Go: Functions"
   },
   {
     "url": "https://gobyexample.com/functions",
     "description": "Go by Example: Functions"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Return_statements",
+    "description": "Go Language Spec: Return Statements"
   }
 ]

--- a/concepts/interfaces/links.json
+++ b/concepts/interfaces/links.json
@@ -1,15 +1,14 @@
 [
-    {
-      "url": "https://tour.golang.org/methods/9",
-      "description": "A Tour of Go: Interfaces"
-    },
-    {
-      "url": "https://gobyexample.com/interfaces",
-      "description": "Go by Example: Interfaces"
-    },
-    {
-      "url": "https://golang.org/doc/effective_go#interfaces",
-      "description": "Effective Go: Interfaces"
-    }
-  ]
-  
+  {
+    "url": "https://tour.golang.org/methods/9",
+    "description": "A Tour of Go: Interfaces"
+  },
+  {
+    "url": "https://gobyexample.com/interfaces",
+    "description": "Go by Example: Interfaces"
+  },
+  {
+    "url": "https://golang.org/doc/effective_go#interfaces",
+    "description": "Effective Go: Interfaces"
+  }
+]

--- a/concepts/maps/links.json
+++ b/concepts/maps/links.json
@@ -1,23 +1,22 @@
 [
   {
+    "url": "https://tour.golang.org/moretypes/19",
+    "description": "A Tour of Go: Maps"
+  },
+  {
+    "url": "https://gobyexample.com/maps",
+    "description": "Go by Example: Maps"
+  },
+  {
+    "url": "https://go.dev/blog/maps",
+    "description": "Go Dev Blog: Go maps in action"
+  },
+  {
+    "url": "https://golang.org/doc/effective_go#maps",
+    "description": "Effective Go: Maps"
+  },
+  {
     "url": "https://golang.org/ref/spec#Map_types",
-    "description": "gospec-map"
-  },
-  { "url": "https://blog.golang.org/maps", "description": "goblog-map" },
-  {
-    "url": "https://golang.org/ref/spec#Comparison_operators",
-    "description": "gospec-comparable"
-  },
-  {
-    "url": "https://golang.org/ref/spec#Comparison_operators",
-    "description": "gospec-comparable"
-  },
-  {
-    "url": "https://golang.org/doc/articles/race_detector.html",
-    "description": "godoc-race-detector"
-  },
-  {
-    "url": "https://blog.golang.org/race-detector",
-    "description": "goblog-race-detector"
+    "description": "Go Language Spec: Map Types"
   }
 ]

--- a/concepts/methods/links.json
+++ b/concepts/methods/links.json
@@ -1,14 +1,18 @@
 [
   {
     "url": "https://tour.golang.org/methods/1",
-    "description": "methods"
+    "description": "A Tour of Go: Methods"
   },
   {
     "url": "https://tour.golang.org/methods/4",
-    "description": "Pointer receivers"
+    "description": "A Tour of Go: Pointer receivers"
+  },
+  {
+    "url": "https://gobyexample.com/methods",
+    "description": "Go By Example: Methods"
   },
   {
     "url": "https://www.callicoder.com/golang-methods-tutorial/",
-    "description": "Methods tutorial"
+    "description": "Article: Golang Methods Tutorial with Examples"
   }
 ]

--- a/concepts/multiple-return-values/links.json
+++ b/concepts/multiple-return-values/links.json
@@ -1,10 +1,14 @@
 [
-    {
-      "url": "https://golang.org/doc/effective_go#multiple-returns",
-      "description": "Effective Go: Multiple Returns"
-    },
-    {
-      "url": "https://tour.golang.org/basics/6",
-      "description": "A Tour of Go: Multiple Results"
-    }
+  {
+    "url": "https://tour.golang.org/basics/6",
+    "description": "A Tour of Go: Multiple Results"
+  },
+  {
+    "url": "https://gobyexample.com/multiple-return-values",
+    "description": "Go By Example: Multiple Return Values"
+  },
+  {
+    "url": "https://golang.org/doc/effective_go#multiple-returns",
+    "description": "Effective Go: Multiple Returns"
+  }
 ]

--- a/concepts/numbers/links.json
+++ b/concepts/numbers/links.json
@@ -1,6 +1,14 @@
 [
   {
+    "url": "https://tour.golang.org/basics/11",
+    "description": "A Tour of Go: Basic Types"
+  },
+  {
     "url": "https://tour.golang.org/basics/13",
-    "description": "type-conversion"
+    "description": "A Tour of Go: Type Conversion"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Numeric_types",
+    "description": "Go Language Spec: Numeric types"
   }
 ]

--- a/concepts/packages/links.json
+++ b/concepts/packages/links.json
@@ -1,18 +1,26 @@
 [
   {
     "url": "https://tour.golang.org/basics/1",
-    "description": "Tour of Go: Packages"
+    "description": "A Tour of Go: Packages"
   },
   {
     "url": "https://tour.golang.org/basics/2",
-    "description": "Tour of Go: Imports"
+    "description": "A Tour of Go: Imports"
+  },
+  {
+    "url": "https://golang.org/doc/effective_go#package-names",
+    "description": "Effective Go: Package Names"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Exported_identifiers",
+    "description": "Go Language Spec: Exported Identifiers"
   },
   {
     "url": "https://golang.org/ref/spec#Import_declarations",
-    "description": "import-declaration-spec"
+    "description": "Go Language Spec: Import Declarations"
   },
   {
     "url": "https://golang.org/ref/spec#Package_clause",
-    "description": "package-spec"
+    "description": "Go Language Spec: Package Clause"
   }
 ]

--- a/concepts/pointers/links.json
+++ b/concepts/pointers/links.json
@@ -1,10 +1,14 @@
 [
     {
         "url": "https://tour.golang.org/moretypes/1",
-        "description": "Tour of Go: Pointers"
+        "description": "A Tour of Go: Pointers"
     },
     {
         "url": "https://gobyexample.com/pointers",
         "description": "Go by Example: Pointers"
+    },
+    {
+        "url": "https://www.digitalocean.com/community/conceptual_articles/understanding-pointers-in-go",
+        "description": "Article: Understanding Pointers in Go"
     }
 ]

--- a/concepts/range-iteration/links.json
+++ b/concepts/range-iteration/links.json
@@ -1,14 +1,14 @@
 [
   {
-    "url": "https://golang.org/ref/spec#For_range",
-    "description": "For statements with range clause"
-  },
-  {
     "url": "https://tour.golang.org/moretypes/16",
-    "description": "Range"
+    "description": "A Tour of Go: Range"
   },
   {
-    "url": "https://tour.golang.org/moretypes/17",
-    "description": "Range, omit variables"
+    "url": "https://gobyexample.com/range",
+    "description": "Go by Example: Range"
+  },
+  {
+    "url": "https://golang.org/ref/spec#For_range",
+    "description": "Go Language Spec: For statements with range clause"
   }
 ]

--- a/concepts/runes/links.json
+++ b/concepts/runes/links.json
@@ -1,18 +1,22 @@
 [
   {
     "url": "https://go.dev/blog/strings",
-    "description": "Strings, bytes, runes and characters in Go."
+    "description": "Go Dev Blog: Strings, bytes, runes and characters in Go."
+  },
+  {
+    "url": "https://golangdocs.com/rune-in-golang",
+    "description": "Article: What is rune in GoLang?"
   },
   {
     "url": "https://wikipedia.org/wiki/Unicode",
-    "description": "Wikipedia page for Unicode."
+    "description": "Wikipedia: Unicode."
   },
   {
     "url": "https://wikipedia.org/wiki/UTF-8",
-    "description": "Wikipedia page for UTF-8."
+    "description": "Wikipedia: UTF-8."
   },
   {
     "url": "https://wikipedia.org/wiki/List_of_Unicode_characters",
-    "description": "Wikipedia page listing Unicode characters."
+    "description": "Wikipedia: List of Unicode characters."
   }
 ]

--- a/concepts/slices/links.json
+++ b/concepts/slices/links.json
@@ -4,19 +4,19 @@
     "description": "A Tour of Go: Slices"
   },
   {
-    "url": "https://go.dev/blog/slices-intro",
-    "description": "Go Slices: usage and internals"
-  },
-  {
     "url": "https://gobyexample.com/slices",
     "description": "Go by Example: Slices"
   },
   {
-    "url": "https://golang.org/ref/spec#Slice_types",
-    "description": "Slice Types"
+    "url": "https://go.dev/blog/slices-intro",
+    "description": "Go Dev Blog: Slices - Usage and internals"
   },
   {
     "url": "https://github.com/golang/go/wiki/SliceTricks",
     "description": "Slice Tricks"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Slice_types",
+    "description": "Go Language Spec: Slice Types"
   }
 ]

--- a/concepts/string-formatting/links.json
+++ b/concepts/string-formatting/links.json
@@ -1,6 +1,18 @@
 [
   {
-    "url": "https://golang.org/ref/spec",
-    "description": "string concatenation"
-  }
+    "url": "https://gobyexample.com/string-formatting",
+    "description": "Go by Example: String formatting"
+  },
+  {
+    "url": "https://pkg.go.dev/fmt",
+    "description": "Go Packages: fmt package"
+  },
+  {
+    "url": "https://gobyexample.com/string-functions",
+    "description": "Go by Example: String Functions"
+  },
+  {
+    "url": "https://golangdocs.com/concatenate-strings-in-golang",
+    "description": "Article: 7 Ways to Concatenate Strings in Golang"
+  }  
 ]

--- a/concepts/strings-package/links.json
+++ b/concepts/strings-package/links.json
@@ -1,6 +1,10 @@
 [
   {
     "url": "https://pkg.go.dev/strings",
-    "description": "strings package"
+    "description": "Go Packages: strings package"
+  },
+  {
+    "url": "https://gobyexample.com/string-functions",
+    "description": "Go by Example: String Functions"
   }
 ]

--- a/concepts/strings/links.json
+++ b/concepts/strings/links.json
@@ -1,6 +1,18 @@
 [
   {
+    "url": "https://golangbot.com/strings/",
+    "description": "Article: Introduction to Strings in Go"
+  },
+  {
     "url": "https://go101.org/article/string.html",
-    "description": "Strings in Go"
+    "description": "Article: Strings in Go"
+  },
+  {
+    "url": "https://pkg.go.dev/strings",
+    "description": "Go Packages: strings package"
+  },
+  {
+    "url": "https://gobyexample.com/string-functions",
+    "description": "Go by Example: String Functions"
   }
 ]

--- a/concepts/structs/links.json
+++ b/concepts/structs/links.json
@@ -1,14 +1,14 @@
 [
   {
     "url": "https://gobyexample.com/structs",
-    "description": "Go by example: Structs"
+    "description": "Go by Example: Structs"
   },
   {
     "url": "https://tour.golang.org/moretypes/2",
-    "description": "A Tour of Go"
+    "description": "A Tour of Go: Structs"
   },
   {
     "url": "https://medium.com/rungo/structures-in-go-76377cc106a2",
-    "description": "Structures in Go (structs)"
+    "description": "Article: Structures in Go (structs)"
   }
 ]

--- a/concepts/time/links.json
+++ b/concepts/time/links.json
@@ -1,9 +1,26 @@
 [
-  { "url": "https://golang.org/pkg/time/#Time", "description": "time" },
-  { "url": "https://golang.org/pkg/time/#Now", "description": "now" },
-  { "url": "https://golang.org/pkg/time/#Parse", "description": "parse" },
+  {
+    "url": "https://gobyexample.com/time",
+    "description": "Go by Example: Time"
+  },
   {
     "url": "https://www.pauladamsmith.com/blog/2011/05/go_time.html",
-    "description": "article"
+    "description": "Blog Post: Parsing and formating dates/time in Go"
+  },
+  {
+    "url": "https://golang.org/pkg/time",
+    "description": "Go packages: time package"
+  },
+  {
+    "url": "https://golang.org/pkg/time/#Time",
+    "description": "Go packages: time.Time type"
+  },
+  {
+    "url": "https://golang.org/pkg/time/#Now",
+    "description": "Go packages: time.Now function"
+  },
+  {
+    "url": "https://golang.org/pkg/time/#Parse",
+    "description": "Go packages: time.Parse function"
   }
 ]

--- a/concepts/type-definitions/links.json
+++ b/concepts/type-definitions/links.json
@@ -1,18 +1,22 @@
 [
   {
     "url": "https://tour.golang.org/moretypes/2",
-    "description": "A Tour of Go"
-  },
-  {
-    "url": "https://go101.org/article/type-system-overview.html",
-    "description": "Go Type System Overview"
-  },
-  {
-    "url": "https://medium.com/rungo/structures-in-go-76377cc106a2",
-    "description": "Structures in Go"
+    "description": "A Tour of Go: Structs"
   },
   {
     "url": "https://gobyexample.com/structs",
     "description": "Go by Example: Structs"
+  },
+  {
+    "url": "https://golang.org/ref/spec#Struct_types",
+    "description": "Go Language Spec: Structs types"
+  },
+  {
+    "url": "https://go101.org/article/type-system-overview.html",
+    "description": "Go 101: Go Type System Overview"
+  },
+  {
+    "url": "https://yourbasic.org/golang/type-alias/",
+    "description": "Article: Type aliases vs type definitions"
   }
 ]

--- a/concepts/zero-values/links.json
+++ b/concepts/zero-values/links.json
@@ -1,10 +1,14 @@
 [
   {
+    "url": "https://tour.golang.org/basics/12",
+    "description": "A Tour of Go: Zero values"
+  },
+  {
     "url": "https://golang.org/ref/spec#The_zero_value",
-    "description": "Go language specification about zero value."
+    "description": "Go Language Spec: The zero value"
   },
   {
     "url": "https://dave.cheney.net/2013/01/19/what-is-the-zero-value-and-why-is-it-useful",
-    "description": "What is the zero value, and what is it useful?"
+    "description": "Blog Post: What is the zero value, and what is it useful?"
   }
 ]


### PR DESCRIPTION
Fixes #1605

I went through the links in the concepts currently live.

Overview of the changes:

* Added new links to some exercises, mainly to include links to "A Tour of Go",  "Go by Example" and "Effective Go" where appropriate. The idea was to assure every concept had at least one link someone totally new could follow and understand.
* Enforced a consistent naming scheme, where the link text is prefixed by its source:
    *  All links to https://tour.golang.org/ start with `A Tour of Go: `
    *  All links to https://golang.org/doc/effective_go start with `Effective Go: `
    *  All links to the language spec https://golang.org/ref/spec start with `Go Language Spec: `
    *  All links to https://gobyexample.com/ start with `Go by Example:  `
    *  All links to https://go.dev/blog/ start with `Go Dev Blog:  `
    * The prefixes `Blog Post: ` and `Article: ` were also used for other sources
* Added links to the `constants` concept
* Reordered the links from most basic to most advanced
* Consistent formatting of the files