### PR TITLE
Docs: fix the number of return values for `strconv.Atoi` in docs

### DIFF
--- a/concepts/type-conversion/about.md
+++ b/concepts/type-conversion/about.md
@@ -33,7 +33,7 @@ There is a `strconv` package for converting between primitive types (like `int`)
 import "strconv"
 
 var intString string = "42"
-var i int = strconv.Atoi(intString)
+var i, err = strconv.Atoi(intString)
 
 var number int = 12
 var s string = strconv.Itoa(number)

--- a/concepts/type-conversion/introduction.md
+++ b/concepts/type-conversion/introduction.md
@@ -17,7 +17,7 @@ There is a `strconv` package for converting between primitive types (like `int`)
 import "strconv"
 
 var intString string = "42"
-var i int = strconv.Atoi(intString)
+var i, err = strconv.Atoi(intString)
 
 var number int = 12
 var s string = strconv.Itoa(number)

--- a/exercises/concept/sorting-room/.docs/introduction.md
+++ b/exercises/concept/sorting-room/.docs/introduction.md
@@ -19,7 +19,7 @@ There is a `strconv` package for converting between primitive types (like `int`)
 import "strconv"
 
 var intString string = "42"
-var i int = strconv.Atoi(intString)
+var i, err = strconv.Atoi(intString)
 
 var number int = 12
 var s string = strconv.Itoa(number)


### PR DESCRIPTION
Closes #1985

The documentation specifies that `strconv.Atoi` has 1 return value,
while it has 2
