### PR TITLE
Add stub functions to practice exercises T-Z

### DIFF
--- a/exercises/practice/tournament/tournament.go
+++ b/exercises/practice/tournament/tournament.go
@@ -1,1 +1,7 @@
 package tournament
+
+import "io"
+
+func Tally(reader io.Reader, writer io.Writer) error {
+	panic("Please implement the Tally function")
+}

--- a/exercises/practice/transpose/transpose.go
+++ b/exercises/practice/transpose/transpose.go
@@ -1,1 +1,5 @@
 package transpose
+
+func Transpose(input []string) []string {
+	panic("Please implement the Transpose function")
+}

--- a/exercises/practice/twelve-days/twelve_days.go
+++ b/exercises/practice/twelve-days/twelve_days.go
@@ -1,1 +1,9 @@
 package twelve
+
+func Verse(i int) string {
+	panic("Please implement the Verse function")
+}
+
+func Song() string {
+	panic("Please implement the Song function")
+}

--- a/exercises/practice/two-bucket/two_bucket.go
+++ b/exercises/practice/two-bucket/two_bucket.go
@@ -1,1 +1,5 @@
 package twobucket
+
+func Solve(sizeBucketOne, sizeBucketTwo, goalAmount int, startBucket string) (string, int, int, error) {
+	panic("Please implement the Solve function")
+}

--- a/exercises/practice/variable-length-quantity/variable_length_quantity.go
+++ b/exercises/practice/variable-length-quantity/variable_length_quantity.go
@@ -1,1 +1,9 @@
 package variablelengthquantity
+
+func EncodeVarint(input []uint32) []byte {
+	panic("Please implement the EncodeVarint function")
+}
+
+func DecodeVarint(input []byte) ([]uint32, error) {
+	panic("Please implement the EncodeVarint function")
+}

--- a/exercises/practice/word-count/word_count.go
+++ b/exercises/practice/word-count/word_count.go
@@ -1,1 +1,7 @@
 package wordcount
+
+type Frequency map[string]int
+
+func WordCount(phrase string) Frequency {
+	panic("Please implement the WordCount function")
+}

--- a/exercises/practice/word-count/word_count_test.go
+++ b/exercises/practice/word-count/word_count_test.go
@@ -5,11 +5,6 @@ import (
 	"testing"
 )
 
-// wordcount API
-//
-// func WordCount(phrase string) Frequency  // Implement this function.
-// type Frequency map[string]int            // Using this return type.
-
 func TestWordCount(t *testing.T) {
 	for _, tt := range testCases {
 		expected := tt.output

--- a/exercises/practice/word-search/word_search.go
+++ b/exercises/practice/word-search/word_search.go
@@ -1,1 +1,5 @@
 package wordsearch
+
+func Solve(words []string, puzzle []string) (map[string][2][2]int, error) {
+	panic("Please implement the Solve function")
+}

--- a/exercises/practice/word-search/word_search_test.go
+++ b/exercises/practice/word-search/word_search_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-// Define a function Solve(words []string, puzzle []string) (map[string][2][2]int, error).
-
 func TestSolve(t *testing.T) {
 	for _, tc := range testCases {
 		actual, err := Solve(tc.words, tc.puzzle)

--- a/exercises/practice/wordy/wordy.go
+++ b/exercises/practice/wordy/wordy.go
@@ -1,1 +1,5 @@
 package wordy
+
+func Answer(question string) (int, bool) {
+	panic("Please implement the Answer function")
+}

--- a/exercises/practice/yacht/yacht.go
+++ b/exercises/practice/yacht/yacht.go
@@ -1,1 +1,5 @@
 package yacht
+
+func Score(dice []int, category string) int {
+	panic("Please implement the Score function")
+}

--- a/exercises/practice/zebra-puzzle/.docs/instructions.append.md
+++ b/exercises/practice/zebra-puzzle/.docs/instructions.append.md
@@ -6,17 +6,6 @@ zebra-puzzle questions "Who drinks water?" and "Who owns the Zebra?".
 Each answer will be one of the resident's nationalities:
 Englishman, Spaniard, Ukrainian, Norwegian, or Japanese.
 
-For the SolvePuzzle function, use the following signature:
-
-```
-type Solution struct {
-	DrinksWater string
-	OwnsZebra string
-}
-
-func SolvePuzzle() Solution
-```
-
 Obviously, you could simply write a one-liner function
 if you peek at the test program to see the expected solution.
 But the goal is to develop an algorithm which uses

--- a/exercises/practice/zebra-puzzle/zebra_puzzle.go
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle.go
@@ -1,1 +1,7 @@
 package zebra
+
+// Define the Solution type here
+
+func SolvePuzzle() Solution {
+	panic("Please implement the SolvePuzzle function")
+}

--- a/exercises/practice/zebra-puzzle/zebra_puzzle.go
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle.go
@@ -1,6 +1,9 @@
 package zebra
 
-// Define the Solution type here
+type Solution struct {
+	DrinksWater string
+	OwnsZebra   string
+}
 
 func SolvePuzzle() Solution {
 	panic("Please implement the SolvePuzzle function")


### PR DESCRIPTION
Closes #1893 

We would like to add stub functions to the practice exercises so that students know what API they are expected to implement. We would also like to remove any API descriptions from test files as these may go out of sync with the code over time

This PR adds stubs for practice exercises starting with letters T through to Z and updates the associated test files accordingly

The following practice exercises have been omitted because they already have stubs defined:
- [tree-building](https://github.com/exercism/go/blob/main/exercises/practice/tree-building/tree_building.go)
- [triangle](https://github.com/exercism/go/blob/main/exercises/practice/triangle/triangle.go)
- [trinary](https://github.com/exercism/go/blob/main/exercises/practice/trinary/trinary.go) - this exercise is also deprecated https://github.com/exercism/go/blob/d8d2082055301d6edc2c6040f894111d17e3c1c2/config.json#L1769-L1778
- [two-fer](https://github.com/exercism/go/blob/main/exercises/practice/two-fer/two_fer.go)
