### PR TITLE
remove valid roman numeral marked as invalid

### DIFF
--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -20,8 +20,7 @@ into stone tablets).
  7  => VII
 ```
 
-There is no need to be able to convert numbers larger than about 3000.
-(The Romans themselves didn't tend to go any higher)
+The largest number that can be represented in this notation is 3,999.
 
 Wikipedia says: Modern Roman numerals ... are written by expressing each
 digit separately starting with the left most digit and skipping any

--- a/exercises/practice/roman-numerals/cases_test.go
+++ b/exercises/practice/roman-numerals/cases_test.go
@@ -30,4 +30,5 @@ var romanNumeralTests = []romanNumeralTest{
 	{911, "CMXI", false},
 	{1024, "MXXIV", false},
 	{3000, "MMM", false},
+	{3999, "MMMCMXCIX", false},
 }

--- a/exercises/practice/roman-numerals/roman_numerals_test.go
+++ b/exercises/practice/roman-numerals/roman_numerals_test.go
@@ -6,7 +6,6 @@ func TestRomanNumerals(t *testing.T) {
 	tc := []romanNumeralTest{
 		{0, "", true},
 		{-1, "", true},
-		{3001, "", true},
 	}
 	tc = append(tc, romanNumeralTests...)
 

--- a/exercises/practice/roman-numerals/roman_numerals_test.go
+++ b/exercises/practice/roman-numerals/roman_numerals_test.go
@@ -6,6 +6,7 @@ func TestRomanNumerals(t *testing.T) {
 	tc := []romanNumeralTest{
 		{0, "", true},
 		{-1, "", true},
+		{4000, "", true},
 	}
 	tc = append(tc, romanNumeralTests...)
 


### PR DESCRIPTION
I know the instruction states that _There is no need to be able to convert numbers larger than about 3000_, but I shouldn't be forced to return an error for a valid number. IMO if there's no need to convert numbers higher than 3000, we should just not test them.