### PR TITLE
Instructions for missed case in PrefilledSlice 

### DIFF
--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -56,6 +56,12 @@ PrefilledSlice(8, 3)
 // Output: []int{8, 8, 8}
 ```
 
+If the given `length` is negative or zero, return an empty stack.
+
+```go
+PrefilledSlice(5, -2)
+// Output: []int{}
+```
 ## 4. Remove a card from the stack
 
 Remove the card at position `index` from the stack and return the stack.

--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -49,19 +49,13 @@ SetItem([]int{1, 2, 4, 1}, index, newCard)
 
 ## 3. Create a stack of cards
 
-Create a stack of given `length` and fill it with cards of the given `value`.
+Create a stack of given `length` and fill it with cards of the given `value`. If the given `length` is negative or zero, return an empty stack.
 
 ```go
 PrefilledSlice(8, 3)
 // Output: []int{8, 8, 8}
 ```
 
-If the given `length` is negative or zero, return an empty stack.
-
-```go
-PrefilledSlice(5, -2)
-// Output: []int{}
-```
 ## 4. Remove a card from the stack
 
 Remove the card at position `index` from the stack and return the stack.

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -13,6 +13,7 @@ func SetItem(slice []int, index, value int) []int {
 }
 
 // PrefilledSlice creates a slice of given length and prefills it with the given value.
+// If the length is negative or zero, PrefilledSlice returns an empty slice.
 func PrefilledSlice(value, length int) []int {
 	panic("Please implement the PrefilledSlice function")
 }

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -13,7 +13,6 @@ func SetItem(slice []int, index, value int) []int {
 }
 
 // PrefilledSlice creates a slice of given length and prefills it with the given value.
-// If the length is negative or zero, PrefilledSlice returns an empty slice.
 func PrefilledSlice(value, length int) []int {
 	panic("Please implement the PrefilledSlice function")
 }


### PR DESCRIPTION
The instructions and comments for PrefilledSlice method do not mention the intended behavior when the length of the slice is non-positive. However, the test suite for Prefilled slice contains a case where the length is -3. Updating the instructions to include an example and updating the comments to match the instructions.