### PR TITLE
Sorting room: instructions and test cases.

### DIFF
--- a/exercises/concept/sorting-room/.docs/instructions.md
+++ b/exercises/concept/sorting-room/.docs/instructions.md
@@ -25,11 +25,11 @@ fmt.Println(DescribeNumber(-12.345))
 
 ## 2. Describe a number box
 
-Jen wants numbers to return strings like `"This is a box containing the number 2.0"` (again, including one digit after the decimal):
+Jen wants number boxes to return strings like `"This is a box containing the number 2.0"` (again, including one digit after the decimal):
 
 ```go
-fmt.Println(DescribeNumberBox(numberBoxContaining{12.345}))
-// Output: This is a box containing the number 12.3
+fmt.Println(DescribeNumberBox(numberBoxContaining{12}))
+// Output: This is a box containing the number 12
 ```
 
 ## 3. Implement a method extracting the number from a fancy number box
@@ -41,7 +41,7 @@ Any other type of `FancyNumberBox` should return 0.
 ```go
 fmt.Println(ExtractFancyNumber(FancyNumber{"10"}))
 // Output: 10
-fmt.Println(ExtractFancyNumber(AnotherFancyNumber{"one"}))
+fmt.Println(ExtractFancyNumber(AnotherFancyNumber{"4"}))
 // Output: 0
 ```
 
@@ -53,7 +53,7 @@ Any other type of `FancyNumberBox` should say `"This is a fancy box containing t
 ```go
 fmt.Println(DescribeFancyNumberBox(FancyNumber{"10"}))
 // Output: This is a fancy box containing the number 10.0
-fmt.Println(DescribeFancyNumberBox(AnotherFancyNumber{"one"}))
+fmt.Println(DescribeFancyNumberBox(AnotherFancyNumber{"4"}))
 // Output: This is a fancy box containing the number 0.0
 ```
 

--- a/exercises/concept/sorting-room/sorting_room_test.go
+++ b/exercises/concept/sorting-room/sorting_room_test.go
@@ -97,8 +97,13 @@ func TestExtractFancyNumber(t *testing.T) {
 			want:        0,
 		},
 		{
-			description: "Extract a different fancy number returns 0",
-			input:       differentFancyNumber{"two"},
+			description: "Extract a differentFancyNumber returns 0",
+			input:       differentFancyNumber{"4"},
+			want:        0,
+		},
+		{
+			description: "Extract an invalid fancy number returns 0",
+			input:       FancyNumber{"two"},
 			want:        0,
 		},
 	}


### PR DESCRIPTION
Resolves #2106

Sorting room instructions: 

- fix in first sentence in Section 2 #2106
- changes to function arguments in example in Sections 2 #2106
- changes to function arguments in examples in Sections 3 and 4. #2110 

sorting_room_test.go, func TestExtractFancyNumber: 

- changed "differentFancyNumber" test case #2106
- added a new test case for "FancyNumber with invalid string"  