### PR TITLE
prime-factors: allow empty nil slices

### DIFF
--- a/exercises/practice/prime-factors/prime_factors_test.go
+++ b/exercises/practice/prime-factors/prime_factors_test.go
@@ -1,7 +1,6 @@
 package prime
 
 import (
-	"reflect"
 	"sort"
 	"testing"
 )
@@ -11,7 +10,7 @@ func TestPrimeFactors(t *testing.T) {
 		actual := Factors(test.input)
 		sort.Slice(actual, ascending(actual))
 		sort.Slice(test.expected, ascending(test.expected))
-		if !reflect.DeepEqual(actual, test.expected) {
+		if !slicesEqual(actual, test.expected) {
 			t.Fatalf("FAIL %s\nFactors(%d) = %#v;\nexpected %#v",
 				test.description, test.input,
 				actual, test.expected)
@@ -29,6 +28,24 @@ func BenchmarkPrimeFactors(b *testing.B) {
 			Factors(test.input)
 		}
 	}
+}
+
+func slicesEqual(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	if len(a) == 0 {
+		return true
+	}
+
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 func ascending(list []int64) func(int, int) bool {


### PR DESCRIPTION
For this exercise, a solution that simply creates a slice with its default value fails the tests:

```go
func Factors(n int64) []int64 {
	var factors []int64
	for i := int64(2); i <= n; i++ {
		for n%i == 0 {
			factors = append(factors, i)
			n /= i
		}
	}
	return factors
}
```

```console
$ go test
--- FAIL: TestPrimeFactors (0.00s)
    prime_factors_test.go:15: FAIL no factors
        Factors(1) = []int64(nil);
        expected []int64{}
FAIL
exit status 1
FAIL    prime   0.001s
```

In the previous solution, changing the declaration of `factors` to `factors :=  make([]int64, 0)` will make the tests pass.

This PR makes the slice comparison not care if an empty slice is created explicitly created with make, or has its `nil` default value.