### PR TITLE
party-robot: update tests

### DIFF
--- a/exercises/concept/party-robot/party_robot_test.go
+++ b/exercises/concept/party-robot/party_robot_test.go
@@ -81,11 +81,11 @@ func TestAssignTable(t *testing.T) {
 		{
 			description: "Greet Xuân Jing and give them directions to their seat",
 			name:        "Xuân Jing",
-			direction:   "on the right",
+			direction:   "by the façade",
 			tableNumber: 4,
 			distance:    23.470103,
-			seatmate:    "Eike",
-			want:        "Welcome to my party, Xuân Jing!\nYou have been assigned to table 004. Your table is on the right, exactly 23.5 meters from here.\nYou will be sitting next to Eike.",
+			seatmate:    "Renée",
+			want:        "Welcome to my party, Xuân Jing!\nYou have been assigned to table 004. Your table is by the façade, exactly 23.5 meters from here.\nYou will be sitting next to Renée.",
 		},
 	}
 	for _, tt := range tests {

--- a/exercises/concept/party-robot/party_robot_test.go
+++ b/exercises/concept/party-robot/party_robot_test.go
@@ -87,6 +87,15 @@ func TestAssignTable(t *testing.T) {
 			seatmate:    "Renée",
 			want:        "Welcome to my party, Xuân Jing!\nYou have been assigned to table 004. Your table is by the façade, exactly 23.5 meters from here.\nYou will be sitting next to Renée.",
 		},
+		{
+			description: "Greet Paula and give them directions to their seat",
+			name:        "Paula",
+			direction:   "on the right",
+			tableNumber: 101,
+			distance:    100.0,
+			seatmate:    "Chioma",
+			want:        "Welcome to my party, Paula!\nYou have been assigned to table 101. Your table is on the right, exactly 100.0 meters from here.\nYou will be sitting next to Chioma.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {


### PR DESCRIPTION
This change does the following:
* extend an existing testcase to include non-standard ASCII character values for other string parameters as well. Note that this was already being checked for the `name` parameter, but was not checked for the `direction` and `seatmate` parameters.
* add a new testcase which checks additional value scenarios for `tableNumber` (an int parameter) and `distance` (a float64 parameter)