### PR TITLE
Tree-building exercise: added custom nodeEqual method, added type def

### DIFF
--- a/exercises/practice/tree-building/tree_building.go
+++ b/exercises/practice/tree-building/tree_building.go
@@ -1,9 +1,17 @@
 package tree
 
-// Define the Record type
+type Record struct {
+	ID     int
+	Parent int
+	// feel free to add fields as you see fit
+}
 
-// Define the Node type
+type Node struct {
+	ID       int
+	Children []*Node
+	// feel free to add fields as you see fit
+}
 
 func Build(records []Record) (*Node, error) {
-  panic("Please implement the Build function")
+	panic("Please implement the Build function")
 }

--- a/exercises/practice/tree-building/tree_building_test.go
+++ b/exercises/practice/tree-building/tree_building_test.go
@@ -3,7 +3,6 @@ package tree
 import (
 	"fmt"
 	"math/rand"
-	"reflect"
 	"testing"
 )
 
@@ -254,7 +253,7 @@ func TestMakeTreeSuccess(t *testing.T) {
 				t.Fatalf("Build for test case %q returned error %q. Error not expected.",
 					tt.name, err)
 			}
-			if !reflect.DeepEqual(actual, tt.expected) {
+			if !nodeEqual(actual, tt.expected) {
 				t.Fatalf("Build for test case %q returned %s but was expected to return %s.",
 					tt.name, actual, tt.expected)
 			}
@@ -348,4 +347,32 @@ func BenchmarkShallowTree(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Build(shallowRecords)
 	}
+}
+
+func nodeEqual(node1, node2 *Node) bool {
+	switch {
+	case node1 == nil && node2 == nil:
+		return true
+	case node1 == nil && node2 != nil:
+		return false
+	case node1 != nil && node2 == nil:
+		return false
+	default:
+		return node1.ID == node2.ID && nodeSliceEqual(node1.Children, node2.Children)
+	}
+}
+
+func nodeSliceEqual(nodes1, nodes2 []*Node) bool {
+	if len(nodes1) == 0 && len(nodes2) == 0 {
+		return true
+	}
+	if len(nodes1) != len(nodes2) {
+		return false
+	}
+	for i := range nodes1 {
+		if !nodeEqual(nodes1[i], nodes2[i]) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Fixes issue #2142 "Tree building exercise test results unclear"
* Added declaration of types `Node` and `Record` in `tree_building.go`
* Defined a `nodeEqual` method and used this for node-equality comparisons in tests