### PR TITLE
sorting-room: Align hints.md content to sorting_room.go source

### DIFF
--- a/exercises/concept/sorting-room/.docs/hints.md
+++ b/exercises/concept/sorting-room/.docs/hints.md
@@ -11,7 +11,7 @@
 
 ## 3. Implement a method extracting the number from a fancy number box
 
-- use a type assertion to check if this is a `FancyBox`
+- use a type assertion to check if this is a `FancyNumber`
 - get the `string` from the `Value()` method
 - use `strconv.Atoi` to convert the `string` to an `int` (we can throw away the error since we want 0 if it cannot be converted to an `int`)
 


### PR DESCRIPTION
In the hints.md, it describes that we can check if this is `FancyBox`.
That is inconsistent to the type in sorting_room.go source.
I think `FancyNumber` is supposed to be the correct word in the hint.