### PR TITLE
modify exercise-tests.yml

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         test-arch: [amd64]
         race: ['-race']


### PR DESCRIPTION
Removed version 1.16.+ from [exercise-tests.yml](https://github.com/exercism/go/blob/main/.github/workflows/exercise-tests.yml) as suggested by @andrerfcsantos in issue #2089 