### PR TITLE
Fix extra tests for arch 386 running in an older version of Go

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Go ${{ matrix.go-version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Go ${{ matrix.go-version }} - ${{ matrix.os }}/${{ matrix.test-arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -21,10 +21,12 @@ jobs:
         race: ['-race']
 
         include:
-          - test-arch: '386'
+          - go-version: 1.17.x
+            test-arch: '386'
             os: ubuntu-latest
             race: ''
-          - test-arch: '386'
+          - go-version: 1.17.x
+            test-arch: '386'
             os: windows-latest
             race: ''
 


### PR DESCRIPTION
Follow-up of: #2093

I noticed that the tests present in the "includes" section were not specifying a version of Go to run. Due to this, they were using a cached version of Go that happened to be go 1.15. This PR forces a specific version on these tests, in this case `go 1.17`, that is the same version the other tests run.

With this change, the names of some jobs would be the same, so I also made the name of the job include the architecture to disambiguate.