### PR TITLE
the-farm: fixes typo in one of the test descriptions

### DIFF
--- a/exercises/concept/the-farm/the_farm_test.go
+++ b/exercises/concept/the-farm/the_farm_test.go
@@ -89,7 +89,7 @@ func TestDivideFood(t *testing.T) {
 			wantErr:                 nil,
 		},
 		{
-			description:             "Scale returns 5 with ErrScaleMalfunction for 10 cows",
+			description:             "Scale returns 1 with ErrScaleMalfunction for 10 cows",
 			weightFodder:            testWeightFodder{fodder: 5, err: ErrScaleMalfunction},
 			weightFodderDescription: "5 fodder, ErrScaleMalfunction",
 			cows:                    10,


### PR DESCRIPTION
One of the tests returns 1, but in the description says it should return 5. This patch set just updates the description to say 1 instead.
```
{
	description:             "Scale returns 5 with ErrScaleMalfunction for 10 cows",
	weightFodder:            testWeightFodder{fodder: 5, err: ErrScaleMalfunction},
	weightFodderDescription: "5 fodder, ErrScaleMalfunction",
	cows:                    10,
	wantAmount:              1,
	wantErr:                 nil,
},
```