### PR TITLE
list-ops: fix typo in stub function

### DIFF
--- a/exercises/practice/list-ops/list_ops.go
+++ b/exercises/practice/list-ops/list_ops.go
@@ -8,7 +8,7 @@ func (s IntList) Foldl(fn func(int, int) int, initial int) int {
 }
 
 func (s IntList) Foldr(fn func(int, int) int, initial int) int {
-	panic("Please implement the Foldl function")
+	panic("Please implement the Foldr function")
 }
 
 func (s IntList) Filter(fn func(int) bool) IntList {


### PR DESCRIPTION
I noticed that there is a typo in the stub function when I was doing list-ops exercise.
Fix it with this small PR.