### PR TITLE
Check explicit zero-value for street key

### DIFF
--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -64,7 +64,18 @@ func TestHasRequiredInfo(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "missing street",
+			name: "missing name",
+			resident: &Resident{
+				Name: "",
+				Age:  29,
+				Address: map[string]string{
+					"street": "Main St.",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty map as address",
 			resident: &Resident{
 				Name:    "Rob Pike",
 				Age:     0,
@@ -73,12 +84,12 @@ func TestHasRequiredInfo(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "missing name",
+			name: "missing street",
 			resident: &Resident{
-				Name: "",
-				Age:  29,
+				Name: "Hossein",
+				Age:  30,
 				Address: map[string]string{
-					"street": "Main St.",
+					"street": "",
 				},
 			},
 			want: false,
@@ -93,17 +104,6 @@ func TestHasRequiredInfo(t *testing.T) {
 				},
 			},
 			want: true,
-		},
-		{
-			name: "explicit zero-value for street",
-			resident: &Resident{
-				Name: "Hossein",
-				Age:  30,
-				Address: map[string]string{
-					"street": "",
-				},
-			},
-			want: false,
 		},
 	}
 

--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -94,6 +94,17 @@ func TestHasRequiredInfo(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "explicit zero-value for street",
+			resident: &Resident{
+				Name: "Hossein",
+				Age:  30,
+				Address: map[string]string{
+					"street": "",
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Tests must fail if the street key has explicitly set to its zero-value

Closes #1995 