### PR TITLE
Car assembly: Escape $ in instructions.md

### DIFF
--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -31,8 +31,8 @@ rate := CalculateWorkingCarsPerMinute(1105, 90)
 
 ## 3. Calculate the cost of production 
 
-Each car normally costs $10,000 to produce individually, regardless of whether it is successful or not.
-But with a bit of planning, 10 cars can be produced together for $95,000.
+Each car normally costs \$10,000 to produce individually, regardless of whether it is successful or not.
+But with a bit of planning, 10 cars can be produced together for \$95,000.
 
 For example, 37 cars can be produced in the following way:
 37 = 3 x groups of ten + 7 individual cars


### PR DESCRIPTION
In markdown with math mode enabled the dollar sign enables this mode and results in italic text with a different font that is hard to read. Escaping with \ fixes this.

With math mode disabled this should not make a difference.