### PR TITLE
Fix error in TestRemainingOvenTime, fix typos

### DIFF
--- a/exercises/concept/lasagna/lasagna_test.go
+++ b/exercises/concept/lasagna/lasagna_test.go
@@ -31,7 +31,7 @@ func TestRemainingOvenTime(t *testing.T) {
 			name:     "Remaining minutes in oven",
 			layers:   0,
 			time:     15,
-			expected: 15,
+			expected: 25,
 		},
 	}
 	for _, tt := range tests {

--- a/exercises/concept/lasagna/lasagna_test.go
+++ b/exercises/concept/lasagna/lasagna_test.go
@@ -52,7 +52,7 @@ func TestPreparationTime(t *testing.T) {
 			expected: 2,
 		},
 		{
-			name:     "Preparation time in minutes for multiple layer",
+			name:     "Preparation time in minutes for multiple layers",
 			layers:   4,
 			time:     0,
 			expected: 8,
@@ -77,7 +77,7 @@ func TestElapsedTime(t *testing.T) {
 			expected: 32,
 		},
 		{
-			name:     "Total time in minutes for multiple layer",
+			name:     "Total time in minutes for multiple layers",
 			layers:   4,
 			time:     8,
 			expected: 16,

--- a/exercises/concept/lasagna/lasagna_test.go
+++ b/exercises/concept/lasagna/lasagna_test.go
@@ -36,8 +36,8 @@ func TestRemainingOvenTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RemainingOvenTime(25); got != tt.time {
-				t.Errorf("RemainingOvenTime(%d) = %d; want %d", tt.expected, got, tt.expected)
+			if got := RemainingOvenTime(tt.time); got != tt.expected {
+				t.Errorf("RemainingOvenTime(%d) = %d; want %d", tt.time, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
There was an error where `tt.expected` was being sent in as the `actualTimeInOven`, where it should have been `tt.time`

I also fixed a couple of typos in the test names.