### PR TITLE
gross store: added test case for item added twice

### DIFF
--- a/exercises/concept/gross-store/gross_store_test.go
+++ b/exercises/concept/gross-store/gross_store_test.go
@@ -65,6 +65,16 @@ func TestAddItem(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"check quantity of item added twice",
+			[]entry{
+				{"peas", "quarter_of_a_dozen", 3},
+				{"peas", "quarter_of_a_dozen", 6},
+				{"tomato", "half_of_a_dozen", 6},
+				{"tomato", "quarter_of_a_dozen", 9},
+			},
+			true,
+		},
 	}
 	units := Units()
 	for _, tt := range tests {


### PR DESCRIPTION
See [#1940](https://github.com/exercism/go/issues/1940).

Testing using `bill[item] = units[unit]` fails with the following:

```
=== RUN   TestAddItem
=== RUN   TestAddItem/Invalid_measurement_unit
=== RUN   TestAddItem/Valid_measurement_unit
=== RUN   TestAddItem/check_quantity_of_item_added_twice
    gross_store_test.go:95: Expected peas to have quantity 6 in customer bill, found 3
    gross_store_test.go:95: Expected tomato to have quantity 9 in customer bill, found 3
--- FAIL: TestAddItem (0.00s)
    --- PASS: TestAddItem/Invalid_measurement_unit (0.00s)
    --- PASS: TestAddItem/Valid_measurement_unit (0.00s)
    --- FAIL: TestAddItem/check_quantity_of_item_added_twice (0.00s)
FAIL
exit status 1
FAIL    gross   0.001s
```

Testing with correct code `bill[item] += units[unit]` passes with the following:

```
=== RUN   TestAddItem
=== RUN   TestAddItem/Invalid_measurement_unit
=== RUN   TestAddItem/Valid_measurement_unit
=== RUN   TestAddItem/check_quantity_of_item_added_twice
--- PASS: TestAddItem (0.00s)
    --- PASS: TestAddItem/Invalid_measurement_unit (0.00s)
    --- PASS: TestAddItem/Valid_measurement_unit (0.00s)
    --- PASS: TestAddItem/check_quantity_of_item_added_twice (0.00s)
PASS
ok      gross   0.001s
```