### PR TITLE
Escape asterisks

### DIFF
--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -38,7 +38,7 @@ For example, 37 cars can be produced in the following way:
 37 = 3 x groups of ten + 7 individual cars
 
 So the cost for 37 cars is:
-3*95,000+7*10,000=355,000
+3\*95,000+7\*10,000=355,000
 
 Implement the function `CalculateCost` that calculates the cost of producing a number of cars, regardless of whether they are successful:
 


### PR DESCRIPTION
Escaping asterisks in instruction text cause it is being interpreted as special caracter.