### PR TITLE
Removing int from `DescribeAnything`

### DIFF
--- a/exercises/concept/sorting-room/.docs/instructions.md
+++ b/exercises/concept/sorting-room/.docs/instructions.md
@@ -65,7 +65,7 @@ This is the main function Jen needs which takes any input (the empty interface m
 `DescribeAnything` should delegate to the other functions based on the type of the value passed in.
 More specifically:
 
-- `int` and `float64` should both delegate to `DescribeNumber`
+- `float64` should delegate to `DescribeNumber`
 - `NumberBox` should delegate to `DescribeNumberBox`
 - `FancyNumberBox` should delegate to `DescribeFancyNumberBox`
 - anything else should result in `"Return to sender"`


### PR DESCRIPTION
`DescribeAnything` should not route `int` to  `DescribeNumber` because `DescribeNumber` can only handle `float64` - here's the function signature:

`func DescribeNumber(f float64) string {...`

Also, none of the above mini-challenges (1 to 4) build up to handling `int`, but rather `float64`s, so it makes sense to remove the `int` verbiage.