### PR TITLE
Add stub functions to practice exercises Q-S

### DIFF
--- a/exercises/practice/queen-attack/queen_attack.go
+++ b/exercises/practice/queen-attack/queen_attack.go
@@ -1,5 +1,5 @@
 package queenattack
 
-func CanQueenAttack(whiteQueen, blackQueen string) (bool, error) {
+func CanQueenAttack(whitePosition, blackPosition string) (bool, error) {
 	panic("Please implement the CanQueenAttack function")
 }

--- a/exercises/practice/queen-attack/queen_attack.go
+++ b/exercises/practice/queen-attack/queen_attack.go
@@ -1,1 +1,5 @@
 package queenattack
+
+func CanQueenAttack(whiteQueen, blackQueen string) (bool, error) {
+	panic("Please implement the CanQueenAttack function")
+}

--- a/exercises/practice/rail-fence-cipher/rail_fence_cipher.go
+++ b/exercises/practice/rail-fence-cipher/rail_fence_cipher.go
@@ -1,1 +1,9 @@
 package railfence
+
+func Encode(message string, rails int) string {
+	panic("Please implement the Encode function")
+}
+
+func Decode(message string, rails int) string {
+	panic("Please implement the Decode function")
+}

--- a/exercises/practice/react/react.go
+++ b/exercises/practice/react/react.go
@@ -1,6 +1,7 @@
 package react
 
 // Define reactor, cell and canceler types here.
+// These types will implement the Reactor, Cell and Canceler interfaces, respectively.
 
 func (c *canceler) Cancel() {
 	panic("Please implement the Cancel function")

--- a/exercises/practice/react/react.go
+++ b/exercises/practice/react/react.go
@@ -1,1 +1,35 @@
 package react
+
+// Define reactor, cell and canceler types here.
+
+func (c *canceler) Cancel() {
+	panic("Please implement the Cancel function")
+}
+
+func (c *cell) Value() int {
+	panic("Please implement the Value function")
+}
+
+func (c *cell) SetValue(value int) {
+	panic("Please implement the SetValue function")
+}
+
+func (c *cell) AddCallback(callback func(int)) Canceler {
+	panic("Please implement the AddCallback function")
+}
+
+func New() Reactor {
+	panic("Please implement the New function")
+}
+
+func (r *reactor) CreateInput(initial int) InputCell {
+	panic("Please implement the CreateInput function")
+}
+
+func (r *reactor) CreateCompute1(dep Cell, compute func(int) int) ComputeCell {
+	panic("Please implement the CreateCompute1 function")
+}
+
+func (r *reactor) CreateCompute2(dep1, dep2 Cell, compute func(int, int) int) ComputeCell {
+	panic("Please implement the CreateCompute2 function")
+}

--- a/exercises/practice/rectangles/rectangles.go
+++ b/exercises/practice/rectangles/rectangles.go
@@ -1,1 +1,5 @@
 package rectangles
+
+func Count(diagram []string) int {
+	panic("Please implement the Count function")
+}

--- a/exercises/practice/reverse-string/reverse_string.go
+++ b/exercises/practice/reverse-string/reverse_string.go
@@ -1,1 +1,5 @@
 package reverse
+
+func Reverse(input string) string {
+	panic("Please implement the Reverse function")
+}

--- a/exercises/practice/robot-name/robot_name.go
+++ b/exercises/practice/robot-name/robot_name.go
@@ -1,1 +1,11 @@
 package robotname
+
+// Define the Robot type here.
+
+func (r *Robot) Name() (string, error) {
+	panic("Please implement the Name function")
+}
+
+func (r *Robot) Reset() {
+	panic("Please implement the Reset function")
+}

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,0 +1,71 @@
+# Instructions append
+
+## Implementation Notes
+
+Tests are separated into 3 steps.
+
+Run all tests with `go test` or run specific tests with the -tags option.
+Examples:
+
+   go test                      # run all tests
+   go test -tags step1          # run just step 1 tests.
+   go test -tags 'step1 step2'  # run step1 and step2 tests
+
+You are given the source file defs.go which defines a number of things
+the test program requires.  It is organized into three sections by step.
+
+## Step 1
+
+To complete step 1 you will define Right, Left, Advance, N, S, E, W,
+and Dir.String.  Complete step 1 before moving on to step 2.
+
+## Step 2
+
+For step 1 you implemented robot movements, but it's not much of a simulation.
+For example where in the source code is "the robot"?  Where is "the grid"?
+Where are the computations that turn robot actions into grid positions,
+in the robot, or in the grid?  The physical world is different.
+
+Step 2 introduces a "room."  It seems a small addition, but we'll make
+big changes to clarify the roles of "room", "robot", and "test program"
+and begin to clarify the physics of the simulation.  You will define Room
+and Robot as functions which the test program "brings into existence" by
+launching them as goroutines.  Information moves between test program,
+robot, and room over Go channels.
+
+Think of Room as a "physics engine," something that models and simulates
+a physical room with walls and a robot.  It should somehow model the
+coordinate space of the room, the location of the robot and the walls,
+and ensure for example that the robot doesn't walk through walls.
+We want Robot to be an agent that performs actions, but we want Room to
+maintain a coherent truth.
+
+The test program creates the channels and starts both Room and Robot.
+The test program then sends commands to Robot.  When it is done sending
+commands, it closes the command channel.  Robot must accept commands and
+inform Room of actions it is attempting.  When it senses the command channel
+closing, it must shut itself down.  The room must interpret the physical
+consequences of the robot actions.  When it senses the robot shutting down,
+it sends a final report back to the test program, telling the robot's final
+position and direction.
+
+## Step 3
+
+Step 3 has three major changes:
+
+*  Robots run scripts rather than respond to individual commands.
+*  A log channel allows robots and the room to log messages.
+*  The room allows multiple robots to exist and operate concurrently.
+
+For the final position report sent from StartRobot3, you can return the same slice
+received from the robots channel, just with updated positions and directions.
+
+Messages must be sent on the log channel for
+*  A robot without a name
+*  Duplicate robot names
+*  Robots placed at the same place
+*  A robot placed outside of the room
+*  An undefined command in a script
+*  An action from an unknown robot
+*  A robot attempting to advance into a wall
+*  A robot attempting to advance into another robot

--- a/exercises/practice/robot-simulator/robot_simulator.go
+++ b/exercises/practice/robot-simulator/robot_simulator.go
@@ -2,6 +2,7 @@ package robot
 
 // See defs.go for other definitions
 
+// Step 1
 // Define Dir type here.
 // Define N, E, S, W here.
 
@@ -21,6 +22,7 @@ func (d Dir) String() string {
 	panic("Please implement the String function")
 }
 
+// Step 2
 // Define Action type here.
 
 func StartRobot(command chan Command, action chan Action) {
@@ -31,6 +33,7 @@ func Room(extent Rect, robot Step2Robot, action chan Action, report chan Step2Ro
 	panic("Please implement the Room function")
 }
 
+// Step 3
 // Define Action3 type here.
 
 func StartRobot3(name, script string, action chan Action3, log chan string) {

--- a/exercises/practice/robot-simulator/robot_simulator.go
+++ b/exercises/practice/robot-simulator/robot_simulator.go
@@ -1,1 +1,42 @@
 package robot
+
+// See defs.go for other definitions
+
+// Define Dir type here.
+// Define N, E, S, W here.
+
+func Right() {
+	panic("Please implement the Right function")
+}
+
+func Left() {
+	panic("Please implement the Left function")
+}
+
+func Advance() {
+	panic("Please implement the Advance function")
+}
+
+func (d Dir) String() string {
+	panic("Please implement the String function")
+}
+
+// Define Action type here.
+
+func StartRobot(command chan Command, action chan Action) {
+	panic("Please implement the StartRobot function")
+}
+
+func Room(extent Rect, robot Step2Robot, action chan Action, report chan Step2Robot) {
+	panic("Please implement the Room function")
+}
+
+// Define Action3 type here.
+
+func StartRobot3(name, script string, action chan Action3, log chan string) {
+	panic("Please implement the StartRobot3 function")
+}
+
+func Room3(extent Rect, robots []Step3Robot, action chan Action3, rep chan []Step3Robot, log chan string) {
+	panic("Please implement the Room3 function")
+}

--- a/exercises/practice/robot-simulator/robot_simulator_step2_test.go
+++ b/exercises/practice/robot-simulator/robot_simulator_step2_test.go
@@ -24,13 +24,6 @@ import "testing"
 // We want Robot to be an agent that performs actions, but we want Room to
 // maintain a coherent truth.
 //
-// Step 2 API:
-//
-// StartRobot(chan Command, chan Action)
-// Room(extent Rect, robot Step2Robot, act chan Action, rep chan Step2Robot)
-//
-// You get to define Action; see defs.go for other definitions.
-//
 // The test program creates the channels and starts both Room and Robot.
 // The test program then sends commands to Robot.  When it is done sending
 // commands, it closes the command channel.  Robot must accept commands and

--- a/exercises/practice/robot-simulator/robot_simulator_step2_test.go
+++ b/exercises/practice/robot-simulator/robot_simulator_step2_test.go
@@ -5,34 +5,6 @@ package robot
 
 import "testing"
 
-// For step 1 you implemented robot movements, but it's not much of a simulation.
-// For example where in the source code is "the robot"?  Where is "the grid"?
-// Where are the computations that turn robot actions into grid positions,
-// in the robot, or in the grid?  The physical world is different.
-//
-// Step 2 introduces a "room."  It seems a small addition, but we'll make
-// big changes to clarify the roles of "room", "robot", and "test program"
-// and begin to clarify the physics of the simulation.  You will define Room
-// and Robot as functions which the test program "brings into existence" by
-// launching them as goroutines.  Information moves between test program,
-// robot, and room over Go channels.
-//
-// Think of Room as a "physics engine," something that models and simulates
-// a physical room with walls and a robot.  It should somehow model the
-// coordinate space of the room, the location of the robot and the walls,
-// and ensure for example that the robot doesn't walk through walls.
-// We want Robot to be an agent that performs actions, but we want Room to
-// maintain a coherent truth.
-//
-// The test program creates the channels and starts both Room and Robot.
-// The test program then sends commands to Robot.  When it is done sending
-// commands, it closes the command channel.  Robot must accept commands and
-// inform Room of actions it is attempting.  When it senses the command channel
-// closing, it must shut itself down.  The room must interpret the physical
-// consequences of the robot actions.  When it senses the robot shutting down,
-// it sends a final report back to the test program, telling the robot's final
-// position and direction.
-
 var test2 = []struct {
 	Command
 	Step2Robot

--- a/exercises/practice/robot-simulator/robot_simulator_step3_test.go
+++ b/exercises/practice/robot-simulator/robot_simulator_step3_test.go
@@ -5,25 +5,6 @@ package robot
 
 import "testing"
 
-// Step 3 has three major changes:
-//
-// *  Robots run scripts rather than respond to individual commands.
-// *  A log channel allows robots and the room to log messages.
-// *  The room allows multiple robots to exist and operate concurrently.
-//
-// For the final position report sent from StartRobot3, you can return the same slice
-// received from the robots channel, just with updated positions and directions.
-//
-// Messages must be sent on the log channel for
-// *  A robot without a name
-// *  Duplicate robot names
-// *  Robots placed at the same place
-// *  A robot placed outside of the room
-// *  An undefined command in a script
-// *  An action from an unknown robot
-// *  A robot attempting to advance into a wall
-// *  A robot attempting to advance into another robot
-
 var testOneRobot = []struct {
 	cmd byte
 	Step2Robot

--- a/exercises/practice/robot-simulator/robot_simulator_step3_test.go
+++ b/exercises/practice/robot-simulator/robot_simulator_step3_test.go
@@ -11,13 +11,6 @@ import "testing"
 // *  A log channel allows robots and the room to log messages.
 // *  The room allows multiple robots to exist and operate concurrently.
 //
-// Step 3 API:
-//
-//    StartRobot3(name, script string, action chan Action3, log chan string)
-//    Room3(extent Rect, robots []Step3Robot, action chan Action3, report chan []Step3Robot, log chan string)
-//
-// Again, you define Action3.
-//
 // For the final position report sent from StartRobot3, you can return the same slice
 // received from the robots channel, just with updated positions and directions.
 //

--- a/exercises/practice/robot-simulator/robot_simulator_test.go
+++ b/exercises/practice/robot-simulator/robot_simulator_test.go
@@ -3,23 +3,8 @@
 
 package robot
 
-// Tests are separated into 3 steps.
-//
-// Run all tests with `go test` or run specific tests with the -tags option.
-// Examples,
-//
-//    go test                      # run all tests
-//    go test -tags step1          # run just step 1 tests.
-//    go test -tags 'step1 step2'  # run step1 and step2 tests
-//
 // This source file contains step 1 tests only.  For other tests see
 // robot_simulator_step2_test.go and robot_simulator_step3_test.go.
-//
-// You are given the source file defs.go which defines a number of things
-// the test program requires.  It is organized into three sections by step.
-//
-// To complete step 1 you will define Right, Left, Advance, N, S, E, W,
-// and Dir.String.  Complete step 1 before moving on to step 2.
 
 import (
 	"runtime"

--- a/exercises/practice/roman-numerals/roman_numerals.go
+++ b/exercises/practice/roman-numerals/roman_numerals.go
@@ -1,1 +1,5 @@
 package romannumerals
+
+func ToRomanNumeral(input int) (string, error) {
+	panic("Please implement the ToRomanNumeral function")
+}

--- a/exercises/practice/rotational-cipher/rotational_cipher.go
+++ b/exercises/practice/rotational-cipher/rotational_cipher.go
@@ -1,1 +1,5 @@
 package rotationalcipher
+
+func RotationalCipher(plain string, shiftKey int) string {
+	panic("Please implement the RotationalCipher function")
+}

--- a/exercises/practice/run-length-encoding/run_length_encoding.go
+++ b/exercises/practice/run-length-encoding/run_length_encoding.go
@@ -1,1 +1,9 @@
 package encode
+
+func RunLengthEncode(input string) string {
+	panic("Please implement the RunLengthEncode function")
+}
+
+func RunLengthDecode(input string) string {
+	panic("Please implement the RunLengthDecode function")
+}

--- a/exercises/practice/saddle-points/saddle_points.go
+++ b/exercises/practice/saddle-points/saddle_points.go
@@ -1,1 +1,11 @@
 package matrix
+
+// Define the Matrix and Pair type here.
+
+func New(s string) (*Matrix, error) {
+	panic("Please implement the New function")
+}
+
+func (m *Matrix) Saddle() []Pair {
+	panic("Please implement the Saddle function")
+}

--- a/exercises/practice/saddle-points/saddle_points.go
+++ b/exercises/practice/saddle-points/saddle_points.go
@@ -1,6 +1,6 @@
 package matrix
 
-// Define the Matrix and Pair type here.
+// Define the Matrix and Pair types here.
 
 func New(s string) (*Matrix, error) {
 	panic("Please implement the New function")

--- a/exercises/practice/say/say.go
+++ b/exercises/practice/say/say.go
@@ -1,1 +1,5 @@
 package say
+
+func Say(n int64) (string, bool) {
+	panic("Please implement the Say function")
+}

--- a/exercises/practice/scale-generator/scale_generator.go
+++ b/exercises/practice/scale-generator/scale_generator.go
@@ -1,1 +1,5 @@
 package scale
+
+func Scale(tonic, interval string) []string {
+	panic("Please implement the Scale function")
+}

--- a/exercises/practice/secret-handshake/secret_handshake.go
+++ b/exercises/practice/secret-handshake/secret_handshake.go
@@ -1,1 +1,5 @@
 package secret
+
+func Handshake(code uint) []string {
+	panic("Please implement the Handshake function")
+}

--- a/exercises/practice/series/series.go
+++ b/exercises/practice/series/series.go
@@ -1,1 +1,9 @@
 package series
+
+func All(n int, s string) []string {
+	panic("Please implement the All function")
+}
+
+func UnsafeFirst(n int, s string) string {
+	panic("Please implement the UnsafeFirst function")
+}

--- a/exercises/practice/series/series_test.go
+++ b/exercises/practice/series/series_test.go
@@ -1,32 +1,3 @@
-// Define two functions:  (Two? Yes, sometimes we ask more out of Go.)
-//
-//    // All returns a list of all substrings of s with length n.
-//    All(n int, s string) []string
-//
-//    // UnsafeFirst returns the first substring of s with length n.
-//    UnsafeFirst(n int, s string) string
-//
-// At this point you could consider this exercise complete and move on.
-// But wait, maybe you ask a reasonable question:
-// Why is the function called **Unsafe** First?
-// If you are interested, read on for a bonus exercise.
-//
-// Bonus exercise:
-//
-// Once you get `go test` passing, try `go test -tags asktoomuch`.
-// This uses a *build tag* to enable a test that wasn't enabled before.
-// You can read more about those at https://golang.org/pkg/go/build/#hdr-Build_Constraints
-//
-// You may notice that you can't make this asktoomuch test happy.
-// We need a way to signal that in some cases you can't take the first N characters of the string.
-// UnsafeFirst can't do that since it only returns a string.
-//
-// To fix that, let's add another return value to the function.  Define
-//
-//    First(int, string) (first string, ok bool)
-//
-// and test with `go test -tags first`.
-
 package series
 
 import (

--- a/exercises/practice/sieve/sieve.go
+++ b/exercises/practice/sieve/sieve.go
@@ -1,1 +1,5 @@
 package sieve
+
+func Sieve(limit int) []int {
+	panic("Please implement the Sieve function")
+}

--- a/exercises/practice/simple-cipher/simple_cipher.go
+++ b/exercises/practice/simple-cipher/simple_cipher.go
@@ -1,1 +1,32 @@
 package cipher
+
+// Define the shift and vigenere types here.
+// Both types should satisfy the Cipher interface.
+
+func NewCaesar() Cipher {
+	panic("Please implement the NewCaesar function")
+}
+
+func NewShift(distance int) Cipher {
+	panic("Please implement the NewShift function")
+}
+
+func (c shift) Encode(input string) string {
+	panic("Please implement the Encode function")
+}
+
+func (c shift) Decode(input string) string {
+	panic("Please implement the Decode function")
+}
+
+func NewVigenere(key string) Cipher {
+	panic("Please implement the NewVigenere function")
+}
+
+func (v vigenere) Encode(input string) string {
+	panic("Please implement the Encode function")
+}
+
+func (v vigenere) Decode(input string) string {
+	panic("Please implement the Decode function")
+}

--- a/exercises/practice/simple-linked-list/simple_linked_list.go
+++ b/exercises/practice/simple-linked-list/simple_linked_list.go
@@ -1,1 +1,27 @@
 package linkedlist
+
+// Define the List and Element types here.
+
+func New([]int) *List {
+	panic("Please implement the New function")
+}
+
+func (l *List) Size() int {
+	panic("Please implement the Size function")
+}
+
+func (l *List) Push(element int) {
+	panic("Please implement the Push function")
+}
+
+func (l *List) Pop() (int, error) {
+	panic("Please implement the Pop function")
+}
+
+func (l *List) Array() []int {
+	panic("Please implement the Array function")
+}
+
+func (l *List) Reverse() *List {
+	panic("Please implement the Reverse function")
+}

--- a/exercises/practice/simple-linked-list/simple_linked_list_test.go
+++ b/exercises/practice/simple-linked-list/simple_linked_list_test.go
@@ -1,22 +1,3 @@
-// API:
-//
-// type Element struct {
-//  data int
-//  next *Element
-// }
-//
-// type List struct {
-//  head *Element
-//  size int
-// }
-//
-// func New([]int) *List
-// func (*List) Size() int
-// func (*List) Push(int)
-// func (*List) Pop() (int, error)
-// func (*List) Array() []int
-// func (*List) Reverse() *List
-
 package linkedlist
 
 import (

--- a/exercises/practice/spiral-matrix/spiral_matrix.go
+++ b/exercises/practice/spiral-matrix/spiral_matrix.go
@@ -1,1 +1,5 @@
 package spiralmatrix
+
+func SpiralMatrix(size int) [][]int {
+	panic("Please implement the SpiralMatrix function")
+}

--- a/exercises/practice/strain/strain.go
+++ b/exercises/practice/strain/strain.go
@@ -1,1 +1,21 @@
 package strain
+
+type Ints []int
+type Lists [][]int
+type Strings []string
+
+func (i Ints) Keep(filter func(int) bool) Ints {
+	panic("Please implement the Keep function")
+}
+
+func (i Ints) Discard(filter func(int) bool) Ints {
+	panic("Please implement the Discard function")
+}
+
+func (l Lists) Keep(filter func([]int) bool) Lists {
+	panic("Please implement the Keep function")
+}
+
+func (s Strings) Keep(filter func(string) bool) Strings {
+	panic("Please implement the Keep function")
+}

--- a/exercises/practice/strain/strain_test.go
+++ b/exercises/practice/strain/strain_test.go
@@ -1,17 +1,3 @@
-// Collections, hm?  For this exercise in Go you'll work with slices as
-// collections.  Define the following in your solution:
-//
-//    type Ints []int
-//    type Lists [][]int
-//    type Strings []string
-//
-// Then complete the exercise by implementing these methods:
-//
-//    (Ints) Keep(func(int) bool) Ints
-//    (Ints) Discard(func(int) bool) Ints
-//    (Lists) Keep(func([]int) bool) Lists
-//    (Strings) Keep(func(string) bool) Strings
-
 package strain
 
 import (

--- a/exercises/practice/sublist/sublist.go
+++ b/exercises/practice/sublist/sublist.go
@@ -1,1 +1,5 @@
 package sublist
+
+func Sublist(l1, l2 []int) string {
+	panic("Please implement the Sublist function")
+}

--- a/exercises/practice/sum-of-multiples/sum_of_multiples.go
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples.go
@@ -1,1 +1,5 @@
 package summultiples
+
+func SumMultiples(limit int, divisors ...int) int {
+	panic("Please implement the SumMultiples function")
+}


### PR DESCRIPTION
Related to #1893 

We would like to add stub functions to the practice exercises so that students know what API they are expected to implement. We would also like to remove any API descriptions from test files as these may go out of sync with the code over time

This PR adds stubs for practice exercises starting with letters Q through to S and updates the associated test files accordingly

The following practice exercises have been omitted because they already have stubs defined:
- [raindrops](https://github.com/exercism/go/blob/main/exercises/practice/raindrops/raindrops.go)
- [rna-transcription](https://github.com/exercism/go/blob/main/exercises/practice/rna-transcription/rna_transcription.go)
- [scrabble-score](https://github.com/exercism/go/blob/main/exercises/practice/scrabble-score/scrabble_score.go)
- [space-age](https://github.com/exercism/go/blob/main/exercises/practice/space-age/space_age.go)