### PR TITLE
String Formatting and Packages: Syncronize concept docs, fix blurb etc

### DIFF
--- a/concepts/packages/introduction.md
+++ b/concepts/packages/introduction.md
@@ -26,7 +26,7 @@ fmt.Sprintf("Hello %s", world)
 ```
 
 Go determines if an item can be called by code in other packages through how it is declared.
-To make a function, type, variable, constant or struct field externally visible (known as `exported`) the name must start with a capital letter.
+To make a function, type, variable, constant or struct field externally visible (known as _exported_) the name must start with a capital letter.
 This is analogous to how other programming languages like Java that use access modifiers such as `public` and `private`.
 
 ```go

--- a/concepts/string-formatting/.meta/config.json
+++ b/concepts/string-formatting/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Immutable sequence of UTF-8 characters.",
+  "blurb": "You can use the built-in formatting package \"fmt\" to create strings that embed values or variables with special formatting.",
   "authors": ["tehsphinx"],
   "contributors": []
 }

--- a/concepts/string-formatting/about.md
+++ b/concepts/string-formatting/about.md
@@ -1,14 +1,29 @@
 # About
 
-Go provides an built-in package called `fmt` (format package) which offers a variety of functions to manipulate the format of input and output. The most common used functions to print output are `Println` and `Printf`.
-`Println` simply prints the input received on the console screen while `Printf` formats the input, using verbs like `%s` for strings, before printing it on the console.
-
-In Go floating point values are conveniently printed with Printf's verbs: `%g` (compact representation), `%e` (exponent) or `%f` (non exponent). All three verbs allow the field's width and numeric position to be controlled.
+Go provides an in-built package called `fmt` (format package) which offers a variety of functions to manipulate the format of input and output.
+The most commonly used function is `Sprintf`, which uses _verbs_ like `%s` to interpolate values into a string and returns that string.
 
 ```go
-number := 4.3242
-fmt.Printf("%.2f", number)
-// Output: 4.32
+import "fmt"
+
+food := "taco"
+fmt.Sprintf("Bring me a %s", food)
+// Returns: Bring me a taco
 ```
 
-[string concatenation]: https://golang.org/ref/spec
+In Go floating point values are conveniently formatted with Sprintf's verbs: `%g` (compact representation), `%e` (exponent) or `%f` (non exponent).
+All three verbs allow the field's width and numeric position to be controlled.
+
+```go
+import "fmt"
+
+number := 4.3242
+fmt.Sprintf("%.2f", number)
+// Returns: 4.32
+```
+
+You can find a full list of available verbs in the [format package documentation][fmt-docs].
+
+`fmt` contains other functions for working with strings, such as `Println` which simply prints the arguments it receives to the console and `Printf` which formats the input in the same way as `Sprintf` before printing it.
+
+[fmt-docs]: https://pkg.go.dev/fmt

--- a/concepts/string-formatting/introduction.md
+++ b/concepts/string-formatting/introduction.md
@@ -1,12 +1,29 @@
 # Introduction
 
-Go provides a built-in package called `fmt` (format package) which offers a variety of functions to manipulate the format of input and output. The most commonly used functions to print output are `Println` and `Printf`.
-`Println` simply prints the input received on the console screen while `Printf` formats the input, using verbs like `%s` for strings, before printing it on the console.
-
-In Go floating point values are conveniently printed with Printf's verbs: `%g` (compact representation), `%e` (exponent) or `%f` (non exponent). All three verbs allow the field's width and numeric position to be controlled.
+Go provides an in-built package called `fmt` (format package) which offers a variety of functions to manipulate the format of input and output.
+The most commonly used function is `Sprintf`, which uses _verbs_ like `%s` to interpolate values into a string and returns that string.
 
 ```go
-number := 4.3242
-fmt.Printf("%.2f", number)
-// Output: 4.32
+import "fmt"
+
+food := "taco"
+fmt.Sprintf("Bring me a %s", food)
+// Returns: Bring me a taco
 ```
+
+In Go floating point values are conveniently formatted with Sprintf's verbs: `%g` (compact representation), `%e` (exponent) or `%f` (non exponent).
+All three verbs allow the field's width and numeric position to be controlled.
+
+```go
+import "fmt"
+
+number := 4.3242
+fmt.Sprintf("%.2f", number)
+// Returns: 4.32
+```
+
+You can find a full list of available verbs in the [format package documentation][fmt-docs].
+
+`fmt` contains other functions for working with strings, such as `Println` which simply prints the arguments it receives to the console and `Printf` which formats the input in the same way as `Sprintf` before printing it.
+
+[fmt-docs]: https://pkg.go.dev/fmt

--- a/concepts/string-formatting/links.json
+++ b/concepts/string-formatting/links.json
@@ -6,13 +6,5 @@
   {
     "url": "https://pkg.go.dev/fmt",
     "description": "Go Packages: fmt package"
-  },
-  {
-    "url": "https://gobyexample.com/string-functions",
-    "description": "Go by Example: String Functions"
-  },
-  {
-    "url": "https://golangdocs.com/concatenate-strings-in-golang",
-    "description": "Article: 7 Ways to Concatenate Strings in Golang"
-  }  
+  }
 ]

--- a/exercises/concept/party-robot/.docs/introduction.md
+++ b/exercises/concept/party-robot/.docs/introduction.md
@@ -1,12 +1,34 @@
 # Introduction
 
-Go programs are organized into packages. 
-A package is a collection of source files in the same directory that are compiled together. 
-Functions, types, variables, and constants defined in one source file are visible to all other source files within the same package. 
-Go determines if an item can be called by code in other packages through how it is declared.
-To make a function, type, variable, constant or struct field externally visible (known as `exported`) the name must start with a capital letter.
+## Packages
 
-For example:
+In Go an application is organized in packages.
+A package is a collection of source files located in the same folder.
+All source files in a folder must have the same package name at the top of the file.
+By convention packages are named to be the same as the folder they are located in.
+
+```go
+package greeting
+```
+
+Go provides an extensive standard library of packages which you can use in your program using the `import` keyword.
+Standard library packages are imported using their name.
+
+```go
+package greeting
+
+import "fmt"
+```
+
+An imported package is then addressed with the package name:
+
+```go
+world := "World"
+fmt.Sprintf("Hello %s", world)
+```
+
+Go determines if an item can be called by code in other packages through how it is declared.
+To make a function, type, variable, constant or struct field externally visible (known as _exported_) the name must start with a capital letter.
 
 ```go
 package greeting
@@ -19,6 +41,8 @@ func hello(name string) string {
     return "Hello " + name
 }
 ```
+
+## String Formatting
 
 Go provides an in-built package called `fmt` (format package) which offers a variety of functions to manipulate the format of input and output.
 The most commonly used function is `Sprintf`, which uses verbs like `%s` to interpolate values into a string and returns that string.
@@ -42,4 +66,8 @@ fmt.Sprintf("%.2f", number)
 // Returns: 4.32
 ```
 
+You can find a full list of available verbs in the [format package documentation][fmt-docs].
+
 `fmt` contains other functions for working with strings, such as `Println` which simply prints the arguments it receives to the console and `Printf` which formats the input in the same way as `Sprintf` before printing it.
+
+[fmt-docs]: https://pkg.go.dev/fmt


### PR DESCRIPTION
I noticed that there was a mismatch in the Party Robot introduction and the concept docs for the two concepts included there. During the September sprint, some issues were addressed but in one case they were only fixed in the introduction and in the other case only in the concept docs. With this PR, I plug in the respective corrected version into the other place as well. I didn't change the content.

Additionally this PR contains
* fixing the wrong blurb of `string-formatting` concept
* add a missing links to where to read about all the formatting verbs
* removing links that did not belong into the string formatting concept anymore (they were artifacts of changing the content of that concept)
* adding h2 headers for the exercise introduction file to make it easier to read