### PR TITLE
sorting-room: fix test description typo

### DIFF
--- a/exercises/concept/sorting-room/sorting_room_test.go
+++ b/exercises/concept/sorting-room/sorting_room_test.go
@@ -118,7 +118,7 @@ func TestDescribeFancyNumberBox(t *testing.T) {
 		want        string
 	}{
 		{
-			description: "Describe fancy number 11",
+			description: "Describe fancy number 12",
 			input:       FancyNumber{"12"},
 			want:        "This is a fancy box containing the number 12.0",
 		},


### PR DESCRIPTION
Sending value `12`, while description says `11`