### PR TITLE
Vehicle purchase exercise - removed UTF-16 ref, renamed ordering

### DIFF
--- a/exercises/concept/vehicle-purchase/.docs/hints.md
+++ b/exercises/concept/vehicle-purchase/.docs/hints.md
@@ -8,7 +8,7 @@
 
 ## 2. Choose between two potential vehicles to buy
 
-- Use a [comparison operator][comparison-operators] to determine which option comes first in dictionary order.
+- Use a [comparison operator][comparison-operators] to determine which option comes first in lexicographical order.
 - Then set the value of a helper variable depending of the outcome of that comparison with the help of an an [if-else statement][if-statement].
 - Finally construct the recommendation sentence. For that you can use the `+` operator to concatenate the two strings.
 

--- a/exercises/concept/vehicle-purchase/.docs/instructions.md
+++ b/exercises/concept/vehicle-purchase/.docs/instructions.md
@@ -23,7 +23,7 @@ needLicense = NeedsLicense("bike")
 
 You evaluate your options of available vehicles.
 You manage to narrow it down to two options but you need help making the final decision.
-For that, implement the function `ChooseVehicle(option1, option2)` that takes two vehicles as arguments and returns a decision that includes the option that comes first in dictionary order.
+For that, implement the function `ChooseVehicle(option1, option2)` that takes two vehicles as arguments and returns a decision that includes the option that comes first in lexicographical order.
 
 ```go
 vehicle := ChooseVehicle("Wuling Hongguang", "Toyota Corolla")

--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -23,8 +23,8 @@ a > 5  // false
 ```
 
 The comparison operators above can also be used to compare strings.
-In that case a dictionary (lexicographical) order is applied.
-You can find a list of the exact order of all the characters [here][utf-16-list].
+In that case a lexicographical (dictionary) order is applied.
+For example:
 
 ```Go
 	"apple" < "banana"  // true
@@ -75,6 +75,5 @@ if v := 2 * num; v > 10 {
 // Output: 14
 ```
 
-> Note: any variables created in the initialization statement go out of scope after the end of the if statement.
+> Note: any variables created in the initialization statement go out of scope after the end of the if statement. 
 
-[utf-16-list]: https://www.fileformat.info/info/charset/UTF-16/list.htm

--- a/exercises/concept/vehicle-purchase/.meta/exemplar.go
+++ b/exercises/concept/vehicle-purchase/.meta/exemplar.go
@@ -5,7 +5,7 @@ func NeedsLicense(kind string) bool {
 	return kind == "car" || kind == "truck"
 }
 
-// ChooseVehicle recommends a vehicle for selection. It always recommends the vehicle that comes first in dictionary order.
+// ChooseVehicle recommends a vehicle for selection. It always recommends the vehicle that comes first in lexicographical order.
 func ChooseVehicle(option1, option2 string) string {
 	var choice string
 	if option1 < option2 {

--- a/exercises/concept/vehicle-purchase/vehicle_purchase.go
+++ b/exercises/concept/vehicle-purchase/vehicle_purchase.go
@@ -5,7 +5,7 @@ func NeedsLicense(kind string) bool {
 	panic("NeedsLicense not implemented")
 }
 
-// ChooseVehicle recommends a vehicle for selection. It always recommends the vehicle that comes first in dictionary order.
+// ChooseVehicle recommends a vehicle for selection. It always recommends the vehicle that comes first in lexicographical order.
 func ChooseVehicle(option1, option2 string) string {
 	panic("ChooseVehicle not implemented")
 }


### PR DESCRIPTION
Fixes #2147
Removed spurious link to UTF-16
Renamed "dictionary order" to "lexicographical order" in several places