### PR TITLE
Add missing test case for Blackjack (#2136)

### DIFF
--- a/exercises/concept/blackjack/blackjack_test.go
+++ b/exercises/concept/blackjack/blackjack_test.go
@@ -73,6 +73,11 @@ func TestParseCard(t *testing.T) {
 			card: "king",
 			want: 10,
 		},
+		{
+			name: "parse invalid",
+			card: "joker",
+			want: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/exercises/concept/blackjack/blackjack_test.go
+++ b/exercises/concept/blackjack/blackjack_test.go
@@ -74,7 +74,7 @@ func TestParseCard(t *testing.T) {
 			want: 10,
 		},
 		{
-			name: "parse invalid",
+			name: "parse other",
 			card: "joker",
 			want: 0,
 		},


### PR DESCRIPTION
Added default test case to TestParseCard. 
name: "parse invalid", card: "joker", want: 0

Related to Issue2137: https://github.com/exercism/go/issues/2137