### PR TITLE
party-robot: clarify difference between Println and Printf

### DIFF
--- a/exercises/concept/party-robot/.docs/introduction.md
+++ b/exercises/concept/party-robot/.docs/introduction.md
@@ -42,4 +42,4 @@ fmt.Sprintf("%.2f", number)
 // Returns: 4.32
 ```
 
-`fmt` contains other functions for working with strings, such as `Println` which simply prints the arguments it receives to the console and `Printf` which formats the input in the same way as `Sprintf` before printing it.
+`fmt` contains other functions for working with strings, such as `Println` which simply prints the arguments it receives to the console and `Printf` which formats the input in the same way as `Sprintf` before printing it. Note that `Println` has built-in whitespace and newline logic when printing output to the console, whereas `Printf` does not.


### PR DESCRIPTION
This additional comment in the Introduction section of the party-robot exercise aims to capture an important difference in usage of fmt.Println and fmt.Printf.