### PR TITLE
fix: rephrasing introduction.md and about.md since golang.org was replaced by go.dev

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,7 +1,7 @@
 # Basics About
 
 The Basics concept introduced [Go](https://golang.org) as a statically typed, compiled programming language.
-The language is often referred to as Golang because of its domain name, golang.org, but the proper name is Go.
+The language is often referred to as Golang because of its previous domain name, golang.org, but the proper name is Go.
 
 The Basics concept introduces three major language features: Packages, Functions, and Variables.
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -2,7 +2,7 @@
 
 [Go](https://golang.org) is a statically typed, compiled programming language.
 Go is syntactically similar to C.
-The language is often referred to as Golang because of its domain name, golang.org, but the proper name is Go.
+The language is often referred to as Golang because of its previous domain name, golang.org, but the proper name is Go.
 
 The Basics concept will introduce three major language features: Packages, Functions, and Variables.
 


### PR DESCRIPTION
Rephrasing introduction and about, since golang.org was replaced by go.dev.

Fixes https://github.com/exercism/go/issues/2085