### PR TITLE
Make roadmap available on the website

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,7 @@ This document provides an overview of the main topics that contributors and main
 - `integer-types`
 - `panic-recover`
 - `error-wrapping` (errors.Is, errors.As)
+- `variadic-functions` (introduces `...`)
 
 ### Potential Future Concepts
 
@@ -60,7 +61,6 @@ This document provides an overview of the main topics that contributors and main
 - `mutexes`
 - `channels` and `select`
 - `closures`/`anonymous-functions`/`higher-order-functions`
-- `rest-and-spread` (introduces the `...` operator)
 - `JSON`
 - `defer`
 - `randomness`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,6 +49,7 @@ This document provides an overview of the main topics that contributors and main
 - `time-duration`
 - `integer-types`
 - `panic-recover`
+- `error-wrapping` (errors.Is, errors.As)
 
 ### Potential Future Concepts
 
@@ -66,8 +67,7 @@ This document provides an overview of the main topics that contributors and main
 - `regular-expressions`
 - `stringers`
 - `Buffer`, `io.Reader`/`io.Writer`
-- error wrapping (errors.Is, errors.As) and custom errors
-- `generics` (once they become available)
+- `typed-parameters` (generics)
 - `context`
 - time helpers (ticket, sleep, etc.)
 - `reflection`

--- a/docs/config.json
+++ b/docs/config.json
@@ -27,6 +27,13 @@
       "path": "docs/RESOURCES.md",
       "title": "Useful Go resources",
       "blurb": "A collection of useful resources to help you master Go"
+    },
+    {
+      "uuid": "5fe99fb7-b45b-472c-a275-d216f11406f2",
+      "slug": "roadmap",
+      "path": "docs/ROADMAP.md",
+      "title": "Roadmap & Concept List",
+      "blurb": "Priorities for future development of the Go track"
     }
   ]
 }


### PR DESCRIPTION
Bethany pointed out that by adding the roadmap to the docs folder and setting the right config, we can make it available on the website in the track-specific contribution guideline section. https://exercism.org/docs/tracks/go

This PR also includes some minor updates.