### PR TITLE
Modifying a test case to verify that car cannot finish the track distance

### DIFF
--- a/exercises/concept/need-for-speed/need_for_speed_test.go
+++ b/exercises/concept/need-for-speed/need_for_speed_test.go
@@ -173,7 +173,7 @@ func TestCanFinish(t *testing.T) {
 			name: "Car cannot finish the track distance.",
 			car: Car{
 				speed:        2,
-				batteryDrain: 10,
+				batteryDrain: 6,
 				battery:      100,
 				distance:     5,
 			},


### PR DESCRIPTION
There are multiple community solutions where the _**"CanFinish"**_ method has a check to keep driving the car until the battery is less than 1. But that logic is incorrect because the car can be driven only when:
`car.battery > car.batteryDrain`.

This case does not get tested because all the test cases are such that either battery is a multiple of batteryDrained or 
`battery - (batteryDrained*some_multiple)=1`.  Hence the modification to the test case.

Here, for initial condition of,
`car: Car{
				speed:        2,
				batteryDrain: 6,
				battery:      100,
				distance:     5,
			},
			track: Track{
				distance: 80,
			}`
After car is driven completely,
`car: Car{
				speed:        2,
				batteryDrain: 6,
				battery:      4,
				distance:     37,
			},`
For solutions with logic "drive car until battery is less than 1" will fail as battery != 1 but battery < batteryDrain.