### PR TITLE
booking-up-for-beauty: fix instructions output for exercise 5

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -52,4 +52,4 @@ AnniversaryDate()
 // Output: 2020-09-15 00:00:00 +0000 UTC
 ```
 
-**Note** the return value is a `time.Time` and the time of day doesn't matter.
+**Note:** the return value is a `time.Time` and the time of day doesn't matter.

--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -45,8 +45,11 @@ Description("7/25/2019 13:45:00")
 Implement the `AnniversaryDate` function that returns the anniversary date of the salon's opening for the current year in UTC.
 
 Assuming the current year is 2020:
+
 ```go
 AnniversaryDate()
 
-// Output: 2020-09-15
+// Output: 2020-09-15 00:00:00 +0000 UTC
 ```
+
+**Note** the return value is a `time.Time` and the time of day doesn't matter.


### PR DESCRIPTION
FIxes: #2035 

### Changes

Quick fix for `booking-up-for-beauty` exercise 5:
- changed output example to: `2020-09-15 00:00:00 +0000 UTC`
- added end note to specify returning type and that time of day doesn't matter