### PR TITLE
Included TimeZone in AnniversaryDate Instructions

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -42,7 +42,7 @@ Description("7/25/2019 13:45:00")
 
 ## 5. Return the anniversary date of the salon's opening
 
-Implement the `AnniversaryDate` function that returns the anniversary date of the salon's opening for the current year.
+Implement the `AnniversaryDate` function that returns the anniversary date of the salon's opening for the current year in UTC.
 
 Assuming the current year is 2020:
 ```go


### PR DESCRIPTION
Based on the test suite, the AnniversaryDate function needs to return the current year's anniversary date in UTC timezone. However, the current instructions have no mention of any such requirement. Updating the instruction to fix this.