### PR TITLE
Remove index 2 value from example output

### DIFF
--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -27,7 +27,7 @@ If you don't specify an ending index, it defaults to the length of the slice.
 
 ```go
 newSlice := withData[2:4] // newSlice == []int{2,3}
-newSlice := withData[:2]  // newSlice == []int{0,1,2}
+newSlice := withData[:2]  // newSlice == []int{0,1}
 newSlice := withData[2:]  // newSlice == []int{2,3,4,5}
 newSlice := withData[:]   // newSlice == []int{0,1,2,3,4,5}
 ```


### PR DESCRIPTION
Remove index 2 value from example output as the ending index is exclusive in about.md

Fix the typo in the example output.
https://go.dev/play/p/6YZqXuuvvXa