### PR TITLE
vehicle-purchase: fix CalculateResellPrice price description (#1934)

### DIFF
--- a/exercises/concept/vehicle-purchase/.docs/instructions.md
+++ b/exercises/concept/vehicle-purchase/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-In this exercise you are going to write some code to help you prepare to buy a vehicle.
+In this exercise, you are going to write some code to help you prepare to buy a vehicle.
 
 You have three tasks, one to determine if you need a licence, one to help you choose between two vehicles and one to estimate the acceptable price for a used vehicle.
 
@@ -38,8 +38,8 @@ ChooseVehicle("Volkswagen Beetle", "Volkswagen Golf")
 Now that you made a decision, you want to make sure you get a fair price at the dealership.
 Since you are interested in buying a used vehicle, the price depends on how old the vehicle is.
 For a rough estimate, assume if the vehicle is less than 3 years old, it costs 80% of the original price it had when it was brand new.
-If it is more than 10 years old, it costs 50%.
-If the vehicle is at least 3 years old but not older than 10 years, it costs 70% of the original price.
+If it is at least 10 years old, it costs 50%.
+If the vehicle is at least 3 years old but less than 10 years, it costs 70% of the original price.
 
 Implement the `CalculateResellPrice(originalPrice, age)` function that applies this logic using `if`, `else if` and `else` (there are other ways if you want to practice).
 It takes the original price and the age of the vehicle as arguments and returns the estimated price in the dealership.

--- a/exercises/concept/vehicle-purchase/vehicle_purchase_test.go
+++ b/exercises/concept/vehicle-purchase/vehicle_purchase_test.go
@@ -141,7 +141,7 @@ func TestCalculateResellPrice(t *testing.T) {
 			expected:      28000,
 		},
 		{
-			name:          "price is reduced to 70%% for age 10",
+			name:          "price is reduced to 50%% for age 10",
 			originalPrice: 25000,
 			age:           10,
 			expected:      12500,


### PR DESCRIPTION
The test for the method at 10 years old was expecting the resell price
to be 50% of the original, not the 70% that was implied by the
instructions.

This comes from a student who commented _If it is more than 10 years old, it costs 50%. Wouldn't the above statement translate into the following? if age > 10 { rate = 0.5 }_ with the following implementation:

```go
func CalculateResellPrice(originalPrice, age float64) float64 {
          
    var rate float64
    if age < 3 {
        rate = 0.8
    } else if age >= 10 {
        rate = 0.5
    } else {
    	rate = 0.7
    }
          
	return originalPrice * rate
}
```

Note, I had a look at the original Javascript version. It looks like their test for 10 year was correctly expecting 70%. I went with adjusting the instructions and test in this PR as there are now existing solutions - if we changed the test data instead, their tests would fail if they update the exercise.