### PR TITLE
Extended Instructions for AddItem Function

### DIFF
--- a/exercises/concept/gross-store/.docs/instructions.md
+++ b/exercises/concept/gross-store/.docs/instructions.md
@@ -41,7 +41,8 @@ fmt.Println(bill)
 To implement this, you'll need to:
 
 - Return `false` if the given `unit` is not in the `units` map.
-- Otherwise add the item to the customer `bill`, indexed by the item name, then return `true`. If the item is already present in the bill, increase its quantity by `unit` amount
+- Otherwise add the item to the customer `bill`, indexed by the item name, then return `true`.
+- If the item is already present in the bill, increase its quantity by the amount that belongs to the provided `unit`.
 
 ```go
 bill := NewBill()

--- a/exercises/concept/gross-store/.docs/instructions.md
+++ b/exercises/concept/gross-store/.docs/instructions.md
@@ -41,7 +41,7 @@ fmt.Println(bill)
 To implement this, you'll need to:
 
 - Return `false` if the given `unit` is not in the `units` map.
-- Otherwise add the item to the customer `bill`, indexed by the item name, then return `true`.
+- Otherwise add the item to the customer `bill`, indexed by the item name, then return `true`. If the item is already present in the bill, increase its quantity by `unit` amount
 
 ```go
 bill := NewBill()


### PR DESCRIPTION
Based on the test suite, the expectation from the AddItem function is to add the input item to the bill and if its already present, to increase its quantity by unit amount. The current instructions mention only the former part of the requirement and leave out the latter. Included an additional line to fix this.