### PR TITLE
hamming: Update link leading to leap exercise

### DIFF
--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
 You may be wondering about the `cases_test.go` file. We explain it in the
-[leap exercise][leap-exercise-readme].
+[leap exercise][leap-exercise-link].
 
-[leap-exercise-readme]: https://github.com/exercism/go/blob/main/exercises/practice/leap/.docs/instructions.md
+[leap-exercise-link]: https://exercism.org/tracks/go/exercises/leap


### PR DESCRIPTION
From the [Hamming](https://github.com/exercism/go/blob/main/exercises/practice/hamming/.docs/instructions.append.md) exercise:
> You may be wondering about the `cases_test.go` file. We explain it in the [leap exercise](https://github.com/exercism/go/blob/main/exercises/practice/leap/.docs/instructions.md).

The link leads to the `instructions.md` file which has no explanation about the `cases_test.go` and I found it very confusing.
I suggest changing it so it leads to the actual exercise on the website.