### PR TITLE
Typo: e.g.

### DIFF
--- a/concepts/arithmetic-operators/about.md
+++ b/concepts/arithmetic-operators/about.md
@@ -12,7 +12,7 @@ Go supports many standard arithmetic operators:
 | `/`      | `13 / 3 == 4`  |
 | `%`      | `13 % 3 == 1`  |
 
-For integer division, the remainder is dropped (eg. `5 / 2 == 2`).
+For integer division, the remainder is dropped (e.g. `5 / 2 == 2`).
 
 ## Arithmetic operations on different types
 

--- a/concepts/arithmetic-operators/introduction.md
+++ b/concepts/arithmetic-operators/introduction.md
@@ -12,7 +12,7 @@ Go supports many standard arithmetic operators:
 | `/`      | `13 / 3 == 4`  |
 | `%`      | `13 % 3 == 1`  |
 
-For integer division, the remainder is dropped (eg. `5 / 2 == 2`).
+For integer division, the remainder is dropped (e.g. `5 / 2 == 2`).
 
 ## Arithmetic operations on different types
 

--- a/exercises/concept/cars-assemble/.docs/introduction.md
+++ b/exercises/concept/cars-assemble/.docs/introduction.md
@@ -29,7 +29,7 @@ Go supports many standard arithmetic operators:
 | `/`      | `13 / 3 == 4`  |
 | `%`      | `13 % 3 == 1`  |
 
-For integer division, the remainder is dropped (eg. `5 / 2 == 2`).
+For integer division, the remainder is dropped (e.g. `5 / 2 == 2`).
 
 Go has shorthand assignment for the operators above (e.g. `a += 5` is short for `a = a + 5`).
 Go also supports the increment and decrement statements `++` and `--` (e.g. `a++`).

--- a/exercises/concept/election-day/.docs/hints.md
+++ b/exercises/concept/election-day/.docs/hints.md
@@ -4,7 +4,7 @@
 
 - `*T` can be used to declared variables that are pointers to some type `T`, e.g `var i *int` declares a variable `i` that is a pointer to an `int`
 - You can get a pointer for a variable (its memory address) by using the `&` operator, e.g `mypointer := &anIntVariable`.
-- You can get the value stored in a pointer by using the `*` operator on a pointer, eg. `var i int = *aPointerToInt`. This is called dereferencing the pointer.
+- You can get the value stored in a pointer by using the `*` operator on a pointer, e.g. `var i int = *aPointerToInt`. This is called dereferencing the pointer.
 - You check if a pointer is not `nil` before dereferencing it. Attempting to dereference a `nil` pointer will give you a runtime error.
 - If you are unsure how pointers work, try reading [Tour of Go: Pointers][go-tour-pointers] or [Go by Example: Pointers][go-by-example-pointers]
 

--- a/exercises/concept/party-robot/.docs/instructions.md
+++ b/exercises/concept/party-robot/.docs/instructions.md
@@ -39,7 +39,7 @@ It should accept 5 parameters.
 The exact result format can be seen in the example below.
 
 The robot provides the table number in a 3 digits format.
-If the number is less than 3 digits it gets extra leading zeroes to become 3 digits (eg. 3 becomes 003).
+If the number is less than 3 digits it gets extra leading zeroes to become 3 digits (e.g. 3 becomes 003).
 The robot also mentions the distance of the table.
 Fortunately only with a precision that's limited to 1 digit.
 

--- a/exercises/concept/sorting-room/.docs/hints.md
+++ b/exercises/concept/sorting-room/.docs/hints.md
@@ -23,5 +23,5 @@
 
 ## 5. Implement `DescribeAnything` which uses them all
 
-- either use type assertions (eg. `i.(someType)`) or a type switch (`switch v := i.(type)`)
+- either use type assertions (e.g. `i.(someType)`) or a type switch (`switch v := i.(type)`)
 - remember to convert `int` to a `float64`


### PR DESCRIPTION
Add a "." to "e.g." to make it consistent with the other uses.