### PR TITLE
Interest-is-Interesting: Fix float comparison

### DIFF
--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
@@ -8,8 +8,9 @@ import (
 const floatEqualityThreshold = 1e-5
 
 func floatingPointEquals(got, want float64) bool {
-	return math.Abs(got-want) <= floatEqualityThreshold ||
-		math.Abs(got-want)/(math.Abs(got)+math.Abs(want)) <= floatEqualityThreshold
+	absoluteDifferenceBelowTreshold := math.Abs(got-want) <= floatEqualityThreshold
+	relativeDifferenceBelowTreshold := math.Abs(got-want)/(math.Abs(got)+math.Abs(want)) <= floatEqualityThreshold
+	return absoluteDifferenceBelowTreshold || relativeDifferenceBelowTreshold
 }
 
 func TestInterestRate(t *testing.T) {

--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
@@ -8,7 +8,8 @@ import (
 const floatEqualityThreshold = 1e-5
 
 func floatingPointEquals(got, want float64) bool {
-	return math.Abs(got-want) <= floatEqualityThreshold
+	return math.Abs(got-want) <= floatEqualityThreshold ||
+		math.Abs(got-want)/(math.Abs(got)+math.Abs(want)) <= floatEqualityThreshold
 }
 
 func TestInterestRate(t *testing.T) {


### PR DESCRIPTION
Fixes #1842 
Changed the comparison between floats to work with bigger values, as suggested by @junedev 

Also found the following options that ended up being more strict:
```go
(math.Abs(x - y) <= epsilon * math.Max(math.Abs(x), math.Abs(y)))
```

And the following one that accepted two different thresholds:
```go
((math.Abs(x-y) <= epsilonTol) || (math.Abs(x-y) <= epsilonRel*math.Max(math.Abs(x), math.Abs(y))))
```

All of the options above also worked with the tests on the Interest-is-Interesting exercise and fixed the issue, but june's suggestion accepted a wider range of values.
The solutions above were found here: http://realtimecollisiondetection.net/blog/?p=89
