### PR TITLE
Card Tricks: Adapt to current concept tree progression #1990

### DIFF
--- a/config.json
+++ b/config.json
@@ -120,7 +120,7 @@
         "prerequisites": [
           "string-formatting",
           "numbers",
-          "multiple-return-values",
+          "functions",
           "booleans"
         ],
         "status": "beta"
@@ -225,7 +225,7 @@
         ],
         "prerequisites": [
           "string-formatting",
-          "multiple-return-values"
+          "functions"
         ],
         "status": "wip"
       },
@@ -249,7 +249,7 @@
         "uuid": "154660c2-db8c-4ec1-91f2-6b1275eabbc0",
         "concepts": [
           "slices",
-          "multiple-return-values"
+          "variadic-functions"
         ],
         "prerequisites": [
           "booleans",

--- a/exercises/concept/card-tricks/.docs/hints.md
+++ b/exercises/concept/card-tricks/.docs/hints.md
@@ -29,7 +29,7 @@ fmt.Println(c)
 - To set the `n`th item in a slice [use an index][go-slices] and assign a new value to it.
 - To add a new item to then end of a slice use the `append` function.
 
-## 4. Prepend cards to the stack
+## 4. Add cards to the top of the stack
 
 - Adding items to the front of a slice can be done by appending the elements of the original slice to the `value` argument slice.
 

--- a/exercises/concept/card-tricks/.docs/hints.md
+++ b/exercises/concept/card-tricks/.docs/hints.md
@@ -2,44 +2,40 @@
 
 ## General
 
-- Slices in Go are zero-based. The first index in a slice is `0`. 
-- The builtin [`append`][append-builtin] function is [`variadic`][variadic-gobyexample] 
-- You can append the elements of one slice to another slice by using the three dots notation: 
+- Slices in Go are zero-based. The first index in a slice is `0`.
+- The builtin [`append`][append-builtin] function is [`variadic`][variadic-gobyexample]
+- You can append the elements of one slice to another slice by using the three dots notation:
 
 ```go
-a := []int{1,3}
-b := []int{4,2,6}
-c := append(a,b...)  
+a := []int{1, 3}
+b := []int{4, 2, 6}
+c := append(a, b...)
 fmt.Println(c)
-// output is [1 3 4 2 6]
+// Output: [1 3 4 2 6]
 ```
 
-## 1. AllItems 
+## 1. FavoriteCards
 
-- There are several ways to create a new slice. The simplest is `var s []int`.
-- You get more options with the [`make`][make-builtin] function. 
-- To create a slice pre-filled with some data, use the slice literal notation: 
-   `s := []T{x1,x2,...,xn}` 
+- To create a slice pre-filled with some data, use the slice literal notation:
+  `s := []T{x1, x2, ..., xn}`
 
 ## 2. Retrieve a card from a stack
 
 - To get the `n`th item of a slice [use an index][go-slices].
-- To check if an item exists in a slice use a conditional and compare the index with the [length of the slice][len-builtin]. 
+- To check if an item exists in a slice use a conditional and compare the index with the [length of the slice][len-builtin].
 
 ## 3. Exchange a card in the stack
 
 - To set the `n`th item in a slice [use an index][go-slices] and assign a new value to it.
-- To add a new item to then end of a list use the `append` function. 
+- To add a new item to then end of a slice use the `append` function.
 
-## 4. Remove a card from the stack 
+## 4. Prepend cards to the stack
 
-- Removing an item from a slice can be done by appending the part after `index`
-  to the part before index. 
+- Adding items to the front of a slice can be done by appending the elements of the original slice to the `value` argument slice.
 
-## 5. Prepend cards to the stack
+## 5. Remove a card from the stack
 
- - Adding items to the front of a slice can be done by appending the elements of
-   the original slice to the `value` argument slice.  
+- Removing an item from a slice can be done by appending the part after `index` to the part before index.
 
 [go-slices]: https://blog.golang.org/go-slices-usage-and-internals
 [make-builtin]: https://golang.org/pkg/builtin/#make

--- a/exercises/concept/card-tricks/.docs/hints.md
+++ b/exercises/concept/card-tricks/.docs/hints.md
@@ -2,29 +2,47 @@
 
 ## General
 
-- slices in Go are zero-based. The first index in a slice is `0`.
+- Slices in Go are zero-based. The first index in a slice is `0`. 
+- The builtin [`append`][append-builtin] function is [`variadic`][variadic-gobyexample] 
+- You can append the elements of one slice to another slice by using the three dots notation: 
 
-## 1. Retrieve a card from a stack
+```go
+a := []int{1,3}
+b := []int{4,2,6}
+c := append(a,b...)  
+fmt.Println(c)
+// output is [1 3 4 2 6]
+```
+
+## 1. AllItems 
+
+- There are several ways to create a new slice. The simplest is `var s []int`.
+- You get more options with the [`make`][make-builtin] function. 
+- To create a slice pre-filled with some data, use the slice literal notation: 
+   `s := []T{x1,x2,...,xn}` 
+
+## 2. Retrieve a card from a stack
 
 - To get the `n`th item of a slice [use an index][go-slices].
-- To check if an item exists in a slice use a conditional and compare the index with the [length of the slice][len-builtin].
-- Note: a slice always starts with index `0`, `1`, `2`, etc.
+- To check if an item exists in a slice use a conditional and compare the index with the [length of the slice][len-builtin]. 
 
-## 2. Exchange a card in the stack
+## 3. Exchange a card in the stack
 
 - To set the `n`th item in a slice [use an index][go-slices] and assign a new value to it.
-- To add a new item to a list use the builtin [`append`][append-builtin] function.
+- To add a new item to then end of a list use the `append` function. 
 
-## 3. Create a stack of cards
+## 4. Remove a card from the stack 
 
-- There are several ways to create a new slice. The simplest is `var s []int`. More options you get with the [`make`][make-builtin] function.
-- Use the techniques from 2. to fill the slice with the correct values in a `for` loop.
+- Removing an item from a slice can be done by appending the part after `index`
+  to the part before index. 
 
-## 4. Remove a card from the stack
+## 5. Prepend cards to the stack
 
-- Removing an item from a slice can be done by appending the part after `index` to the part before index.
+ - Adding items to the front of a slice can be done by appending the elements of
+   the original slice to the `value` argument slice.  
 
 [go-slices]: https://blog.golang.org/go-slices-usage-and-internals
 [make-builtin]: https://golang.org/pkg/builtin/#make
 [len-builtin]: https://golang.org/pkg/builtin/#len
 [append-builtin]: https://golang.org/pkg/builtin/#append
+[variadic-gobyexample]: https://gobyexample.com/variadic-functions

--- a/exercises/concept/card-tricks/.docs/hints.md
+++ b/exercises/concept/card-tricks/.docs/hints.md
@@ -14,7 +14,7 @@ fmt.Println(c)
 // Output: [1 3 4 2 6]
 ```
 
-## 1. FavoriteCards
+## 1. Create a slice with certain cards
 
 - To create a slice pre-filled with some data, use the slice literal notation:
   `s := []T{x1, x2, ..., xn}`

--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -4,7 +4,7 @@ As a magician-to-be, Elyse needs to practice some basics. She has a stack of car
 
 To make things a bit easier she only uses the cards 1 to 10.
 
-## 1. Create a slice with certain cards
+## 1. FavoriteCards
 
 When practicing with her cards, Elyse likes to start with her favorite three cards of the deck: 2, 6 and 9.
 Write a function `FavoriteCards` that returns a slice with those cards in that order.

--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -4,38 +4,41 @@ As a magician-to-be, Elyse needs to practice some basics. She has a stack of car
 
 To make things a bit easier she only uses the cards 1 to 10.
 
-## 1. Retrieve a card from a stack
+## 1. Create a slice with all the cards 
+
+Return a slice with all cards from 1 to 10 
+
+```go 
+cards := AllItems()
+fmt.Println(cards) 
+// Output: [1 2 3 4 5 6 7 8 9 10]
+``` 
+
+## 2. Retrieve a card from a stack
 
 Return the card at position `index` from the given stack.
 
 ```go
-card, ok := GetItem([]int{1, 2, 4, 1}, 2)
-fmt.Println(card)
-// Output: 4
-fmt.Println(ok)
-// Output: true
+card := GetItem([]int{1, 2, 4, 1}, 2) // card == 4  
 ```
 
-If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to return `0` and `false`:
+If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to return `-1`:
 
 ```go
-card, ok := GetItem([]int{1, 2, 4, 1}, 10)
-fmt.Println(card)
-// Output: 0
-fmt.Println(ok)
-// Output: false
+card := GetItem([]int{1, 2, 4, 1}, 10) // card == -1  
 ```
 
-## 2. Exchange a card in the stack
+## 3. Exchange a card in the stack
 
 Exchange the card at position `index` with the new card provided and return the adjusted stack.
-Note that this will also change the input slice which is ok.
+Note that this will modify the input slice which is the expected behavior. 
 
 ```go
 index := 2
 newCard := 6
-SetItem([]int{1, 2, 4, 1}, index, newCard)
-// Output: []int{1, 2, 6, 1}
+cards := SetItem([]int{1, 2, 4, 1}, index, newCard)  
+fmt.Println(cards) 
+// Output: [1 2 6 1]
 ```
 
 If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to append the new card to the end of the stack:
@@ -43,31 +46,56 @@ If the index is out of bounds (ie. if it is negative or after the end of the sta
 ```go
 index := -1
 newCard := 6
-SetItem([]int{1, 2, 4, 1}, index, newCard)
-// Output: []int{1, 2, 4, 1, 6}
-```
-
-## 3. Create a stack of cards
-
-Create a stack of given `length` and fill it with cards of the given `value`. If the given `length` is negative or zero, return an empty stack.
-
-```go
-PrefilledSlice(8, 3)
-// Output: []int{8, 8, 8}
+cards := SetItem([]int{1, 2, 4, 1}, index, newCard)
+fmt.Println(cards) 
+// Output: [1 2 4 1 6]
 ```
 
 ## 4. Remove a card from the stack
 
-Remove the card at position `index` from the stack and return the stack.
+Remove the card at position `index` from the stack and return the stack. Note
+that this may modify the input slice which is ok. 
 
-```go
-RemoveItem([]int{3, 2, 6, 4, 8}, 2)
-// Output: []int{3, 2, 4, 8}
+```go 
+cards := RemoveItem([]int{3, 2, 6, 4, 8}, 2)
+fmt.Println(cards) 
+// Output: [3 2 4 8]
 ```
 
-If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to leave the stack unchanged:
+If the index is out of bounds (ie. if it is negative or after the end of the
+stack), we want to leave the stack unchanged:
 
 ```go
-RemoveItem([]int{3, 2, 6, 4, 8}, 11)
-// Output: []int{3, 2, 6, 4, 8}
+cards := RemoveItem([]int{3, 2, 6, 4, 8}, 11)
+fmt.Println(cards) 
+// Output: [3 2 6 4 8]
 ```
+
+## 5. PrependItems
+
+Add values at the front of a stack. Note that `PrependItems` is a variadic
+function, its type is: 
+
+```go 
+func PrependItems(slice []int, value ...int) []int
+``` 
+
+The function can be called with an arbitrary number of arguments for the `value` parameter:  
+
+```go
+slice := []int{3, 2, 6, 4, 8}
+cards := PrependItems(slice, 5, 1) 
+fmt.Println(cards)  
+// Output: [5 1 3 2 6 4 8]
+```
+
+If no argument is given for the `value` parameter, then the result equals the
+original slice. 
+
+```go 
+slice := []int{3, 2, 6, 4, 8}
+cards := PrependItems(slice) 
+fmt.Println(cards)  
+// Output: [3 2 6 4 8]
+``` 
+ 

--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -4,40 +4,41 @@ As a magician-to-be, Elyse needs to practice some basics. She has a stack of car
 
 To make things a bit easier she only uses the cards 1 to 10.
 
-## 1. Create a slice with all the cards 
+## 1. Create a slice with certain cards
 
-Return a slice with all cards from 1 to 10 
+When practicing with her cards, Elyse likes to start with her favorite three cards of the deck: 2, 6 and 9.
+Write a function `FavoriteCards` that returns a slice with those cards in that order.
 
-```go 
-cards := AllItems()
-fmt.Println(cards) 
-// Output: [1 2 3 4 5 6 7 8 9 10]
-``` 
+```go
+cards := FavoriteCards()
+fmt.Println(cards)
+// Output: [2 6 9]
+```
 
 ## 2. Retrieve a card from a stack
 
 Return the card at position `index` from the given stack.
 
 ```go
-card := GetItem([]int{1, 2, 4, 1}, 2) // card == 4  
+card := GetItem([]int{1, 2, 4, 1}, 2) // card == 4
 ```
 
 If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to return `-1`:
 
 ```go
-card := GetItem([]int{1, 2, 4, 1}, 10) // card == -1  
+card := GetItem([]int{1, 2, 4, 1}, 10) // card == -1
 ```
 
 ## 3. Exchange a card in the stack
 
 Exchange the card at position `index` with the new card provided and return the adjusted stack.
-Note that this will modify the input slice which is the expected behavior. 
+Note that this will modify the input slice which is the expected behavior.
 
 ```go
 index := 2
 newCard := 6
-cards := SetItem([]int{1, 2, 4, 1}, index, newCard)  
-fmt.Println(cards) 
+cards := SetItem([]int{1, 2, 4, 1}, index, newCard)
+fmt.Println(cards)
 // Output: [1 2 6 1]
 ```
 
@@ -47,55 +48,45 @@ If the index is out of bounds (ie. if it is negative or after the end of the sta
 index := -1
 newCard := 6
 cards := SetItem([]int{1, 2, 4, 1}, index, newCard)
-fmt.Println(cards) 
+fmt.Println(cards)
 // Output: [1 2 4 1 6]
 ```
 
-## 4. Remove a card from the stack
+## 4. Add cards to the top of the stack
 
-Remove the card at position `index` from the stack and return the stack. Note
-that this may modify the input slice which is ok. 
-
-```go 
-cards := RemoveItem([]int{3, 2, 6, 4, 8}, 2)
-fmt.Println(cards) 
-// Output: [3 2 4 8]
-```
-
-If the index is out of bounds (ie. if it is negative or after the end of the
-stack), we want to leave the stack unchanged:
-
-```go
-cards := RemoveItem([]int{3, 2, 6, 4, 8}, 11)
-fmt.Println(cards) 
-// Output: [3 2 6 4 8]
-```
-
-## 5. PrependItems
-
-Add values at the front of a stack. Note that `PrependItems` is a variadic
-function, its type is: 
-
-```go 
-func PrependItems(slice []int, value ...int) []int
-``` 
-
-The function can be called with an arbitrary number of arguments for the `value` parameter:  
+Add the card(s) specified in the `value` parameter at the top of the stack.
 
 ```go
 slice := []int{3, 2, 6, 4, 8}
-cards := PrependItems(slice, 5, 1) 
-fmt.Println(cards)  
+cards := PrependItems(slice, 5, 1)
+fmt.Println(cards)
 // Output: [5 1 3 2 6 4 8]
 ```
 
-If no argument is given for the `value` parameter, then the result equals the
-original slice. 
+If no argument is given for the `value` parameter, then the result equals the original slice.
 
-```go 
+```go
 slice := []int{3, 2, 6, 4, 8}
-cards := PrependItems(slice) 
-fmt.Println(cards)  
+cards := PrependItems(slice)
+fmt.Println(cards)
 // Output: [3 2 6 4 8]
-``` 
- 
+```
+
+## 5. Remove a card from the stack
+
+Remove the card at position `index` from the stack and return the stack.
+Note that this may modify the input slice which is ok.
+
+```go
+cards := RemoveItem([]int{3, 2, 6, 4, 8}, 2)
+fmt.Println(cards)
+// Output: [3 2 4 8]
+```
+
+If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to leave the stack unchanged:
+
+```go
+cards := RemoveItem([]int{3, 2, 6, 4, 8}, 11)
+fmt.Println(cards)
+// Output: [3 2 6 4 8]
+```

--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -4,7 +4,7 @@ As a magician-to-be, Elyse needs to practice some basics. She has a stack of car
 
 To make things a bit easier she only uses the cards 1 to 10.
 
-## 1. FavoriteCards
+## 1. Create a slice with certain cards
 
 When practicing with her cards, Elyse likes to start with her favorite three cards of the deck: 2, 6 and 9.
 Write a function `FavoriteCards` that returns a slice with those cards in that order.

--- a/exercises/concept/card-tricks/.docs/introduction.md
+++ b/exercises/concept/card-tricks/.docs/introduction.md
@@ -28,27 +28,88 @@ If you don't specify an ending index, it defaults to the length of the slice.
 newSlice := withData[2:4] // newSlice == []int{2,3}
 ```
 
-## Multiple Return Values
+Go provides a built-in `append` function to append new elements to a slice: 
 
-Go functions and methods can return multiple values.
-Very often, a second return value is used to return an error.
-For example:
-
-```go
-func GetCard() (Card, error) { ... }
+```go 
+a := []int{1,3}
+b := append(a,4,2)  // b == []int{1,3,4,2}
 ```
 
-The assignment for multiple return values just uses a comma to separate the variables:
+Note that `append` is a variadic function, see details below. 
+
+## Variadic Functions 
+
+Usually, functions in Go accept only a fixed number of arguments.
+However, it is also possible to write variadic functions in Go.
+
+A variadic function is a function that accepts a variable number of arguments.
+
+If the type of the last parameter in a function definition is prefixed by ellipsis `...`, then the function can accept any number of arguments for that parameter.
 
 ```go
-card, err := GetCard()
-```
-
-If statements can use an initializer before the condition separated by a semicolon.
-This is a common idiom seen for error handling:
-
-```go
-if card, err := GetCard(); err != nil {
-    // handle the error
+func find(a int, b ...int) {
+    // ...
 }
+```
+
+In the above function, parameter `b` is variadic and we can pass 0 or more arguments to `b`.
+
+```go
+find(5, 6)
+find(5, 6, 7)
+find(5)
+```
+
+```exercism/caution
+The variadic parameter must be the last parameter of the function.
+```
+
+The way variadic functions work is by converting the variable number of arguments to a slice of the type of the variadic parameter.
+
+Here is an example of an implementation of a variadic function.
+
+```go
+func find(num int, nums ...int) {
+    fmt.Printf("type of nums is %T\n", nums)
+
+    for i, v := range nums {
+        if v == num {
+            fmt.Println(num, "found at index", i, "in", nums)
+            return
+        }
+    }
+
+    fmt.Println(num, "not found in ", nums)
+}
+
+func main() {
+    find(89, 90, 91, 95)
+    // Output:
+    // type of nums is []int
+    // 89 not found in  [90 91 95]
+
+    find(45, 56, 67, 45, 90, 109)
+    // Output:
+    // type of nums is []int
+    // 45 found at index 2 in [56 67 45 90 109]
+
+    find(87)
+    // Output:
+    // type of nums is []int
+    // 87 not found in  []
+}
+```
+
+In line `find(89, 90, 91, 95)` of the program above, the variable number of arguments to the find function are `90`, `91` and `95`.
+The `find` function expects a variadic int parameter after `num`.
+Hence these three arguments will be converted by the compiler to a slice of type `int` `[]int{90, 91, 95}` and then it will be passed to the find function as `nums`.
+
+Sometimes you already have a slice and want to pass that to a variadic function.
+This can be achieved by passing the slice followed by `...`.
+That will tell the compiler to use the slice as is inside the variadic function.
+The step described above where a slice is created will simply be omitted in this case.
+
+```go
+list := []int{1,2,3}
+find(1, list...) // "find" defined as shown above
 ```

--- a/exercises/concept/card-tricks/.docs/introduction.md
+++ b/exercises/concept/card-tricks/.docs/introduction.md
@@ -10,7 +10,7 @@ A slice is written like `[]T` with `T` being the type of the elements in the sli
 
 ```go
 var empty []int                 // an empty slice
-withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
+withData := []int{0, 1, 2, 3, 4, 5}  // a slice pre-filled with some data
 ```
 
 You can get/set an element at a given zero-based index using square-bracket notation:
@@ -28,16 +28,16 @@ If you don't specify an ending index, it defaults to the length of the slice.
 newSlice := withData[2:4] // newSlice == []int{2,3}
 ```
 
-Go provides a built-in `append` function to append new elements to a slice: 
+It is common to add new elements to the end of a slice, and so Go provides a built-in [`append`][append-yourbasic] function.
 
-```go 
-a := []int{1,3}
-b := append(a,4,2)  // b == []int{1,3,4,2}
+```go
+a := []int{1, 3}
+b := append(a, 4, 2) // b == []int{1,3,4,2}
 ```
 
-Note that `append` is a variadic function, see details below. 
+Note that `append` is a variadic function, see details below.
 
-## Variadic Functions 
+## Variadic Functions
 
 Usually, functions in Go accept only a fixed number of arguments.
 However, it is also possible to write variadic functions in Go.
@@ -110,6 +110,8 @@ That will tell the compiler to use the slice as is inside the variadic function.
 The step described above where a slice is created will simply be omitted in this case.
 
 ```go
-list := []int{1,2,3}
+list := []int{1, 2, 3}
 find(1, list...) // "find" defined as shown above
 ```
+
+[append-yourbasic]: https://yourbasic.org/golang/append-explained/

--- a/exercises/concept/card-tricks/.meta/config.json
+++ b/exercises/concept/card-tricks/.meta/config.json
@@ -3,6 +3,9 @@
   "authors": [
     "tehsphinx"
   ],
+  "contributors": [
+    "norbs57"
+  ],
   "files": {
     "solution": [
       "card_tricks.go"

--- a/exercises/concept/card-tricks/.meta/design.md
+++ b/exercises/concept/card-tricks/.meta/design.md
@@ -12,7 +12,7 @@ The goal of this exercise is to teach the student the basics on how to work with
 - read value
 - remove value
 - taking length
-- subslices
+- sub-slices
 - expanding slices (e.g. in `append(slice1, slice2...)`)
 
 ## Out of scope
@@ -23,10 +23,10 @@ The goal of this exercise is to teach the student the basics on how to work with
 ## Concepts
 
 - `slices`
+- `variadic-function`
 
 ## Prerequisites
-
-- `iteration`: fill a slice (Not yet available: `range iteration`)
+ 
 - `numbers`: integers (`int`) to represent cards
 - `conditionals-if`: mostly to check for existing indexes
 

--- a/exercises/concept/card-tricks/.meta/exemplar.go
+++ b/exercises/concept/card-tricks/.meta/exemplar.go
@@ -1,8 +1,8 @@
 package cards
 
-// AllItems returns a slice with the numbers 1..10 in ascending order
-func AllItems() []int {
-	return []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+// FavoriteCards returns a slice with the cards 2, 6 and 9 in that order.
+func FavoriteCards() []int {
+	return []int{2, 6, 9}
 }
 
 // GetItem retrieves an item from a slice at given position.
@@ -24,15 +24,15 @@ func SetItem(slice []int, index, value int) []int {
 	return slice
 }
 
+// PrependItems adds an arbitrary number of values at the front of a slice.
+func PrependItems(slice []int, value ...int) []int {
+	return append(value, slice...)
+}
+
 // RemoveItem removes an item from a slice by modifying the existing slice.
 func RemoveItem(slice []int, index int) []int {
 	if len(slice) <= index || index < 0 {
 		return slice
 	}
 	return append(slice[:index], slice[index+1:]...)
-}
-
-// PrependItems adds an arbitrary number of values at the front of a slice
-func PrependItems(slice []int, value ...int) []int {
-	return append(value, slice...)
 }

--- a/exercises/concept/card-tricks/.meta/exemplar.go
+++ b/exercises/concept/card-tricks/.meta/exemplar.go
@@ -1,12 +1,17 @@
 package cards
 
-// GetItem retrieves an item from a slice at given position. The second return value indicates whether
-// the given index exists in the slice or not.
-func GetItem(slice []int, index int) (int, bool) {
+// AllItems returns a slice with the numbers 1..10 in ascending order
+func AllItems() []int {
+	return []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+}
+
+// GetItem retrieves an item from a slice at given position.
+// If the index is out of a range we want it to return -1
+func GetItem(slice []int, index int) int {
 	if len(slice) <= index || index < 0 {
-		return 0, false
+		return -1
 	}
-	return slice[index], true
+	return slice[index]
 }
 
 // SetItem writes an item to a slice at given position overwriting an existing value.
@@ -19,23 +24,15 @@ func SetItem(slice []int, index, value int) []int {
 	return slice
 }
 
-// PrefilledSlice creates a slice of given length and prefills it with the given value.
-func PrefilledSlice(value, length int) []int {
-	if length < 1 {
-		return []int{}
-	}
-
-	var s = make([]int, 0, length)
-	for i := 0; i < length; i++ {
-		s = append(s, value)
-	}
-	return s
-}
-
 // RemoveItem removes an item from a slice by modifying the existing slice.
 func RemoveItem(slice []int, index int) []int {
 	if len(slice) <= index || index < 0 {
 		return slice
 	}
 	return append(slice[:index], slice[index+1:]...)
+}
+
+// PrependItems adds an arbitrary number of values at the front of a slice
+func PrependItems(slice []int, value ...int) []int {
+	return append(value, slice...)
 }

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -1,8 +1,8 @@
 package cards
 
-// AllItems returns a slice with the numbers 1..10 in ascending order.
-func AllItems() []int {
-	panic("Please implement the AllItems function")
+// FavoriteCards returns a slice with the cards 2, 6 and 9 in that order.
+func FavoriteCards() []int {
+	panic("Please implement the FavoriteCards function")
 }
 
 // GetItem retrieves an item from a slice at given position.
@@ -17,12 +17,12 @@ func SetItem(slice []int, index, value int) []int {
 	panic("Please implement the SetItem function")
 }
 
-// RemoveItem removes an item from a slice by modifying the existing slice.
-func RemoveItem(slice []int, index int) []int {
-	panic("Please implement the RemoveItem function")
-}
-
 // PrependItems adds an arbitrary number of values at the front of a slice.
 func PrependItems(slice []int, value ...int) []int {
 	panic("Please implement the PrependItems function")
+}
+
+// RemoveItem removes an item from a slice by modifying the existing slice.
+func RemoveItem(slice []int, index int) []int {
+	panic("Please implement the RemoveItem function")
 }

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -1,8 +1,13 @@
 package cards
 
-// GetItem retrieves an item from a slice at given position. The second return value indicates whether
-// the given index exists in the slice or not.
-func GetItem(slice []int, index int) (int, bool) {
+// AllItems returns a slice with the numbers 1..10 in ascending order.
+func AllItems() []int {
+	panic("Please implement the AllItems function")
+}
+
+// GetItem retrieves an item from a slice at given position.
+// If the index is out of range, we want it to return -1.
+func GetItem(slice []int, index int) int {
 	panic("Please implement the GetItem function")
 }
 
@@ -12,12 +17,12 @@ func SetItem(slice []int, index, value int) []int {
 	panic("Please implement the SetItem function")
 }
 
-// PrefilledSlice creates a slice of given length and prefills it with the given value.
-func PrefilledSlice(value, length int) []int {
-	panic("Please implement the PrefilledSlice function")
-}
-
 // RemoveItem removes an item from a slice by modifying the existing slice.
 func RemoveItem(slice []int, index int) []int {
 	panic("Please implement the RemoveItem function")
+}
+
+// PrependItems adds an arbitrary number of values at the front of a slice.
+func PrependItems(slice []int, value ...int) []int {
+	panic("Please implement the PrependItems function")
 }

--- a/exercises/concept/card-tricks/card_tricks_test.go
+++ b/exercises/concept/card-tricks/card_tricks_test.go
@@ -4,16 +4,23 @@ import (
 	"testing"
 )
 
+func TestAllItems(t *testing.T) {
+	got := AllItems()
+	want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	if !slicesEqual(got, want) {
+		t.Errorf("NewCards() got = %v, want %v", got, want)
+	}
+}
+
 func TestGetItem(t *testing.T) {
 	type args struct {
 		slice []int
 		index int
 	}
 	tests := []struct {
-		name   string
-		args   args
-		want   int
-		wantOk bool
+		name string
+		args args
+		want int
 	}{
 		{
 			name: "Retrieve item from slice by index",
@@ -21,8 +28,7 @@ func TestGetItem(t *testing.T) {
 				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 4,
 			},
-			want:   8,
-			wantOk: true,
+			want: 8,
 		},
 		{
 			name: "Get first item from slice",
@@ -30,8 +36,7 @@ func TestGetItem(t *testing.T) {
 				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 0,
 			},
-			want:   5,
-			wantOk: true,
+			want: 5,
 		},
 		{
 			name: "Get last item from slice",
@@ -39,8 +44,7 @@ func TestGetItem(t *testing.T) {
 				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 7,
 			},
-			want:   9,
-			wantOk: true,
+			want: 9,
 		},
 		{
 			name: "Index out of bounds",
@@ -48,8 +52,7 @@ func TestGetItem(t *testing.T) {
 				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: 8,
 			},
-			want:   0,
-			wantOk: false,
+			want: -1,
 		},
 		{
 			name: "Negative index",
@@ -57,18 +60,14 @@ func TestGetItem(t *testing.T) {
 				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
 				index: -1,
 			},
-			want:   0,
-			wantOk: false,
+			want: -1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotOk := GetItem(tt.args.slice, tt.args.index)
+			got := GetItem(tt.args.slice, tt.args.index)
 			if got != tt.want {
 				t.Errorf("GetItem(slice:%v, index:%v) got = %v, want %v", tt.args.slice, tt.args.index, got, tt.want)
-			}
-			if gotOk != tt.wantOk {
-				t.Errorf("GetItem(slice:%v, index:%v) gotOk = %v, want %v", tt.args.slice, tt.args.index, gotOk, tt.wantOk)
 			}
 		})
 	}
@@ -133,61 +132,19 @@ func TestSetItem(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SetItem(tt.args.slice, tt.args.index, tt.args.value); !slicesEqual(got, tt.want) {
+			got := SetItem(tt.args.slice, tt.args.index, tt.args.value)
+			if !slicesEqual(got, tt.want) {
 				t.Errorf("SetItem(slice:%v, index:%v, value:%v) = %v, want %v",
 					tt.args.slice, tt.args.index, tt.args.value, got, tt.want)
 			}
-		})
-	}
-}
-
-func TestPrefilledSlice(t *testing.T) {
-	type args struct {
-		value  int
-		length int
-	}
-	tests := []struct {
-		name string
-		args args
-		want []int
-	}{
-		{
-			name: "Create a prefilled slice with value 3",
-			args: args{
-				value:  3,
-				length: 7,
-			},
-			want: []int{3, 3, 3, 3, 3, 3, 3},
-		},
-		{
-			name: "Create a prefilled slice with value 10",
-			args: args{
-				value:  10,
-				length: 2,
-			},
-			want: []int{10, 10},
-		},
-		{
-			name: "Length zero",
-			args: args{
-				value:  3,
-				length: 0,
-			},
-			want: []int{},
-		},
-		{
-			name: "Negative length",
-			args: args{
-				value:  3,
-				length: -3,
-			},
-			want: []int{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := PrefilledSlice(tt.args.value, tt.args.length); !slicesEqual(got, tt.want) {
-				t.Errorf("PrefilledSlice(value:%v, length:%v) = %v, want %v", tt.args.value, tt.args.length, got, tt.want)
+			if len(tt.args.slice) == len(got) {
+				for i := range got {
+					got[i] = -1
+				}
+				if !slicesEqual(got, tt.args.slice) {
+					t.Errorf("SetItem(slice:%v, index:%v) does not return the modified input slice)", tt.args.slice,
+						tt.args.value)
+				}
 			}
 		})
 	}
@@ -248,6 +205,68 @@ func TestRemoveItem(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := RemoveItem(copySlice(tt.args.slice), tt.args.index); !slicesEqual(got, tt.want) {
 				t.Errorf("RemoveItem(slice:%v, index:%v) = %v, want %v", tt.args.slice, tt.args.index, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrependItems(t *testing.T) {
+	type args struct {
+		slice []int
+		value []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "prepend nil",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: nil,
+			},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "prepend zero items",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: []int{},
+			},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "Prepend one item",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: []int{1},
+			},
+			want: []int{1, 5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "Prepend two items",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: []int{0, 6},
+			},
+			want: []int{0, 6, 5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "Prepend slice to itself",
+			args: args{
+				slice: []int{5, 2, 10, 6},
+				value: []int{5, 2, 10, 6},
+			},
+			want: []int{5, 2, 10, 6, 5, 2, 10, 6},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PrependItems(tt.args.slice, tt.args.value...)
+			if !slicesEqual(got, tt.want) {
+				t.Errorf("PrependItems(slice:%v, value:%v) = %v, want %v",
+					tt.args.slice, tt.args.value, got, tt.want)
 			}
 		})
 	}

--- a/exercises/concept/card-tricks/card_tricks_test.go
+++ b/exercises/concept/card-tricks/card_tricks_test.go
@@ -1,12 +1,13 @@
 package cards
 
 import (
+	"reflect"
 	"testing"
 )
 
-func TestAllItems(t *testing.T) {
-	got := AllItems()
-	want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+func TestFavoriteCards(t *testing.T) {
+	got := FavoriteCards()
+	want := []int{2, 6, 9}
 	if !slicesEqual(got, want) {
 		t.Errorf("NewCards() got = %v, want %v", got, want)
 	}
@@ -141,10 +142,72 @@ func TestSetItem(t *testing.T) {
 				for i := range got {
 					got[i] = -1
 				}
-				if !slicesEqual(got, tt.args.slice) {
+				if reflect.ValueOf(got).Pointer() != reflect.ValueOf(tt.args.slice).Pointer() {
 					t.Errorf("SetItem(slice:%v, index:%v) does not return the modified input slice)", tt.args.slice,
 						tt.args.value)
 				}
+			}
+		})
+	}
+}
+
+func TestPrependItems(t *testing.T) {
+	type args struct {
+		slice []int
+		value []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "Prepend one item",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: []int{1},
+			},
+			want: []int{1, 5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "Prepend two items",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: []int{0, 6},
+			},
+			want: []int{0, 6, 5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "prepend nil",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: nil,
+			},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "prepend zero items",
+			args: args{
+				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
+				value: []int{},
+			},
+			want: []int{5, 2, 10, 6, 8, 7, 0, 9},
+		},
+		{
+			name: "Prepend slice to itself",
+			args: args{
+				slice: []int{5, 2, 10, 6},
+				value: []int{5, 2, 10, 6},
+			},
+			want: []int{5, 2, 10, 6, 5, 2, 10, 6},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PrependItems(tt.args.slice, tt.args.value...)
+			if !slicesEqual(got, tt.want) {
+				t.Errorf("PrependItems(slice:%v, value:%v) = %v, want %v",
+					tt.args.slice, tt.args.value, got, tt.want)
 			}
 		})
 	}
@@ -205,68 +268,6 @@ func TestRemoveItem(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := RemoveItem(copySlice(tt.args.slice), tt.args.index); !slicesEqual(got, tt.want) {
 				t.Errorf("RemoveItem(slice:%v, index:%v) = %v, want %v", tt.args.slice, tt.args.index, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestPrependItems(t *testing.T) {
-	type args struct {
-		slice []int
-		value []int
-	}
-	tests := []struct {
-		name string
-		args args
-		want []int
-	}{
-		{
-			name: "prepend nil",
-			args: args{
-				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
-				value: nil,
-			},
-			want: []int{5, 2, 10, 6, 8, 7, 0, 9},
-		},
-		{
-			name: "prepend zero items",
-			args: args{
-				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
-				value: []int{},
-			},
-			want: []int{5, 2, 10, 6, 8, 7, 0, 9},
-		},
-		{
-			name: "Prepend one item",
-			args: args{
-				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
-				value: []int{1},
-			},
-			want: []int{1, 5, 2, 10, 6, 8, 7, 0, 9},
-		},
-		{
-			name: "Prepend two items",
-			args: args{
-				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
-				value: []int{0, 6},
-			},
-			want: []int{0, 6, 5, 2, 10, 6, 8, 7, 0, 9},
-		},
-		{
-			name: "Prepend slice to itself",
-			args: args{
-				slice: []int{5, 2, 10, 6},
-				value: []int{5, 2, 10, 6},
-			},
-			want: []int{5, 2, 10, 6, 5, 2, 10, 6},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := PrependItems(tt.args.slice, tt.args.value...)
-			if !slicesEqual(got, tt.want) {
-				t.Errorf("PrependItems(slice:%v, value:%v) = %v, want %v",
-					tt.args.slice, tt.args.value, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adapted card tricks to  current concept tree progression 
Fixes #1990

* Removed the task about `PrefilledSlice` from all the relevant exercise files
* Added function `FavoriteCards` which returns a new slice filled with numbers 2,5,9. Added to docs and added a test.
* Changed `GetItem` to have only one return value. Updated tests accordingly.
* Added code in `TestSetItem` which checks that `SetItem(slice,index)` modifies the
  existing slice as long as `index` is within slice bounds.
* Added a variadic function `PrependItems`.  Added to docs and added a test.
* Added the content of `concepts/variadic-functions/introductions.md` to the introduction.
* Added more info about the inbuilt `append` function to hints and instructions.
* Updated the root level `config.json` in line with #1990 recommendations