### PR TITLE
vehicle-purchase: correct spelling of `License`. - #1965

### DIFF
--- a/exercises/concept/vehicle-purchase/.docs/hints.md
+++ b/exercises/concept/vehicle-purchase/.docs/hints.md
@@ -1,6 +1,6 @@
 # Hints
 
-## 1. Determine if you will need a driver's licence
+## 1. Determine if you will need a driver's license
 
 - Use the [equals comparison operator][comparison-operators] to check whether your input equals a certain string.
 - Use one of the two [logical operators][logical-operators] you learned about in the boolean concept to combine the two requirements.

--- a/exercises/concept/vehicle-purchase/.docs/instructions.md
+++ b/exercises/concept/vehicle-purchase/.docs/instructions.md
@@ -2,20 +2,20 @@
 
 In this exercise you are going to write some code to help you prepare to buy a vehicle.
 
-You have three tasks, one to determine if you need a licence, one to help you choose between two vehicles and one to estimate the acceptable price for a used vehicle.
+You have three tasks, one to determine if you need a license, one to help you choose between two vehicles and one to estimate the acceptable price for a used vehicle.
 
-## 1. Determine if you will need a driver's licence
+## 1. Determine if you will need a driver's license
 
-Some vehicle kinds require a driver's licence to operate them.
-Assume only the kinds `"car"` and `"truck"` require a licence, everything else can be operated without a licence.
+Some vehicle kinds require a driver's license to operate them.
+Assume only the kinds `"car"` and `"truck"` require a license, everything else can be operated without a license.
 
-Implement the `NeedsLicence(kind)` function that takes the kind of vehicle and returns a boolean indicating whether you need a licence for that kind of vehicle.
+Implement the `NeedsLicense(kind)` function that takes the kind of vehicle and returns a boolean indicating whether you need a license for that kind of vehicle.
 
 ```go
-needLicence := NeedsLicence("car")
+needLicense := NeedsLicense("car")
 // Output: true
 
-needLicence = NeedsLicence("bike")
+needLicense = NeedsLicense("bike")
 // Output: false
 ```
 

--- a/exercises/concept/vehicle-purchase/.meta/exemplar.go
+++ b/exercises/concept/vehicle-purchase/.meta/exemplar.go
@@ -1,7 +1,7 @@
 package purchase
 
-// NeedsLicence determines whether a licence is need to drive a type of vehicle. Only "car" and "truck" require a licence.
-func NeedsLicence(kind string) bool {
+// NeedsLicense determines whether a license is need to drive a type of vehicle. Only "car" and "truck" require a license.
+func NeedsLicense(kind string) bool {
 	return kind == "car" || kind == "truck"
 }
 

--- a/exercises/concept/vehicle-purchase/vehicle_purchase.go
+++ b/exercises/concept/vehicle-purchase/vehicle_purchase.go
@@ -1,8 +1,8 @@
 package purchase
 
-// NeedsLicence determines whether a licence is need to drive a type of vehicle. Only "car" and "truck" require a licence.
-func NeedsLicence(kind string) bool {
-	panic("NeedsLicence not implemented")
+// NeedsLicense determines whether a license is need to drive a type of vehicle. Only "car" and "truck" require a license.
+func NeedsLicense(kind string) bool {
+	panic("NeedsLicense not implemented")
 }
 
 // ChooseVehicle recommends a vehicle for selection. It always recommends the vehicle that comes first in dictionary order.

--- a/exercises/concept/vehicle-purchase/vehicle_purchase_test.go
+++ b/exercises/concept/vehicle-purchase/vehicle_purchase_test.go
@@ -7,34 +7,34 @@ import (
 
 const floatEqualityThreshold = 1e-5
 
-func TestNeedsLicence(t *testing.T) {
+func TestNeedsLicense(t *testing.T) {
 	tests := []struct {
 		name     string
 		kind     string
 		expected bool
 	}{
 		{
-			name:     "need a licence for a car",
+			name:     "need a license for a car",
 			kind:     "car",
 			expected: true,
 		},
 		{
-			name:     "need a licence for a truck",
+			name:     "need a license for a truck",
 			kind:     "truck",
 			expected: true,
 		},
 		{
-			name:     "does not need a licence for a bike",
+			name:     "does not need a license for a bike",
 			kind:     "bike",
 			expected: false,
 		},
 		{
-			name:     "does not need a licence for a stroller",
+			name:     "does not need a license for a stroller",
 			kind:     "stroller",
 			expected: false,
 		},
 		{
-			name:     "does not need a licence for a e-scooter",
+			name:     "does not need a license for a e-scooter",
 			kind:     "e-scooter",
 			expected: false,
 		},
@@ -42,10 +42,10 @@ func TestNeedsLicence(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := NeedsLicence(test.kind)
+			actual := NeedsLicense(test.kind)
 			if actual != test.expected {
 				t.Errorf(
-					"NeedsLicence(%q) = %t, want %t",
+					"NeedsLicense(%q) = %t, want %t",
 					test.kind,
 					actual,
 					test.expected)


### PR DESCRIPTION
Replace the occurence of the word Licence with License.
closes #1965
