### PR TITLE
Clarify error message for bird-count

### DIFF
--- a/exercises/concept/bird-watcher/bird_watcher_test.go
+++ b/exercises/concept/bird-watcher/bird_watcher_test.go
@@ -97,8 +97,11 @@ func TestFixBirdCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			input := make([]int, len(tt.birdCounts))
+			copy(input, tt.birdCounts)
+
 			if got := FixBirdCountLog(tt.birdCounts); !reflect.DeepEqual(tt.want, got) {
-				t.Errorf("FixBirdCountLog(%v) = %v; want %v", tt.birdCounts, got, tt.want)
+				t.Errorf("FixBirdCountLog(%v) = %v; want %v", input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This _seems_ like is a fairly minor change to make error messages in a particular `bird-watcher` test a bit easier to understand. On the other hand, it's totally possible a change like this would open the door to needing to look for any other "mutates input slice" examples. But at any rate, I wanted to raise the question as I'm going through these exercises. Thanks for creating and maintaining them!

Before this change, a mistake in the implementation, such as `i%2 == 1` instead of `i%2 == 0`, the error messages were a bit confusing for the learner (or at least for me 😃):

    bird_watcher_test.go:101: FixBirdCountLog([3 1 5 2 0 5 1 1 3 5 3 1]) = [3 1 5 2 0 5 1 1 3 5 3 1]; want [4 0 6 1 1 4 2 0 4 4 4 0]

Note in the above that the *actual* input slice was `[3 0 5 1 0 4 1 0 3 4 3 0]`, and so the printed input is *after* mutation.

So until they dig into the underlying test suite to see what's happening (a valuable skill! but perhaps not what's being tested here) a learner might reasonably assume that no mutation actually happened.

This change ensures (at the cost of extra allocation) that the error message's displayed input shows the original input slice rather than the mutated one:

    bird_watcher_test.go:104: FixBirdCountLog([3 0 5 1 0 4 1 0 3 4 3 0]) = [3 1 5 2 0 5 1 1 3 5 3 1]; want [4 0 6 1 1 4 2 0 4 4 4 0]