### PR TITLE
add missing prerequisite for chessboard

### DIFF
--- a/config.json
+++ b/config.json
@@ -297,6 +297,7 @@
         ],
         "prerequisites": [
           "conditionals-if",
+          "for-loops",
           "maps",
           "slices",
           "structs"

--- a/exercises/concept/chessboard/.meta/design.md
+++ b/exercises/concept/chessboard/.meta/design.md
@@ -8,8 +8,8 @@ The goal of this exercise is to make the student familiar with the range loop on
 
 - Know how to iterate a slice with a range loop
 - Know how to iterate a map with a range loop
-- Know how and when to omit the index with _
-- Know how and when to omit the value by just providing one variable (don't use _ to omit the value!)
+- Know how and when to omit the index with \_
+- Know how and when to omit the value by just providing one variable (don't use \_ to omit the value!)
 - Know how and when to omit both, index and value
 - Know about the random order of map iteration
 
@@ -28,3 +28,4 @@ The goal of this exercise is to make the student familiar with the range loop on
 - `maps`
 - `conditionals-if`
 - `iteration`
+- `for-loops`


### PR DESCRIPTION
Learning `range-iteration` in the Chessboard exercise should happen after learning about basic for loops. However, `for-loops` was missing as prerequisite for Chessboard. (This happened because `for-loops` was created later.)