### PR TITLE
Fix broken link in nucleotide-count's description

### DIFF
--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -14,7 +14,7 @@ Which is the best Go types to represent the output values ?
 Take a look at the test cases to get a hint about what could be the possible inputs.
 
 
-## note about the tests
+## Note about the tests
 You may be wondering about the `cases_test.go` file. We explain it in the
 [leap exercise][leap-exercise].
 

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -16,7 +16,7 @@ Take a look at the test cases to get a hint about what could be the possible inp
 
 ## note about the tests
 You may be wondering about the `cases_test.go` file. We explain it in the
-[leap exercise][leap-exercise-readme].
+[leap exercise][leap-exercise].
 
-[leap-exercise-readme]: https://github.com/exercism/go/blob/master/exercises/leap/README.md
+[leap-exercise]: https://exercism.org/tracks/go/exercises/leap
 


### PR DESCRIPTION
The link at the end of the description goes to a GitHub page that is out
of date—the link is a 404. In addition, I think it makes more sense to link
to the leap exercise on Exercism's own site rather than to a raw markdown
document on GitHub.

I've updated the link accordingly.