### PR TITLE
Adds Function Stub for grains.go Exercise

### DIFF
--- a/exercises/practice/grains/grains.go
+++ b/exercises/practice/grains/grains.go
@@ -1,6 +1,6 @@
 package grains
 
-func Square(number int) (uint64 error) {
+func Square(number int) (uint64, error) {
 	panic("Please implement the Square function")
 }
 


### PR DESCRIPTION
Adds function stubs according to [grains_test.go](https://github.com/exercism/go/blob/main/exercises/practice/grains/grains_test.go) and [Example.go](https://github.com/exercism/go/blob/main/exercises/practice/grains/.meta/example.go)