### PR TITLE
Animal Magic: Set Icon

### DIFF
--- a/exercises/concept/animal-magic/.meta/config.json
+++ b/exercises/concept/animal-magic/.meta/config.json
@@ -6,5 +6,6 @@
     "solution": ["animal_magic.go"],
     "test": ["animal_magic_test.go"],
     "exemplar": [".meta/exemplar.go"]
-  }
+  },
+  "icon": "roll-the-die"
 }


### PR DESCRIPTION
"Animal Magic" was kind of forked from "Roll the die" but the name was changed. Therefore the icon is not selected automatically. This PR sets the icon explicitly.