### PR TITLE
robot-simulator: Fix formatting on append instructions

### DIFF
--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -5,11 +5,14 @@
 Tests are separated into 3 steps.
 
 Run all tests with `go test` or run specific tests with the -tags option.
+
 Examples:
 
-   go test                      # run all tests
-   go test -tags step1          # run just step 1 tests.
-   go test -tags 'step1 step2'  # run step1 and step2 tests
+```bash
+go test                      # run all tests
+go test -tags step1          # run just step 1 tests.
+go test -tags 'step1 step2'  # run step1 and step2 tests
+```
 
 You are given the source file defs.go which defines a number of things
 the test program requires.  It is organized into three sections by step.


### PR DESCRIPTION
Right now these commands appear all in one line since whitespace is being ignored. This makes the text very confusing to read:

![image](https://user-images.githubusercontent.com/6928620/154803882-2dba2093-ef7f-4748-970d-1822b0a470ad.png)

This PR fixes this by introducing a new bash code block where whitespaces are respected.