### PR TITLE
cars-assemble: Rework to cover only numbers & arithmetic-operators

### DIFF
--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -7,20 +7,20 @@
 
 ## 1. Calculate the number of working cars produced per hour
 
-- The percentage passed as an argument is a number between 0-100. To make this percentage a bit easier to work with, start by dividing it by 100.
+- The percentage (passed as an argument) is a number between 0-100. To make this percentage a bit easier to work with, start by dividing it by 100.
 - To compute the number of cars produced successfully, multiply the percentage (divided by 100) by the number of cars produced.
 - When multiplying two numbers together, they both need to be of the same type. Use [type conversions][type conversions] if needed.
 
 ## 2. Calculate the number of working cars produced per minute
 
-- Start by calculating the production of successful cars per hour. For this, you can use the `CalculateProductionRatePerHour` function you made on the previous step.
+- Start by calculating the production of successful cars per hour. For this, you can use the `CalculateProductionRatePerHour` function you made from the previous step.
 - Knowing the production per hour of cars, you can get the production per minute by dividing the production per hour by 60 (the number of minutes in an hour)
 - Remember to cast the result to an `int`.
 
 ## 3. Calculate the cost of production 
 
 - Start by working out how many complete groups of 10 there are.
-- Then work out how many cars are remaining (there is an [operator][modulo operator] for this).
+- Then work out how many cars are remaining (the [operator][modulo operator] is useful for this).
 - From the remaining, work out how many complete groups of 3 there are and then how many are left ungrouped.
 
 [basic types]: https://tour.golang.org/basics/11

--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -2,17 +2,19 @@
 
 ## General
 
-- [Basic types][basic types] and [Type conversions][type conversions] tutorials.
+- To know more about types in Go, check [Tour of Go: Basic Types][basic types]
+- To know more about type conversions in Go, check [Tour of Go: Type Conversions][type conversions]
 
 ## 1. Calculate the number of working cars produced per hour
 
-- To calculate, divide the percentage by 100 and multiply the result by the number of cars produced.
-- When multiple two numbers together, they both need to be of the same type.
+- The percentage passed as an argument is a number between 0-100. To make this percentage a bit easier to work with, start by dividing it by 100.
+- To compute the number of cars produced successfully, multiply the percentage (divided by 100) by the number of cars produced.
+- When multiplying two numbers together, they both need to be of the same type. Use [type conversions][type conversions] if needed.
 
 ## 2. Calculate the number of working cars produced per minute
 
-- Use the `CalculateProductionRatePerHour` function.
-- Remember, there are 60 minutes in an hour.
+- Start by calculating the production of successful cars per hour. For this, you can use the `CalculateProductionRatePerHour` function you made on the previous step.
+- Knowing the production per hour of cars, you can get the production per minute by dividing the production per hour by 60 (the number of minutes in an hour)
 - Remember to cast the result to an `int`.
 
 ## 3. Calculate the cost of production 

--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -4,24 +4,23 @@
 
 - [Basic types][basic types] and [Type conversions][type conversions] tutorials.
 
-## 1. Calculate the success rate
+## 1. Calculate the number of working cars produced per hour
 
-- Use if conditionals to return the values in the table.
+- To calculate, divide the percentage by 100 and multiply the result by the number of cars produced.
+- When multiple two numbers together, they both need to be of the same type.
 
-## 2. Calculate the production rate per hour
-
-- Use the `successRate` method coupled with the base rate (221 times the speed).
-- When multiplying two numbers by one another, they both need to be of the same type.
-
-## 3. Calculate the number of working items produced per minute
+## 2. Calculate the number of working cars produced per minute
 
 - Use the `CalculateProductionRatePerHour` function.
+- Remember, there are 60 minutes in an hour.
 - Remember to cast the result to an `int`.
 
-## 4. Calculate the artificially-limited production rate
+## 3. Calculate the cost of production 
 
-- Use the `CalculateProductionRatePerHour` function.
-- Use an initializer statement for the if condition.
+- Start by working out how many complete groups of 10 there are.
+- Then work out how many cars are remaining (there is an [operator][modulo operator] for this).
+- From the remaining, work out how many complete groups of 3 there are and then how many are left ungrouped.
 
 [basic types]: https://tour.golang.org/basics/11
 [type conversions]: https://tour.golang.org/basics/13
+[modulo operator]: https://golangbyexample.com/remainder-modulus-go-golang/

--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -2,8 +2,8 @@
 
 ## General
 
-- To know more about types in Go, check [Tour of Go: Basic Types][basic types]
-- To know more about type conversions in Go, check [Tour of Go: Type Conversions][type conversions]
+- To learn more about types in Go, check [Tour of Go: Basic Types][basic types].
+- To learn more about type conversions in Go, check [Tour of Go: Type Conversions][type conversions].
 
 ## 1. Calculate the number of working cars produced per hour
 
@@ -14,7 +14,7 @@
 ## 2. Calculate the number of working cars produced per minute
 
 - Start by calculating the production of successful cars per hour. For this, you can use the `CalculateProductionRatePerHour` function you made from the previous step.
-- Knowing the production per hour of cars, you can get the production per minute by dividing the production per hour by 60 (the number of minutes in an hour)
+- Knowing the production per hour of cars, you can get the production per minute by dividing the production per hour by 60 (the number of minutes in an hour).
 - Remember to cast the result to an `int`.
 
 ## 3. Calculate the cost of production 

--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -19,9 +19,9 @@
 
 ## 3. Calculate the cost of production 
 
-- Start by working out how many complete groups of 10 there are.
+- Start by working out how many groups of 10 cars there are. You can do this by dividing the number of cars by 10.
 - Then work out how many cars are remaining (the [operator][modulo operator] is useful for this).
-- From the remaining, work out how many complete groups of 3 there are and then how many are left ungrouped.
+- To arrive at the cost, multiply the number of groups by the cost to produce 10 cars and then multiply the number of cars remaining by the cost to produce each individual car. Then sum the results of the multiplication together.
 
 [basic types]: https://tour.golang.org/basics/11
 [type conversions]: https://tour.golang.org/basics/13

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -16,7 +16,7 @@ rate := CalculateWorkingCarsPerHour(1547, 90)
 // Output: 1392.3
 ```
 
-**Note** the return value should be a `float64`.
+**Note:** the return value should be a `float64`.
 
 ## 2. Calculate the number of working cars produced per minute
 
@@ -27,7 +27,7 @@ rate := CalculateWorkingCarsPerMinute(1105, 90)
 // Output: 16
 ```
 
-**Note** the return value should be an `int`.
+**Note:** the return value should be an `int`.
 
 ## 3. Calculate the cost of production 
 
@@ -44,10 +44,10 @@ Implement the function `CalculateCost` that calculates the cost of producing a n
 
 ```go
 cost := CalculateCost(37)
-// Output: 355,000
+// Output: 355000
 
 cost = CalculateCost(21)
-// Output: 200,000
+// Output: 200000
 ```
 
-**Note** the return value should be an `uint`.
+**Note:** the return value should be an `uint`.

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -6,7 +6,7 @@ In this exercise you'll be writing code to analyze the production in a car facto
 
 The cars are produced in an assembly line. The assembly line has a certain speed, that can be changed. The faster the assembly line speed is, the more cars are produced. However, changing the speed of the assembly line also changes the number of cars that are produced successfully, that is cars without any errors in their production.
 
-Implement a function that takes in the number of cars produced per hour and the success rate (as a percentage) and calculates the number of successful cars made per hour:
+Implement a function that takes in the number of cars produced per hour and the success rate and calculates the number of successful cars made per hour. The success rate is given as a percentage, from `0` to `100`:
 
 ```go
 rate := CalculateWorkingCarsPerHour(1547, 90)

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -3,8 +3,8 @@
 In this exercise you'll be writing code to analyze the production in a car factory.
 
 ## 1. Calculate the number of working cars produced per hour
-The assembly line's speed is can be changed.
-But, a higher production rate can lead to more errors and, therefore, a lower success rate.
+
+The cars are produced in an assembly line. The assembly line has a certain speed, that can be changed. The faster the assembly line speed is, the more cars are produced. However, changing the speed of the assembly line also changes the number of cars that are produced successfully, that is cars without any errors in their production.
 
 Implement a function that takes in the number of cars produced per hour and the success rate (as a percentage) and calculates the number of successful cars made per hour:
 

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -4,7 +4,10 @@ In this exercise you'll be writing code to analyze the production in a car facto
 
 ## 1. Calculate the number of working cars produced per hour
 
-The cars are produced in an assembly line. The assembly line has a certain speed, that can be changed. The faster the assembly line speed is, the more cars are produced. However, changing the speed of the assembly line also changes the number of cars that are produced successfully, that is cars without any errors in their production.
+The cars are produced on an assembly line. 
+The assembly line has a certain speed, that can be changed. 
+The faster the assembly line speed is, the more cars are produced. 
+However, changing the speed of the assembly line also changes the number of cars that are produced successfully, that is cars without any errors in their production.
 
 Implement a function that takes in the number of cars produced per hour and the success rate and calculates the number of successful cars made per hour. The success rate is given as a percentage, from `0` to `100`:
 

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -1,67 +1,51 @@
 # Instructions
 
-In this exercise you'll be writing code to analyze the production of an assembly line in a car factory.
-The assembly line's speed can range from `0` (off) to `10` (maximum).
+In this exercise you'll be writing code to analyze the production in a car factory.
 
-At its default speed (`1`), `221` cars are produced each hour.
-In principle, the production increases linearly.
-So with the speed set to `4`, it should produce `4 * 221 = 884` cars per hour.
-However, higher speeds increase the likelihood that faulty cars are produced, which then have to be discarded.
+## 1. Calculate the number of working cars produced per hour
+The assembly line's speed is can be changed.
+But, a higher production rate can lead to more errors and, therefore, a lower success rate.
 
-Also, there are times when the assembly line has an artificially imposed limit on the throughput (meaning no more than the limit can be produced per hour).
-
-## 1. Calculate the success rate
-
-Implement a function (`SuccessRate`) to calculate the ratio of an item being created without error for a given speed.
-The following table shows how speed influences the success rate:
-
-- `0`: 0% success rate.
-- `1` - `4`: 100% success rate.
-- `5` - `8`: 90% success rate.
-- `9` - `10`: 77% success rate.
+Implement a function that takes in the number of cars produced per hour and the success rate (as a percentage) and calculates the number of successful cars made per hour:
 
 ```go
-rate := SuccessRate(6)
-fmt.Println(rate)
-// Output: 0.9
-```
-
-## 2. Calculate the production rate per hour
-
-Implement a function to calculate the assembly line's production rate per hour:
-
-```go
-rate := CalculateProductionRatePerHour(7)
-fmt.Println(rate)
+rate := CalculateWorkingCarsPerHour(1547, 90)
 // Output: 1392.3
 ```
 
-> Note that the value returned is of type `float64`.
+**Note** the return value should be a `float64`.
 
-## 3. Calculate the number of working items produced per minute
+## 2. Calculate the number of working cars produced per minute
 
-Implement a function to calculate how many cars are produced each minute:
+Implement a function that takes in the number of cars produced per hour and the success rate and calculates how many cars are successfully produced each minute:
 
 ```go
-rate := CalculateProductionRatePerMinute(5)
-fmt.Println(rate)
+rate := CalculateWorkingCarsPerMinute(1105, 90)
 // Output: 16
 ```
 
-> Note that the value returned is of type `int`.
+**Note** the return value should be an `int`.
 
-## 4. Calculate the artificially-limited production rate
+## 3. Calculate the cost of production 
 
-Implement a function to calculate the assembly line's production rate per hour:
+Each car normally costs $10,000 to produce, regardless of whether it is successful or not.
+But with a bit of planning, the 3 cars can be produced together for $29,000.
+10 cars can be produced together for $95,000.
+
+For example, 37 cars can be produced in the following groups:
+37 = 3 x groups of 10 + 2 groups of 3 + 1 
+
+So the cost for 37 cars is:
+3*95,000+2*29,000+10,000=353,000
+
+Implement the function `CalculateCost` that calculates the cost of producing a number of cars, regardless of whether they are successful:
 
 ```go
-rate := CalculateLimitedProductionRatePerHour(2, 1000.0)
-fmt.Println(rate)
-// Output: 442.0
-rate := CalculateLimitedProductionRatePerHour(7, 1000.0)
-fmt.Println(rate)
-// Output: 1000.0
+cost := CalculateCost(37)
+// Output: 353,000
+
+cost = CalculateCost(21)
+// Output: 200,000
 ```
 
-> Note that the value returned is of type `float64`.
-  This should call the `CalculateProductionRatePerHour` function exactly once.
+**Note** the return value should be an `uint`.

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -31,21 +31,20 @@ rate := CalculateWorkingCarsPerMinute(1105, 90)
 
 ## 3. Calculate the cost of production 
 
-Each car normally costs $10,000 to produce, regardless of whether it is successful or not.
-But with a bit of planning, the 3 cars can be produced together for $29,000.
-10 cars can be produced together for $95,000.
+Each car normally costs $10,000 to produce individually, regardless of whether it is successful or not.
+But with a bit of planning, 10 cars can be produced together for $95,000.
 
-For example, 37 cars can be produced in the following groups:
-37 = 3 x groups of 10 + 2 groups of 3 + 1 
+For example, 37 cars can be produced in the following way:
+37 = 3 x groups of ten + 7 individual cars
 
 So the cost for 37 cars is:
-3*95,000+2*29,000+10,000=353,000
+3*95,000+7*10,000=355,000
 
 Implement the function `CalculateCost` that calculates the cost of producing a number of cars, regardless of whether they are successful:
 
 ```go
 cost := CalculateCost(37)
-// Output: 353,000
+// Output: 355,000
 
 cost = CalculateCost(21)
 // Output: 200,000

--- a/exercises/concept/cars-assemble/.docs/introduction.md
+++ b/exercises/concept/cars-assemble/.docs/introduction.md
@@ -13,6 +13,10 @@ For the sake of this exercise you will only be dealing with:
 
 - `float64`: e.g. `0.0`, `3.14`. Contains the set of all 64-bit floating-point numbers.
 
+- `uint`: e.g. `0`, `255`. An unsigned integer that is the same size as `int` (value range of: 0 through 4294967295 for 32 bits and 0 through 18446744073709551615 for 64 bits)
+
+Numbers can be converted to other numeric types through Type Conversion.
+
 ## Arithmetic Operators
 
 Go supports many standard arithmetic operators:
@@ -30,7 +34,7 @@ For integer division, the remainder is dropped (eg. `5 / 2 == 2`).
 Go has shorthand assignment for the operators above (e.g. `a += 5` is short for `a = a + 5`).
 Go also supports the increment and decrement statements `++` and `--` (e.g. `a++`).
 
-## Converting between int and float64
+## Converting between types 
 
 Converting between types is done via a function with the name of the type to convert to.
 For example:
@@ -55,49 +59,3 @@ value := float32(2.0) * x // invalid operation: mismatched types float32 and int
 // you must convert int type to float32 before performing arithmetic operation
 value := float32(2.0) * float32(x)
 ```
-
-## If Statements
-
-Conditionals in Go are similar to conditionals in other languages.
-The underlying type of any conditional operation is the `bool` type, which can have the value of `true` or `false`.
-Conditionals are often used as flow control mechanisms to check for various conditions.
-
-For checking a particular case an `if` statement can be used, which executes its code if the underlying condition is `true` like this:
-
-```go
-var value string
-
-if value == "val" {
-    return "was val"
-}
-```
-
-In scenarios involving more than one case many `if` statements can be chained together using the `else if` and `else` statements.
-
-```go
-var number int
-result := "This number is "
-
-if number > 0 {
-    result += "positive"
-} else if number < 0 {
-    result += "negative"
-} else {
-    result += "zero"
-}
-```
-
-If statements can also include a short initialization statement that can be used to initialize one or more variables for the if statement.
-For example:
-
-```go
-num := 7
-if v := 2 * num; v > 10 {
-    fmt.Println(v)
-} else {
-    fmt.Println(num)
-}
-// Output: 14
-```
-
-> Note: any variables created in the initialization statement go out of scope after the end of the if statement.

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -1,11 +1,12 @@
 {
   "blurb": "Learn about numbers and type conversion by analyzing an assembly line in a car factory.",
   "authors": [
-    "DavyJ0nes"
+    "DavyJ0nes",
+    "kahgoh"
   ],
   "contributors": [
     "tehsphinx",
-    "kahgoh"
+    "andrerfcsantos"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -4,7 +4,8 @@
     "DavyJ0nes"
   ],
   "contributors": [
-    "tehsphinx"
+    "tehsphinx",
+    "kahgoh"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -6,7 +6,7 @@ The goal of this exercise is to teach the student how to deal with numbers in Go
 
 ## Learning objectives
 
-- This should introduce the `int` and `float64` types (the basic number types in Go).
+- This should introduce the `uint`, `int` and `float64` types (the basic number types in Go).
 - It should introduce operations with numbers like multiplication, division, etc.
 - Introduce basic type conversion between number types
 

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -6,17 +6,14 @@ The goal of this exercise is to teach the student how to deal with numbers in Go
 
 ## Learning objectives
 
-- This should introduce the `int` and `float64` types (be basic number types in Go).
+- This should introduce the `int` and `float64` types (the basic number types in Go).
 - It should introduce operations with numbers like multiplication, division, etc.
 - Introduce basic type conversion between number types
-
-My suggestion is to copy C# `numbers` exercise: https://github.com/exercism/v3/tree/master/languages/csharp/exercises/concept/numbers
 
 ## Concepts
 
 - `numbers`
-- `conditionals-if`
-- `type-conversion`
+- `arithmetic-operators`
 
 ## Prerequisites
 

--- a/exercises/concept/cars-assemble/.meta/exemplar.go
+++ b/exercises/concept/cars-assemble/.meta/exemplar.go
@@ -6,7 +6,7 @@ func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float6
 	return float64(productionRate) * successRate / 100
 }
 
-// CalculateWorkingCarsPerMinute describes how many working items are
+// CalculateWorkingCarsPerMinute describes how many working cars are
 // produced by the assembly line every minute
 func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
 	return int(CalculateWorkingCarsPerHour(productionRate, successRate) / 60)

--- a/exercises/concept/cars-assemble/.meta/exemplar.go
+++ b/exercises/concept/cars-assemble/.meta/exemplar.go
@@ -1,23 +1,18 @@
 package cars
 
-// CalculateWorkingCarsPerHour for the assembly line, taking into account
-// the production rate (in units per hour) and the success rate (as a percentage)
+// CalculateWorkingCarsPerHour calculates how many working cars are
+// produced by the assembly line every hour
 func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float64 {
 	return float64(productionRate) * successRate / 100
 }
 
-// CalculateWorkingCarsPerMinute describes how many working cars are
+// CalculateWorkingCarsPerMinute calculates how many working cars are
 // produced by the assembly line every minute
 func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
 	return int(CalculateWorkingCarsPerHour(productionRate, successRate) / 60)
 }
 
-// CalculateCost works out how much the materials to produce a
-// number of cars cost
+// CalculateCost works out the cost of producing the given number of cars
 func CalculateCost(carsCount int) uint {
-	tens := carsCount / 10
-	afterTens := carsCount % 10
-	threes := afterTens / 3
-	singles := afterTens % 3
-	return uint(tens*95000 + threes*29000 + singles*10000)
+	return uint((carsCount/10)*95000 + (carsCount%10)*10000)
 }

--- a/exercises/concept/cars-assemble/.meta/exemplar.go
+++ b/exercises/concept/cars-assemble/.meta/exemplar.go
@@ -1,44 +1,23 @@
 package cars
 
-// SuccessRate is used to calculate the ratio of an item being created without
-// error for a given speed
-func SuccessRate(speed int) float64 {
-	if speed == 0 {
-		return 0.0
-	}
-
-	if speed < 5 {
-		return 1.0
-	}
-
-	if speed >= 9 {
-		return 0.77
-	}
-
-	return 0.9
+// CalculateWorkingCarsPerHour for the assembly line, taking into account
+// the production rate (in units per hour) and the success rate (as a percentage)
+func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float64 {
+	return float64(productionRate) * successRate / 100
 }
 
-// CalculateProductionRatePerHour for the assembly line, taking into account
-// its success rate
-func CalculateProductionRatePerHour(speed int) float64 {
-	const defaultRate = 221.0
-
-	rateForSpeed := defaultRate * float64(speed)
-
-	return rateForSpeed * SuccessRate(speed)
-}
-
-// CalculateProductionRatePerMinute describes how many working items are
+// CalculateWorkingCarsPerMinute describes how many working items are
 // produced by the assembly line every minute
-func CalculateProductionRatePerMinute(speed int) int {
-	return int(CalculateProductionRatePerHour(speed) / 60)
+func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
+	return int(CalculateWorkingCarsPerHour(productionRate, successRate) / 60)
 }
 
-// CalculateLimitedProductionRatePerHour describes how many working items are
-// produced per hour with an upper limit on how many can be produced per hour
-func CalculateLimitedProductionRatePerHour(speed int, limit float64) float64 {
-	if rate := CalculateProductionRatePerHour(speed); rate <= limit {
-		return rate
-	}
-	return limit
+// CalculateCost works out how much the materials to produce a
+// number of cars cost
+func CalculateCost(carsCount int) uint {
+	tens := carsCount / 10
+	afterTens := carsCount % 10
+	threes := afterTens / 3
+	singles := afterTens % 3
+	return uint(tens*95000 + threes*29000 + singles*10000)
 }

--- a/exercises/concept/cars-assemble/cars_assemble.go
+++ b/exercises/concept/cars-assemble/cars_assemble.go
@@ -6,7 +6,7 @@ func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float6
 	panic("CalculateWorkingCarsPerHour not implemented")
 }
 
-// CalculateWorkingCarsPerMinute describes how many working items are
+// CalculateWorkingCarsPerMinute describes how many working cars are
 // produced by the assembly line every minute
 func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
 	panic("CalculateWorkingCarsPerMinute not implemented")

--- a/exercises/concept/cars-assemble/cars_assemble.go
+++ b/exercises/concept/cars-assemble/cars_assemble.go
@@ -1,19 +1,18 @@
 package cars
 
-// CalculateWorkingCarsPerHour for the assembly line, taking into account
-// the production rate (in units per hour) and the success rate (as a percentage)
+// CalculateWorkingCarsPerHour calculates how many working cars are
+// produced by the assembly line every hour
 func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float64 {
 	panic("CalculateWorkingCarsPerHour not implemented")
 }
 
-// CalculateWorkingCarsPerMinute describes how many working cars are
+// CalculateWorkingCarsPerMinute calculates how many working cars are
 // produced by the assembly line every minute
 func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
 	panic("CalculateWorkingCarsPerMinute not implemented")
 }
 
-// CalculateCost works out how much the materials to produce a
-// number of cars cost
+// CalculateCost works out the cost of producing the given number of cars
 func CalculateCost(carsCount int) uint {
 	panic("CalculateCost not implemented")
 }

--- a/exercises/concept/cars-assemble/cars_assemble.go
+++ b/exercises/concept/cars-assemble/cars_assemble.go
@@ -1,25 +1,19 @@
 package cars
 
-// SuccessRate is used to calculate the ratio of an item being created without
-// error for a given speed
-func SuccessRate(speed int) float64 {
-	panic("SuccessRate not implemented")
+// CalculateWorkingCarsPerHour for the assembly line, taking into account
+// the production rate (in units per hour) and the success rate (as a percentage)
+func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float64 {
+	panic("CalculateWorkingCarsPerHour not implemented")
 }
 
-// CalculateProductionRatePerHour for the assembly line, taking into account
-// its success rate
-func CalculateProductionRatePerHour(speed int) float64 {
-	panic("CalculateProductionRatePerHour not implemented")
-}
-
-// CalculateProductionRatePerMinute describes how many working items are
+// CalculateWorkingCarsPerMinute describes how many working items are
 // produced by the assembly line every minute
-func CalculateProductionRatePerMinute(speed int) int {
-	panic("CalculateProductionRatePerMinute not implemented")
+func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
+	panic("CalculateWorkingCarsPerMinute not implemented")
 }
 
-// CalculateLimitedProductionRatePerHour describes how many working items are
-// produced per hour with an upper limit on how many can be produced per hour
-func CalculateLimitedProductionRatePerHour(speed int, limit float64) float64 {
-	panic("CalculateLimitedProductionRatePerHour not implemented")
+// CalculateCost works out how much the materials to produce a
+// number of cars cost
+func CalculateCost(carsCount int) uint {
+	panic("CalculateCost not implemented")
 }

--- a/exercises/concept/cars-assemble/cars_assemble_test.go
+++ b/exercises/concept/cars-assemble/cars_assemble_test.go
@@ -7,46 +7,53 @@ import (
 
 const FloatEqualityThreshold = 1e-9
 
-func TestSuccessRate(t *testing.T) {
+func TestCalculateWorkingCarsPerHour(t *testing.T) {
 	tests := []struct {
-		name  string
-		speed int
-		want  float64
+		name           string
+		productionRate int
+		successRate    float64
+		want           float64
 	}{
 		{
-			name:  "calculate success rate for speed zero",
-			speed: 0,
-			want:  0.0,
+			name:           "calculate working cars per hour for production rate 0",
+			productionRate: 0,
+			successRate:    100,
+			want:           0.0,
 		},
 		{
-			name:  "calculate success rate for speed one",
-			speed: 1,
-			want:  1.0,
+			name:           "calculate working cars per hour for 100%% success rate",
+			productionRate: 221,
+			successRate:    100,
+			want:           221.0,
 		},
 		{
-			name:  "calculate success rate for speed four",
-			speed: 4,
-			want:  1.0,
+			name:           "calculate working cars per hour for 80%% success rate",
+			productionRate: 426,
+			successRate:    80,
+			want:           340.8,
 		},
 		{
-			name:  "calculate success rate for speed seven",
-			speed: 7,
-			want:  0.9,
+			name:           "calculate working cars per hour for 20.5%% success rate",
+			productionRate: 6824,
+			successRate:    20.5,
+			want:           1398.92,
 		},
 		{
-			name:  "calculate success rate for speed nine",
-			speed: 9,
-			want:  0.77,
+			name:           "calculate working cars per hour for 0%% success rate",
+			productionRate: 8000,
+			successRate:    0,
+			want:           0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SuccessRate(tt.speed)
+			got := CalculateWorkingCarsPerHour(tt.productionRate, tt.successRate)
 			if math.Abs(got-tt.want) > FloatEqualityThreshold {
 				t.Errorf(
-					"SuccessRate(%d) = %f, want %f",
-					tt.speed,
+					"CalculateWorkingCarsPerHour(%d, %f) = %f, want %f",
+					tt.productionRate,
+					tt.successRate,
 					got,
 					tt.want,
 				)
@@ -55,94 +62,53 @@ func TestSuccessRate(t *testing.T) {
 	}
 }
 
-func TestCalculateProductionRatePerHour(t *testing.T) {
+func TestCalculateWorkingCarsPerMinute(t *testing.T) {
 	tests := []struct {
-		name  string
-		speed int
-		want  float64
+		name           string
+		productionRate int
+		successRate    float64
+		want           int
 	}{
 		{
-			name:  "calculate production rate per hour for speed zero",
-			speed: 0,
-			want:  0.0,
+			name:           "calculate working cars per minute for production rate 0",
+			productionRate: 0,
+			successRate:    100,
+			want:           0,
 		},
 		{
-			name:  "calculate production rate per hour for speed one",
-			speed: 1,
-			want:  221.0,
+			name:           "calculate working cars per minute for 100%% success rate",
+			productionRate: 221,
+			successRate:    100,
+			want:           3,
 		},
 		{
-			name:  "calculate production rate per hour for speed four",
-			speed: 4,
-			want:  884.0,
+			name:           "calculate working cars per minute for 80%% success rate",
+			productionRate: 426,
+			successRate:    80,
+			want:           5,
 		},
 		{
-			name:  "calculate production rate per hour for speed seven",
-			speed: 7,
-			want:  1392.3,
+			name:           "calculate working cars per minute for 20.5%% success rate",
+			productionRate: 6824,
+			successRate:    20.5,
+			want:           23,
 		},
 		{
-			name:  "calculate production rate per hour for speed nine",
-			speed: 9,
-			want:  1531.53,
+			name:           "calculate working cars per minute for 0%% success rate",
+			productionRate: 8000,
+			successRate:    0,
+			want:           0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CalculateProductionRatePerHour(tt.speed)
-			if math.Abs(got-tt.want) > FloatEqualityThreshold {
-				t.Errorf(
-					"CalculateProductionRatePerHour(%d) = %f, want %f",
-					tt.speed,
-					got,
-					tt.want,
-				)
-			}
-		})
-	}
-}
-
-func TestCalculateProductionRatePerMinute(t *testing.T) {
-	tests := []struct {
-		name  string
-		speed int
-		want  int
-	}{
-		{
-			name:  "calculate production rate per minute for speed zero",
-			speed: 0,
-			want:  0,
-		},
-		{
-			name:  "calculate production rate per minute for speed one",
-			speed: 1,
-			want:  3,
-		},
-		{
-			name:  "calculate production rate per minute for speed five",
-			speed: 5,
-			want:  16,
-		},
-		{
-			name:  "calculate production rate per minute for speed eight",
-			speed: 8,
-			want:  26,
-		},
-		{
-			name:  "calculate production rate per minute for speed ten",
-			speed: 10,
-			want:  28,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := CalculateProductionRatePerMinute(tt.speed)
+			got := CalculateWorkingCarsPerMinute(tt.productionRate, tt.successRate)
 			if got != tt.want {
 				t.Errorf(
-					"CalculateProductionRatePerMinute(%d) = %d, want %d",
-					tt.speed,
+					"CalculateWorkingCarsPerMinute(%d, %f) = %d, want %d",
+					tt.productionRate,
+					tt.successRate,
 					got,
 					tt.want,
 				)
@@ -151,47 +117,81 @@ func TestCalculateProductionRatePerMinute(t *testing.T) {
 	}
 }
 
-func TestCalculateLimitedProductionRatePerHour(t *testing.T) {
+func TestCalculateCost(t *testing.T) {
 	tests := []struct {
-		name  string
-		speed int
-		limit float64
-		want  float64
+		name      string
+		carsCount int
+		want      uint
 	}{
 		{
-			name:  "calculate limited production rate per hour for speed zero",
-			speed: 0,
-			limit: 500.0,
-			want:  0.0,
+			name:      "calculate cost to produce 0 cars",
+			carsCount: 0,
+			want:      0,
 		},
 		{
-			name:  "calculate limited production rate per hour below limit",
-			speed: 1,
-			limit: 500.0,
-			want:  221.0,
+			name:      "calculate the cost of materials to produce 1 car",
+			carsCount: 1,
+			want:      10000,
 		},
 		{
-			name:  "calculate limited production rate per hour above limit",
-			speed: 9,
-			limit: 500.0,
-			want:  500.0,
+			name:      "calculate cost to produce 3 cars ",
+			carsCount: 3,
+			want:      29000,
 		},
 		{
-			name:  "calculate limited production rate per hour at limit",
-			speed: 3,
-			limit: 663.0,
-			want:  663.0,
+			name:      "calculate cost to produce 10 cars",
+			carsCount: 10,
+			want:      95000,
+		},
+		{
+			name:      "calculate cost to produce 2 cars",
+			carsCount: 2,
+			want:      20000,
+		},
+		{
+			name:      "calculate cost to produce 6 cars",
+			carsCount: 6,
+			want:      58000,
+		},
+		{
+			name:      "caulcate cost of materials to produce 9 cars",
+			carsCount: 9,
+			want:      87000,
+		},
+		{
+			name:      "calculate cost to produce 100 cars",
+			carsCount: 100,
+			want:      950000,
+		},
+		{
+			name:      "calculate cost to produce 21 cars",
+			carsCount: 21,
+			want:      200000,
+		},
+		{
+			name:      "calculate cost to produce 37 cars",
+			carsCount: 37,
+			want:      353000,
+		},
+		{
+			name:      "calculate cost to produce 56 cars",
+			carsCount: 56,
+			want:      533000,
+		},
+		{
+			name:      "calculate cost to produce 148 cars",
+			carsCount: 148,
+			want:      1408000,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CalculateLimitedProductionRatePerHour(tt.speed, tt.limit)
-			if math.Abs(got-tt.want) > FloatEqualityThreshold {
+			got := CalculateCost(tt.carsCount)
+			if got != tt.want {
 				t.Errorf(
-					"CalculateLimitedProductionRatePerHour(%d, %f) = %f, want %f",
-					tt.speed,
-					tt.limit,
+					"CalculateCost(%d) = %d, want %d",
+					tt.carsCount,
 					got,
 					tt.want,
 				)

--- a/exercises/concept/cars-assemble/cars_assemble_test.go
+++ b/exercises/concept/cars-assemble/cars_assemble_test.go
@@ -134,29 +134,19 @@ func TestCalculateCost(t *testing.T) {
 			want:      10000,
 		},
 		{
-			name:      "calculate cost to produce 3 cars ",
-			carsCount: 3,
-			want:      29000,
-		},
-		{
-			name:      "calculate cost to produce 10 cars",
-			carsCount: 10,
-			want:      95000,
-		},
-		{
 			name:      "calculate cost to produce 2 cars",
 			carsCount: 2,
 			want:      20000,
 		},
 		{
-			name:      "calculate cost to produce 6 cars",
-			carsCount: 6,
-			want:      58000,
+			name:      "calculate cost to produce 9 cars",
+			carsCount: 9,
+			want:      90000,
 		},
 		{
-			name:      "caulcate cost of materials to produce 9 cars",
-			carsCount: 9,
-			want:      87000,
+			name:      "calculate cost to produce 10 cars",
+			carsCount: 10,
+			want:      95000,
 		},
 		{
 			name:      "calculate cost to produce 100 cars",
@@ -171,17 +161,17 @@ func TestCalculateCost(t *testing.T) {
 		{
 			name:      "calculate cost to produce 37 cars",
 			carsCount: 37,
-			want:      353000,
+			want:      355000,
 		},
 		{
 			name:      "calculate cost to produce 56 cars",
 			carsCount: 56,
-			want:      533000,
+			want:      535000,
 		},
 		{
 			name:      "calculate cost to produce 148 cars",
 			carsCount: 148,
-			want:      1408000,
+			want:      1410000,
 		},
 	}
 

--- a/exercises/concept/cars-assemble/cars_assemble_test.go
+++ b/exercises/concept/cars-assemble/cars_assemble_test.go
@@ -5,7 +5,13 @@ import (
 	"testing"
 )
 
-const FloatEqualityThreshold = 1e-9
+const floatEqualityThreshold = 1e-9
+
+func floatingPointEquals(got, want float64) bool {
+	absoluteDifferenceBelowTreshold := math.Abs(got-want) <= floatEqualityThreshold
+	relativeDifferenceBelowTreshold := math.Abs(got-want)/(math.Abs(got)+math.Abs(want)) <= floatEqualityThreshold
+	return absoluteDifferenceBelowTreshold || relativeDifferenceBelowTreshold
+}
 
 func TestCalculateWorkingCarsPerHour(t *testing.T) {
 	tests := []struct {
@@ -49,7 +55,7 @@ func TestCalculateWorkingCarsPerHour(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CalculateWorkingCarsPerHour(tt.productionRate, tt.successRate)
-			if math.Abs(got-tt.want) > FloatEqualityThreshold {
+			if !floatingPointEquals(got, tt.want) {
 				t.Errorf(
 					"CalculateWorkingCarsPerHour(%d, %f) = %f, want %f",
 					tt.productionRate,


### PR DESCRIPTION
Closes #1936

The `conditionals-if` and `comparison` concepts were removed from this
exercise because they are now covered by the vehicle-purhcase exercise
(added by ae2f5e7).