### PR TITLE
Fix typo

### DIFF
--- a/exercises/practice/binary-search-tree/binary_search_tree_test.go
+++ b/exercises/practice/binary-search-tree/binary_search_tree_test.go
@@ -221,6 +221,6 @@ func TestMapIntWithComplexStructure(t *testing.T) {
 	actual := bst.MapInt(f)
 	expected := []int{1, 2, 3, 4, 5, 6, 7}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("bst.MapString(): %v, want %v.", actual, expected)
+		t.Errorf("bst.MapInt(): %v, want %v.", actual, expected)
 	}
 }


### PR DESCRIPTION
This test invokes `MapInt`. It looks like a copy + paste mistake because previous tests invoked `MapString`