### PR TITLE
the-farm: fix go-staticcheck warning

### DIFF
--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -36,24 +36,24 @@ fodder, err := DivideFood(twentyFodderWithErrScaleMalfunction, 10)
 
 ## 2. Return an error for negative fodder
 
-If the scale is broken and returning negative amounts of fodder, return an error saying "Negative fodder":
+If the scale is broken and returning negative amounts of fodder, return an error saying "negative fodder":
 
 ```go
 // negativeFiveFodder says there are -5.0 fodder
 fodder, err := DivideFood(negativeFiveFodder, 10)
 // fodder == 0.0
-// err.Error() == "Negative fodder"
+// err.Error() == "negative fodder"
 ```
 
 ## 3. Prevent division by zero
 
-After getting the fodder amount from `weightFodder`, prevent a division by zero when there are no cows at all by returning an error saying "Division by zero":
+After getting the fodder amount from `weightFodder`, prevent a division by zero when there are no cows at all by returning an error saying "division by zero":
 
 ```go
 // twentyFodderNoError says there are 20.0 fodder
 fodder, err := DivideFood(twentyFodderNoError, 0)
 // fodder == 0.0
-// err.Error() == "Division by zero"
+// err.Error() == "division by zero"
 ```
 
 ## 4. Handle negative cows

--- a/exercises/concept/the-farm/.meta/exemplar.go
+++ b/exercises/concept/the-farm/.meta/exemplar.go
@@ -25,10 +25,10 @@ func DivideFood(weightFodder WeightFodder, cows int) (float64, error) {
 		fodder *= 2
 	}
 	if fodder < 0 {
-		return 0, errors.New("Negative fodder")
+		return 0, errors.New("negative fodder")
 	}
 	if cows == 0 {
-		return 0, errors.New("Division by zero")
+		return 0, errors.New("division by zero")
 	}
 	if cows < 0 {
 		return 0, &SillyNephewError{Cows: cows}

--- a/exercises/concept/the-farm/the_farm_test.go
+++ b/exercises/concept/the-farm/the_farm_test.go
@@ -94,7 +94,7 @@ func TestDivideFood(t *testing.T) {
 			weightFodderDescription: "-1 fodder, no error",
 			cows:                    2,
 			wantAmount:              0,
-			wantErr:                 errors.New("Negative fodder"),
+			wantErr:                 errors.New("negative fodder"),
 		},
 		{
 			description:             "Negative fodder with ScaleError",
@@ -102,7 +102,7 @@ func TestDivideFood(t *testing.T) {
 			weightFodderDescription: "-1 fodder, ScaleError",
 			cows:                    2,
 			wantAmount:              0,
-			wantErr:                 errors.New("Negative fodder"),
+			wantErr:                 errors.New("negative fodder"),
 		},
 		{
 			description:             "Zero cows",
@@ -110,7 +110,7 @@ func TestDivideFood(t *testing.T) {
 			weightFodderDescription: "100 fodder, no error",
 			cows:                    0,
 			wantAmount:              0,
-			wantErr:                 errors.New("Division by zero"),
+			wantErr:                 errors.New("division by zero"),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Task2 asks for:

```go
// negativeFiveFodder says there are -5.0 fodder
fodder, err := DivideFood(negativeFiveFodder, 10)
// fodder == 0.0
// err.Error() == "Negative fodder"
```

When I type `return 0, errors.New("Negative fodder")`, VSCode warns out: `error strings should not be capitalized (ST1005) go-staticcheck`
Same for Task3.