### PR TITLE
Correct typo in Chessboard exercise

### DIFF
--- a/exercises/concept/chessboard/.meta/exemplar.go
+++ b/exercises/concept/chessboard/.meta/exemplar.go
@@ -3,7 +3,7 @@ package chessboard
 // Rank stores if a square is occupied by a piece
 type Rank []bool
 
-// Chessboard contains eight Ranks, accessed with values from "A" to "H"
+// Chessboard contains eight Ranks, accessed with keys from "A" to "H"
 type Chessboard map[string]Rank
 
 // CountInRank returns how many squares are occupied in the chessboard,

--- a/exercises/concept/chessboard/chessboard.go
+++ b/exercises/concept/chessboard/chessboard.go
@@ -2,7 +2,7 @@ package chessboard
 
 // Declare a type named Rank which stores if a square is occupied by a piece - this will be a slice of bools
 
-// Declare a type named Chessboard contains a map of eight Ranks, accessed with values from "A" to "H"
+// Declare a type named Chessboard which contains a map of eight Ranks, accessed with keys from "A" to "H"
 
 // CountInRank returns how many squares are occupied in the chessboard,
 // within the given rank


### PR DESCRIPTION
The exemplar says that ranks are accessed by values from "A" to "H",
but maps are accessed by keys.