### PR TITLE
Check errors are not nil.

### DIFF
--- a/exercises/practice/protein-translation/protein_translation_test.go
+++ b/exercises/practice/protein-translation/protein_translation_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+func TestErrorsNotNil(t *testing.T) {
+	if ErrStop == nil {
+		t.Fatalf("FAIL: ErrStop cannot be nil")
+	}
+	if ErrInvalidBase == nil {
+		t.Fatalf("FAIL: ErrInvalidBase cannot be nil")
+	}
+}
+
 type codonCase struct {
 	input         string
 	expected      string


### PR DESCRIPTION
Otherwise it's possible to create a solution which never correctly returns any of the errors but which still passes the tests, as the tests compare the returned errors to these sentinel variables.

I realized that my original solution to this problem managed to do this when I mentored someone - I'd declared the error variables, written the initial lookup code, and then happily submitted my solution as all the tests passed and moved on; however I'd neglected to write any of the code to handle the error cases, oops!