### PR TITLE
Small typo in error comparison example

### DIFF
--- a/concepts/errors/about.md
+++ b/concepts/errors/about.md
@@ -93,7 +93,7 @@ You can compare error variables with the equality operator `==`:
 ```go
 var ErrResourceNotFound = errors.New("resource not found")
 // ...
-if err == ErrSomethingWrong {
+if err == ErrResourceNotFound {
   // do something about the resource-not-found error
 }
 ```

--- a/concepts/errors/introduction.md
+++ b/concepts/errors/introduction.md
@@ -95,7 +95,7 @@ You can compare error variables with the equality operator `==`:
 ```go
 var ErrResourceNotFound = errors.New("resource not found")
 // ...
-if err == ErrSomethingWrong {
+if err == ErrResourceNotFound {
   // do something about the resource-not-found error
 }
 ```

--- a/exercises/concept/the-farm/.docs/introduction.md
+++ b/exercises/concept/the-farm/.docs/introduction.md
@@ -128,7 +128,7 @@ You can compare error variables with the equality operator `==`:
 ```go
 var ErrResourceNotFound = errors.New("resource not found")
 // ...
-if err == ErrSomethingWrong {
+if err == ErrResourceNotFound {
   // do something about the resource-not-found error
 }
 ```


### PR DESCRIPTION
Error name should be `ErrResourceNotFound` in `if` statement, it was incorrectly showing `ErrSomethingWrong` which is not related to this specific example.