### PR TITLE
Lasagna Master: Fix references to "array"

### DIFF
--- a/exercises/concept/lasagna-master/.docs/hints.md
+++ b/exercises/concept/lasagna-master/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## 1. Estimate the preparation time
 
-- Use the [`len()` built-in function][len-builtin] to determine the number of layers (length of the layers array).
+- Use the [`len()` built-in function][len-builtin] to determine the number of layers (length of the layers slice).
 
 ## 2. Compute the amounts of noodles and sauce needed
 
@@ -13,7 +13,7 @@
 ## 3. Add the secret ingredient
 
 - Revisit [slices][concept-slices] to find out how to retrieve an element from an slice and how to replace an element in a slice.
-- The index of the last element in an array `a` is `len(a) - 1`.
+- The index of the last element in a slice `a` is `len(a) - 1`.
 
 ## 4. Scale the recipe
 

--- a/exercises/concept/lasagna-master/.docs/instructions.md
+++ b/exercises/concept/lasagna-master/.docs/instructions.md
@@ -11,7 +11,7 @@ For the next lasagna that you will prepare, you want to make sure you have enoug
 You already planned which layers your lasagna will have.
 Now you want to estimate how long the preparation will take based on that.
 
-Implement a function `PreparationTime` that accepts an array of layers as a `[]string` and the average preparation time per layer in minutes as an `int`.
+Implement a function `PreparationTime` that accepts a slice of layers as a `[]string` and the average preparation time per layer in minutes as an `int`.
 The function should return the estimate for the total preparation time based on the number of layers as an `int`.
 Go has no default values for functions.
 If the average preparation time is passed as `0` (the default initial value for an `int`), then the default value of `2` should be used.
@@ -30,7 +30,7 @@ Besides reserving the time, you also want to make sure you have enough sauce and
 For each noodle layer in your lasagna, you will need 50 grams of noodles.
 For each sauce layer in your lasagna, you will need 0.2 liters of sauce.
 
-Define the function `Quantities` that takes an array of layers as parameter as a `[]string`.
+Define the function `Quantities` that takes a slice of layers as parameter as a `[]string`.
 The function will then determine the quantity of noodles and sauce needed to make your meal.
 The result should be returned as two values of `noodles` as an `int` and `sauce` as a `float64`.
 
@@ -46,7 +46,7 @@ It was amazing and had something special to it.
 The friend sent you the list of ingredients and told you the last item on the list is the "secret ingredient" that made the meal so special.
 Now you want to add that secret ingredient to your recipe as well.
 
-Write a function `AddSecretIngredient` that accepts two arrays of ingredients of type `[]string` as parameters.
+Write a function `AddSecretIngredient` that accepts two slices of ingredients of type `[]string` as parameters.
 The first parameter is the list your friend sent you, the second is the ingredient list of your own recipe.
 The last element in your ingredient list is always `"?"`. The function should replace it with the last item from your friends list.
 **Note:** `AddSecretIngredient` does not return anything - you should modify the list of your ingredients directly. The list with your friend's ingredients should **not** be modified.


### PR DESCRIPTION
The instructions for _Lasagna Master_ say "array(s)" in several places
when referring to slices, which might be confusing given that they are
different, incompatible data structures in Go.