### PR TITLE
Wrapped CalculateResellPrice under Test.Run

### DIFF
--- a/exercises/concept/vehicle-purchase/vehicle_purchase_test.go
+++ b/exercises/concept/vehicle-purchase/vehicle_purchase_test.go
@@ -161,15 +161,17 @@ func TestCalculateResellPrice(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := CalculateResellPrice(test.originalPrice, test.age)
-		if !floatingPointEquals(actual, test.expected) {
-			t.Errorf(
-				"CalculateResellPrice(%v, %v) = %v, want %v",
-				test.originalPrice,
-				test.age,
-				actual,
-				test.expected)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			actual := CalculateResellPrice(test.originalPrice, test.age)
+			if !floatingPointEquals(actual, test.expected) {
+				t.Errorf(
+					"CalculateResellPrice(%v, %v) = %v, want %v",
+					test.originalPrice,
+					test.age,
+					actual,
+					test.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The tests for CalculateResellPrice vary from the other tests in that it just prints whether all the tests were Pass or Fail. Its missing the following:
1. List of individual tests that were executed for the CalculateResellPrice method
2. The status at individual test level (Pass or Fail)
3. The time taken to execute the individual tests (e.g. 0.01s)