### PR TITLE
fix: concept methods typo

### DIFF
--- a/concepts/methods/about.md
+++ b/concepts/methods/about.md
@@ -11,7 +11,7 @@ func (receiver type) MethodName(parameters) (returnTypes) {
 You can only define a method with a receiver whose type is defined in the same package as the method.
 
 ```go
-type Person {
+type Person struct {
 	Name string
 }
 

--- a/concepts/methods/introduction.md
+++ b/concepts/methods/introduction.md
@@ -12,7 +12,7 @@ func (receiver type) MethodName(parameters) (returnTypes) {
 You can only define a method with a receiver whose type is defined in the same package as the method.
 
 ```go
-type Person {
+type Person struct {
     Name string
 }
 


### PR DESCRIPTION
Missing `struct` keyword.