### PR TITLE
Add stub functions to practice exercises M-P

### DIFF
--- a/exercises/practice/matching-brackets/matching_brackets.go
+++ b/exercises/practice/matching-brackets/matching_brackets.go
@@ -1,1 +1,5 @@
 package brackets
+
+func Bracket(input string) bool {
+	panic("Please implement the Bracket function")
+}

--- a/exercises/practice/matrix/matrix.go
+++ b/exercises/practice/matrix/matrix.go
@@ -1,1 +1,20 @@
 package matrix
+
+// Define the Matrix type here.
+
+func New(s string) (*Matrix, error) {
+	panic("Please implement the New function")
+}
+
+// Cols and Rows must return the results without affecting the matrix.
+func (m *Matrix) Cols() [][]int {
+	panic("Please implement the Cols function")
+}
+
+func (m *Matrix) Rows() [][]int {
+	panic("Please implement the Rows function")
+}
+
+func (m *Matrix) Set(row, col, val int) bool {
+	panic("Please implement the Set function")
+}

--- a/exercises/practice/matrix/matrix_test.go
+++ b/exercises/practice/matrix/matrix_test.go
@@ -1,18 +1,3 @@
-// For the Matrix exercise in Go you have to do a few things not mentioned
-// in the README.
-//
-// 1. Implement the type Matrix
-//
-// 2. Write a method with signature: New(s string) (*Matrix, error)
-//
-// 3. Decorate the Matrix type, with three methods:
-//      - Cols() [][]int
-//      - Rows() [][]int
-//      - Set(row, column, value int) bool
-//    Cols and Rows must return the results without affecting the matrix.
-//
-// Detect and return error when it is expected.
-
 package matrix
 
 import (

--- a/exercises/practice/meetup/meetup.go
+++ b/exercises/practice/meetup/meetup.go
@@ -1,1 +1,9 @@
 package meetup
+
+import "time"
+
+// Define the WeekSchedule type here.
+
+func Day(week WeekSchedule, weekday time.Weekday, month time.Month, year int) int {
+	panic("Please implement the Day function")
+}

--- a/exercises/practice/meetup/meetup_test.go
+++ b/exercises/practice/meetup/meetup_test.go
@@ -2,18 +2,6 @@ package meetup
 
 import "testing"
 
-/* API
-package meetup
-type WeekSchedule
-WeekSchedule First
-WeekSchedule Second
-WeekSchedule Third
-WeekSchedule Fourth
-WeekSchedule Last
-WeekSchedule Teenth
-func Day(WeekSchedule, time.Weekday, time.Month, int) int
-*/
-
 var weekName = map[WeekSchedule]string{
 	First:  "first",
 	Second: "second",

--- a/exercises/practice/minesweeper/minesweeper.go
+++ b/exercises/practice/minesweeper/minesweeper.go
@@ -1,1 +1,7 @@
 package minesweeper
+
+// Define the Board type here.
+
+func (b Board) Count() error {
+	panic("Please implement the Count function")
+}

--- a/exercises/practice/ocr-numbers/.docs/instructions.append.md
+++ b/exercises/practice/ocr-numbers/.docs/instructions.append.md
@@ -2,11 +2,11 @@
 
 ## Implementation Notes
 
-Define a function recognizeDigit as README Step 1 except make it recognize
+Define a function recognizeDigit as described in Step 1 of instructions except make it recognize
 all ten digits 0 to 9.  Pick what you like for parameters and return values
-but make it useful as a subroutine for README step 2.
+but make it useful as a subroutine for step 2.
 
-For README Step 2 define,
+For Step 2 define,
 
    func Recognize(string) []string
 

--- a/exercises/practice/ocr-numbers/.docs/instructions.append.md
+++ b/exercises/practice/ocr-numbers/.docs/instructions.append.md
@@ -1,0 +1,21 @@
+# Instructions append
+
+## Implementation Notes
+
+Define a function recognizeDigit as README Step 1 except make it recognize
+all ten digits 0 to 9.  Pick what you like for parameters and return values
+but make it useful as a subroutine for README step 2.
+
+For README Step 2 define,
+
+   func Recognize(string) []string
+
+and implement it using recognizeDigit.
+
+Input strings tested here have a \n at the beginning of each line and
+no trailing \n on the last line. (This makes for readable raw string
+literals.)
+
+For bonus points, gracefully handle misformatted data.  What should you
+do with a partial cell?  Discard it?  Pad with spaces?  Report it with a
+"?" character?  What should you do if the first character is not \n?

--- a/exercises/practice/ocr-numbers/ocr_numbers.go
+++ b/exercises/practice/ocr-numbers/ocr_numbers.go
@@ -1,1 +1,5 @@
 package ocr
+
+func Recognize(string) []string {
+	panic("Please implement the Recognize function")
+}

--- a/exercises/practice/ocr-numbers/ocr_numbers_test.go
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.go
@@ -1,23 +1,3 @@
-// Go requirements:
-//
-// Define a function recognizeDigit as README Step 1 except make it recognize
-// all ten digits 0 to 9.  Pick what you like for parameters and return values
-// but make it useful as a subroutine for README step 2.
-//
-// For README Step 2 define,
-//
-//    func Recognize(string) []string
-//
-// and implement it using recognizeDigit.
-//
-// Input strings tested here have a \n at the beginning of each line and
-// no trailing \n on the last line. (This makes for readable raw string
-// literals.)
-//
-// For bonus points, gracefully handle misformatted data.  What should you
-// do with a partial cell?  Discard it?  Pad with spaces?  Report it with a
-// "?" character?  What should you do if the first character is not \n?
-
 package ocr
 
 import (

--- a/exercises/practice/paasio/paasio.go
+++ b/exercises/practice/paasio/paasio.go
@@ -3,7 +3,7 @@ package paasio
 import "io"
 
 // Define readCounter and writeCounter types here.
-
+// For the return of the function NewReadWriteCounter, you must also define a type that satisfies the ReadWriteCounter interface.
 func NewWriteCounter(writer io.Writer) WriteCounter {
 	panic("Please implement the NewWriterCounter function")
 }

--- a/exercises/practice/paasio/paasio.go
+++ b/exercises/practice/paasio/paasio.go
@@ -1,1 +1,33 @@
 package paasio
+
+import "io"
+
+// Define readCounter and writeCounter types here.
+
+func NewWriteCounter(writer io.Writer) WriteCounter {
+	panic("Please implement the NewWriterCounter function")
+}
+
+func NewReadCounter(reader io.Reader) ReadCounter {
+	panic("Please implement the NewReadCounter function")
+}
+
+func NewReadWriteCounter(readwriter io.ReadWriter) ReadWriteCounter {
+	panic("Please implement the NewReadWriteCounter function")
+}
+
+func (rc *readCounter) Read(p []byte) (int, error) {
+	panic("Please implement the Read function")
+}
+
+func (rc *readCounter) ReadCount() (int64, int) {
+	panic("Please implement the ReadCount function")
+}
+
+func (wc *writeCounter) Write(p []byte) (int, error) {
+	panic("Please implement the Write function")
+}
+
+func (wc *writeCounter) WriteCount() (int64, int) {
+	panic("Please implement the WriteCount function")
+}

--- a/exercises/practice/paasio/paasio.go
+++ b/exercises/practice/paasio/paasio.go
@@ -3,7 +3,9 @@ package paasio
 import "io"
 
 // Define readCounter and writeCounter types here.
+
 // For the return of the function NewReadWriteCounter, you must also define a type that satisfies the ReadWriteCounter interface.
+
 func NewWriteCounter(writer io.Writer) WriteCounter {
 	panic("Please implement the NewWriterCounter function")
 }

--- a/exercises/practice/palindrome-products/palindrome_products.go
+++ b/exercises/practice/palindrome-products/palindrome_products.go
@@ -1,1 +1,7 @@
 package palindrome
+
+// Define Product type here.
+
+func Products(fmin, fmax int) (Product, Product, error) {
+	panic("Please implement the Products function")
+}

--- a/exercises/practice/palindrome-products/palindrome_products_test.go
+++ b/exercises/practice/palindrome-products/palindrome_products_test.go
@@ -7,16 +7,6 @@ import (
 	"testing"
 )
 
-/* API to implement:
-
-type Product struct {
-	Product int // palindromic, of course
-	Factorizations [][2]int //list of all possible two-factor factorizations of Product, within given limits, in order
- }
-
- func Products(fmin, fmax int) (pmin, pmax Product, error)
-*/
-
 var testData = []struct {
 	// input to Products(): range limits for factors of the palindrome
 	fmin, fmax int

--- a/exercises/practice/pangram/pangram.go
+++ b/exercises/practice/pangram/pangram.go
@@ -1,1 +1,5 @@
 package pangram
+
+func IsPangram(input string) bool {
+	panic("Please implement the IsPangram function")
+}

--- a/exercises/practice/pascals-triangle/pascals_triangle.go
+++ b/exercises/practice/pascals-triangle/pascals_triangle.go
@@ -1,1 +1,5 @@
 package pascal
+
+func Triangle(n int) [][]int {
+	panic("Please implement the Triangle function")
+}

--- a/exercises/practice/perfect-numbers/perfect_numbers.go
+++ b/exercises/practice/perfect-numbers/perfect_numbers.go
@@ -1,1 +1,7 @@
 package perfect
+
+// Define the Classification type here.
+
+func Classify(n int64) (Classification, error) {
+	panic("Please implement the Classify function")
+}

--- a/exercises/practice/phone-number/phone_number.go
+++ b/exercises/practice/phone-number/phone_number.go
@@ -1,1 +1,13 @@
 package phonenumber
+
+func Number(phoneNumber string) (string, error) {
+	panic("Please implement the Number function")
+}
+
+func AreaCode(phoneNumber string) (string, error) {
+	panic("Please implement the AreaCode function")
+}
+
+func Format(phoneNumber string) (string, error) {
+	panic("Please implement the Format function")
+}

--- a/exercises/practice/pig-latin/pig_latin.go
+++ b/exercises/practice/pig-latin/pig_latin.go
@@ -1,1 +1,5 @@
 package piglatin
+
+func Sentence(sentence string) string {
+	panic("Please implement the Sentence function")
+}

--- a/exercises/practice/poker/poker.go
+++ b/exercises/practice/poker/poker.go
@@ -1,1 +1,5 @@
 package poker
+
+func BestHand(hands []string) ([]string, error) {
+	panic("Please implement the BestHand function")
+}

--- a/exercises/practice/poker/poker_test.go
+++ b/exercises/practice/poker/poker_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-// Define a function BestHand([]string) ([]string, error).
-
 var invalidTestCases = []struct {
 	name string
 	hand string

--- a/exercises/practice/pov/.docs/instructions.append.md
+++ b/exercises/practice/pov/.docs/instructions.append.md
@@ -1,0 +1,31 @@
+# Instructions append
+
+## Implementation Notes
+
+POV / reparent / change root of a tree
+
+The type name is Graph because you'll probably be implementing a general
+directed graph representation, although the test program will only use
+it to create a tree.  The term "arc" is used here to mean a directed edge.
+
+The test program will create a graph with New, then use AddNode to add
+leaf nodes.  After that it will use AddArc to construct the rest of the tree
+from the bottom up.  That is, the `to` argument will always specify a node
+that has already been added.
+
+ArcList is a dump method to let the test program see your graph.  It must
+return a list of all arcs in the graph.  Format each arc as a single string
+like "from -> to". The test program can then easily sort the list and
+compare it to an expected result.  You do not need to bother with sorting
+the list yourself.
+
+All this graph construction and dumping must be working before you start
+on the interesting part of the exercise, so it is tested separately as
+a first test.
+
+API function ChangeRoot does the interesting part of the exercise.
+OldRoot is passed (as a convenience) and you must return a graph with
+newRoot as the root.  You can modify the original graph in place and
+return it or create a new graph and return that.  If you return a new
+graph you are free to consume or destroy the original graph.  Of course
+it's nice to leave it unmodified.

--- a/exercises/practice/pov/pov.go
+++ b/exercises/practice/pov/pov.go
@@ -1,1 +1,23 @@
 package pov
+
+// Define the Graph type here.
+
+func New() *Graph {
+	panic("Please implement the New function")
+}
+
+func (g *Graph) AddNode(nodeLabel string) {
+	panic("Please implement the AddNode function")
+}
+
+func (g *Graph) AddArc(from, to string) {
+	panic("Please implement the AddArc function")
+}
+
+func (g *Graph) ArcList() []string {
+	panic("Please implement the ArcList function")
+}
+
+func (g *Graph) ChangeRoot(oldRoot, newRoot string) *Graph {
+	panic("Please implement the ChangeRoot function")
+}

--- a/exercises/practice/pov/pov_test.go
+++ b/exercises/practice/pov/pov_test.go
@@ -6,42 +6,6 @@ import (
 	"testing"
 )
 
-// POV / reparent / change root of a tree
-//
-// API:
-// type Graph
-// func New() *Graph
-// func (*Graph) AddNode(nodeLabel string)
-// func (*Graph) AddArc(from, to string)
-// func (*Graph) ArcList() []string
-// func (*Graph) ChangeRoot(oldRoot, newRoot string) *Graph
-//
-// The type name is Graph because you'll probably be implementing a general
-// directed graph representation, although the test program will only use
-// it to create a tree.  The term "arc" is used here to mean a directed edge.
-//
-// The test program will create a graph with New, then use AddNode to add
-// leaf nodes.  After that it will use AddArc to construct the rest of the tree
-// from the bottom up.  That is, the `to` argument will always specify a node
-// that has already been added.
-//
-// ArcList is a dump method to let the test program see your graph.  It must
-// return a list of all arcs in the graph.  Format each arc as a single string
-// like "from -> to". The test program can then easily sort the list and
-// compare it to an expected result.  You do not need to bother with sorting
-// the list yourself.
-//
-// All this graph construction and dumping must be working before you start
-// on the interesting part of the exercise, so it is tested separately as
-// a first test.
-//
-// API function ChangeRoot does the interesting part of the exercise.
-// OldRoot is passed (as a convenience) and you must return a graph with
-// newRoot as the root.  You can modify the original graph in place and
-// return it or create a new graph and return that.  If you return a new
-// graph you are free to consume or destroy the original graph.  Of course
-// it's nice to leave it unmodified.
-
 type arc struct{ fr, to string }
 
 type testCase struct {

--- a/exercises/practice/prime-factors/prime_factors.go
+++ b/exercises/practice/prime-factors/prime_factors.go
@@ -1,1 +1,5 @@
 package prime
+
+func Factors(n int64) []int64 {
+	panic("Please implement the Factors function")
+}

--- a/exercises/practice/protein-translation/protein_translation.go
+++ b/exercises/practice/protein-translation/protein_translation.go
@@ -1,1 +1,9 @@
 package protein
+
+func FromRNA(rna string) ([]string, error) {
+	panic("Please implement the FromRNA function")
+}
+
+func FromCodon(codon string) (string, error) {
+	panic("Please implement the FromCodon function")
+}

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet.go
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet.go
@@ -1,1 +1,18 @@
 package pythagorean
+
+type Triplet [3]int
+
+// Range returns a list of all Pythagorean triplets with sides in the
+// range min to max inclusive.
+func Range(min, max int) []Triplet {
+	panic("Please implement the Range function")
+}
+
+// Sum returns a list of all Pythagorean triplets where the sum a+b+c
+// (the perimeter) is equal to p.
+// The three elements of each returned triplet must be in order,
+// t[0] <= t[1] <= t[2], and the list of triplets must be in lexicographic
+// order.
+func Sum(p int) []Triplet {
+	panic("Please implement the Sum function")
+}

--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.go
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet_test.go
@@ -1,24 +1,5 @@
 package pythagorean
 
-// Use this type definition,
-//
-//    type Triplet [3]int
-//
-// and implement two functions,
-//
-//    Range(min, max int) []Triplet
-//    Sum(p int) []Triplet
-//
-// Range returns a list of all Pythagorean triplets with sides in the
-// range min to max inclusive.
-//
-// Sum returns a list of all Pythagorean triplets where the sum a+b+c
-// (the perimeter) is equal to p.
-//
-// The three elements of each returned triplet must be in order,
-// t[0] <= t[1] <= t[2], and the list of triplets must be in lexicographic
-// order.
-
 import (
 	"reflect"
 	"testing"


### PR DESCRIPTION
Related to #1893 

We would like to add stub functions to the practice exercises so that students know what API they are expected to implement. We would also like to remove any API descriptions from test files as these may go out of sync with the code over time

This PR adds stubs for practice exercises starting with letters M through to P and updates the associated test files accordingly

The following practice exercises have been omitted (mostly because they already have stubs):
- [markdown](https://github.com/exercism/go/blob/main/exercises/practice/markdown/markdown.go)
- [nth-prime](https://github.com/exercism/go/blob/main/exercises/practice/nth-prime/nth_prime.go)
- [nucleotide-count](https://github.com/exercism/go/blob/main/exercises/practice/nucleotide-count/nucleotide_count.go)
- [octal](https://github.com/exercism/go/blob/main/exercises/practice/octal/octal.go) - This exercise is deprecated https://github.com/exercism/go/blob/48e725c15ba8461d778af5203e5b28a441bc3ac8/config.json#L1752
- [parallel-letter-frequency](https://github.com/exercism/go/blob/main/exercises/practice/parallel-letter-frequency/parallel_letter_frequency.go)
- [proverb](https://github.com/exercism/go/blob/main/exercises/practice/proverb/proverb.go)