### PR TITLE
need-for-speed: CanFinish starting battery can be less than 100%

### DIFF
--- a/exercises/concept/need-for-speed/.docs/hints.md
+++ b/exercises/concept/need-for-speed/.docs/hints.md
@@ -21,7 +21,8 @@
 
 ## 4. Check if a remote controlled car can finish a race
 
-- You need to calculate the maximum distance a car can drive
-- We assume that the cars' battery is charged to 100% initially
+- Assume the car is just starting the race
+- You need to calculate the maximum distance a car can drive with the current level of battery
+- Knowing the maximum distance the car can drive, compare it with the distance of the race track
 
 [struct]: https://tour.golang.org/moretypes/2

--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -54,7 +54,7 @@ car = Drive(car)
 
 ## 4. Check if a remote controlled car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `CanFinish` function that takes a `Car` and a `Track` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
+To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `CanFinish` function that takes a `Car` and a `Track` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`. Assume the car is just starting the race:
 
 ```go
 speed := 5

--- a/exercises/concept/need-for-speed/.meta/exemplar.go
+++ b/exercises/concept/need-for-speed/.meta/exemplar.go
@@ -44,6 +44,6 @@ func Drive(car Car) Car {
 
 // CanFinish checks if a car is able to finish a certain track.
 func CanFinish(car Car, track Track) bool {
-	maxDistance := car.battery / car.batteryDrain * car.distance
+	maxDistance := car.battery / car.batteryDrain * car.speed
 	return track.distance <= maxDistance
 }

--- a/exercises/concept/need-for-speed/need_for_speed_test.go
+++ b/exercises/concept/need-for-speed/need_for_speed_test.go
@@ -167,6 +167,32 @@ func TestCanFinish(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Car can finish the track distance with initial battery less than 100%",
+			car: Car{
+				speed:        2,
+				batteryDrain: 3,
+				battery:      25,
+				distance:     0,
+			},
+			track: Track{
+				distance: 16,
+			},
+			expected: true,
+		},
+		{
+			name: "Car cannot finish the track distance with initial battery less than 100%",
+			car: Car{
+				speed:        2,
+				batteryDrain: 3,
+				battery:      25,
+				distance:     0,
+			},
+			track: Track{
+				distance: 24,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -174,7 +200,7 @@ func TestCanFinish(t *testing.T) {
 			got := CanFinish(tt.car, tt.track)
 
 			if got != tt.expected {
-				t.Errorf("CanFinish(%v, %v) = %v; expected %v", tt.car, tt.track, got, tt.expected)
+				t.Errorf("CanFinish(%#v, %#v) = %v; expected %v", tt.car, tt.track, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1848

* Removes the Hint saying that one should assume the starting battery is 100%
* Added tests with starting battery lower than 100%
* I added the "assume the car is just starting the race" note to both the hint and the instructions to make it clear the distance the car already drove should not be taken into account (see https://github.com/exercism/go/issues/1848#issuecomment-943728158)