### PR TITLE
Delete instructions.append.md

### DIFF
--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -1,9 +1,0 @@
-# Simple Stub
-
-The raindrops.go "stub file" contains only one line with the correct
-package name and nothing more.  This will be the usual pattern for future
-exercises.  You will need to figure out the function signature(s).
-
-One way to figure out the function signature(s) is to look
-at the corresponding \*\_test.go file. It will show the package level
-functions(s) that the test will use to verify the solution.


### PR DESCRIPTION
This information is no longer correct. The "Simple Stub" is not valid as the function signature is now provided.