### PR TITLE
Added test case to ensure fives is implemented

### DIFF
--- a/exercises/practice/yacht/.meta/tests.toml
+++ b/exercises/practice/yacht/.meta/tests.toml
@@ -29,6 +29,9 @@ description = "Yacht counted as threes"
 [464fc809-96ed-46e4-acb8-d44e302e9726]
 description = "Yacht of 3s counted as fives"
 
+[d054227f-3a71-4565-a684-5c7e621ec1e9]
+description = "Fives"
+
 [e8a036e0-9d21-443a-8b5f-e15a9e19a761]
 description = "Sixes"
 

--- a/exercises/practice/yacht/cases_test.go
+++ b/exercises/practice/yacht/cases_test.go
@@ -1,8 +1,7 @@
 package yacht
 
 // Source: exercism/problem-specifications
-// Commit: 69f0783 yacht: Add "No pairs but not a big straight" test case (#1508)
-// Problem Specifications Version: 1.2.0
+// Commit: 4758bf7 yacht: add test to ensure fives are handled (#1993)
 
 var testCases = []struct {
 	description string
@@ -63,6 +62,12 @@ var testCases = []struct {
 		dice:        []int{3, 3, 3, 3, 3},
 		category:    "fives",
 		expected:    0,
+	},
+	{
+		description: "Fives",
+		dice:        []int{1, 5, 3, 5, 3},
+		category:    "fives",
+		expected:    10,
 	},
 	{
 		description: "Sixes",


### PR DESCRIPTION
The test cases prior to this change do not require the "fives" category to be implemented. This test case ensures it is implemented.