### PR TITLE
allergies: add stub functions

### DIFF
--- a/exercises/practice/allergies/allergies.go
+++ b/exercises/practice/allergies/allergies.go
@@ -1,9 +1,9 @@
 package allergies
 
-func Allergies(i uint) []string {
+func Allergies(allergies uint) []string {
 	panic("Please implement the Allergies function")
 }
 
-func AllergicTo(i uint, allergen string) bool {
+func AllergicTo(allergies uint, allergen string) bool {
 	panic("Please implement the AllergicTo function")
 }


### PR DESCRIPTION
References:
- Github issue #1893 
- [`allergies_test.go`](https://github.com/exercism/go/blob/main/exercises/practice/allergies/allergies_test.go)

We would like to add stub functions to the practice exercises so that students know what API they are expected to implement.

This PR adds stubs for the two functions are required for this exercise: `Allergies` and `AllergicTo`