### PR TITLE
Instructions fix for The Farm

### DIFF
--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -12,7 +12,7 @@ While this is good for your pocket, you want to catch the division by zero retur
 Also, your silly nephew (who has just learned about negative numbers) sometimes will say that there are a negative number of cows.
 You love your nephew so you want to return a helpful error when he does that.
 
-## 1. Get the amount of fodder from the `weightFodder` method
+## 1. Get the amount of fodder from the `FodderAmount` method
 
 You will be passed a `WeightFodder` struct which has a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
 

--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -14,7 +14,7 @@ You love your nephew so you want to return a helpful error when he does that.
 
 ## 1. Get the amount of fodder from the `FodderAmount` method
 
-You will be passed a `WeightFodder` struct which has a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
+You will be passed a `WeightFodder` interface instance which has a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
 
 ## 2. Return an error for negative fodder
 

--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -12,33 +12,16 @@ While this is good for your pocket, you want to catch the division by zero retur
 Also, your silly nephew (who has just learned about negative numbers) sometimes will say that there are a negative number of cows.
 You love your nephew so you want to return a helpful error when he does that.
 
-## 1. Get the amount of fodder from the `weightFodder` function
+## 1. Get the amount of fodder from the `weightFodder` method
 
-You will be passed a `WeightFodder` which has a function called `FodderAmount` which returns the amount of fodder available and possibly an error.
-
-```go
-// twentyFodderNoError says there are 20.0 fodder
-fodder, err := DivideFood(twentyFodderNoError, 10)
-// fodder == 2.0
-// err == nil
-```
-
-If `ErrScaleMalfunction` is returned by `FodderAmount`, double the fodder amount returned by `FodderAmount`.
-For any other error, return `0` and the error.
-
-```go
-// twentyFodderNoError says there are 20.0 fodder and a ErrScaleMalfunction
-fodder, err := DivideFood(twentyFodderWithErrScaleMalfunction, 10)
-// fodder == 4.0
-// err == nil
-```
+You will be passed a `WeightFodder` struct which has a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
 
 ## 2. Return an error for negative fodder
 
 If the scale is broken and returning negative amounts of fodder, return an error saying "Negative fodder":
 
 ```go
-// twentyFodderNoError says there are -5.0 fodder
+// negativeFiveFodder says there are -5.0 fodder
 fodder, err := DivideFood(negativeFiveFodder, 10)
 // fodder == 0.0
 // err.Error() == "Negative fodder"
@@ -68,4 +51,25 @@ You can see the format of the error message in the example below.
 fodder, err := DivideFood(twentyFodderNoError, -5)
 // fodder == 0.0
 // err.Error() == "silly nephew, there cannot be -5 cows"
+```
+
+## 5. Handle ErrScaleMalfunction and other errors
+
+If `ErrScaleMalfunction` error is returned by `FodderAmount`, double the fodder amount returned by `FodderAmount` before dividing it between the cows.
+For any other error, return `0` and the error. 
+
+```go
+// twentyFodderWithErrScaleMalfunction says there are 20.0 fodder and a ErrScaleMalfunction
+fodder, err := DivideFood(twentyFodderWithErrScaleMalfunction, 10)
+// fodder == 4.0
+// err == nil
+```
+
+In case of `nil` error, return the fodder amount equally divided between the input number of cows.
+
+```go
+// twentyFodderNoError says there are 20.0 fodder
+fodder, err := DivideFood(twentyFodderNoError, 10)
+// fodder == 2.0
+// err == nil
 ```

--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -14,7 +14,23 @@ You love your nephew so you want to return a helpful error when he does that.
 
 ## 1. Get the amount of fodder from the `FodderAmount` method
 
-You will be passed a `WeightFodder` interface instance which has a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
+You will be passed a value that fulfills the `WeightFodder` interface. `WeightFodder` includes a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
+
+```go
+// twentyFodderNoError says there are 20.0 fodder
+fodder, err := DivideFood(twentyFodderNoError, 10)
+// fodder == 2.0
+// err == nil
+```
+
+If `ErrScaleMalfunction` is returned by `FodderAmount` and the fodder amount is positive, double the fodder amount returned by `FodderAmount` before dividing it equally between the cows. For any other error, return `0` and the error.
+
+```go
+// twentyFodderWithErrScaleMalfunction says there are 20.0 fodder and a ErrScaleMalfunction
+fodder, err := DivideFood(twentyFodderWithErrScaleMalfunction, 10)
+// fodder == 4.0
+// err == nil
+```
 
 ## 2. Return an error for negative fodder
 
@@ -51,25 +67,4 @@ You can see the format of the error message in the example below.
 fodder, err := DivideFood(twentyFodderNoError, -5)
 // fodder == 0.0
 // err.Error() == "silly nephew, there cannot be -5 cows"
-```
-
-## 5. Handle ErrScaleMalfunction and other errors
-
-If `ErrScaleMalfunction` error is returned by `FodderAmount`, double the fodder amount returned by `FodderAmount` before dividing it between the cows.
-For any other error, return `0` and the error. 
-
-```go
-// twentyFodderWithErrScaleMalfunction says there are 20.0 fodder and a ErrScaleMalfunction
-fodder, err := DivideFood(twentyFodderWithErrScaleMalfunction, 10)
-// fodder == 4.0
-// err == nil
-```
-
-In case of `nil` error, return the fodder amount equally divided between the input number of cows.
-
-```go
-// twentyFodderNoError says there are 20.0 fodder
-fodder, err := DivideFood(twentyFodderNoError, 10)
-// fodder == 2.0
-// err == nil
 ```

--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -14,7 +14,8 @@ You love your nephew so you want to return a helpful error when he does that.
 
 ## 1. Get the amount of fodder from the `FodderAmount` method
 
-You will be passed a value that fulfills the `WeightFodder` interface. `WeightFodder` includes a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
+You will be passed a value that fulfills the `WeightFodder` interface.
+`WeightFodder` includes a method called `FodderAmount` that returns the amount of fodder available and possibly an error.
 
 ```go
 // twentyFodderNoError says there are 20.0 fodder
@@ -23,7 +24,8 @@ fodder, err := DivideFood(twentyFodderNoError, 10)
 // err == nil
 ```
 
-If `ErrScaleMalfunction` is returned by `FodderAmount` and the fodder amount is positive, double the fodder amount returned by `FodderAmount` before dividing it equally between the cows. For any other error, return `0` and the error.
+If `ErrScaleMalfunction` is returned by `FodderAmount` and the fodder amount is positive, double the fodder amount returned by `FodderAmount` before dividing it equally between the cows.
+For any other error, return `0` and the error.
 
 ```go
 // twentyFodderWithErrScaleMalfunction says there are 20.0 fodder and a ErrScaleMalfunction


### PR DESCRIPTION
This PR contains the following minor changes:

- Renamed `weightFodder` to `FodderAmount` when referencing the method that provides the fodder amount
- Renamed instances of `function` with `method` when referencing the `FodderAmount` method
- Included the keyword `struct` when referring to the `weightFodder` instance
- Updated the names of `WeightFodder` instances to maintain consistency between comments and function arguments (e.g. replaced `twentyFodderNoError says there are -5.0 fodder` with `negativeFiveFodder says there are -5.0 fodder`)

This PR contains the following major change:

The sequence of instructions do not reflect the sequence of cases that need to be handled by the `DivideFood` function. For example, if the amount of fodder is negative then the error returned by `FodderAmount` method (e.g. `ErrScaleMalfunction` or `nil`) is inconsequential since in this case `DivideFood` should always return `Negative fodder` error [Inferred from test cases]. From observation, it appears that negative fodder, no cows and negative cows take precedence over `ErrScaleMalfunction` and other errors which in turn take precedence over the happy-path case. The instructions have been rearranged (and modified a bit) to reflect this sequence.