### PR TITLE
Issue #2090: linked list add note for Node struct field Value

### DIFF
--- a/exercises/practice/linked-list/.meta/example.go
+++ b/exercises/practice/linked-list/.meta/example.go
@@ -6,17 +6,17 @@ import (
 
 // Node is a node in a linked list.
 type Node struct {
-	Val  interface{}
-	next *Node
-	prev *Node
+	Value interface{}
+	next  *Node
+	prev  *Node
 }
 
 // NewNode constructs a new Node with the given value & no next/prev links.
 func NewNode(v interface{}) *Node {
 	return &Node{
-		Val:  v,
-		next: nil,
-		prev: nil,
+		Value: v,
+		next:  nil,
+		prev:  nil,
 	}
 }
 
@@ -156,13 +156,13 @@ func (ll *List) PopFront() (interface{}, error) {
 	case ll.head == nil && ll.tail == nil: // empty list
 		return nil, ErrEmptyList
 	case ll.head != nil && ll.tail != nil && ll.head.next == nil: // 1 element
-		v := ll.head.Val
+		v := ll.head.Value
 		ll.head = nil
 		ll.tail = nil
 
 		return v, nil
 	case ll.head != nil && ll.tail != nil && ll.head.next != nil: // >1 element
-		v := ll.head.Val
+		v := ll.head.Value
 		ll.head.next.prev = nil
 		ll.head = ll.head.next
 
@@ -178,13 +178,13 @@ func (ll *List) PopBack() (interface{}, error) {
 	case ll.head == nil && ll.tail == nil: // empty list
 		return nil, ErrEmptyList
 	case ll.head != nil && ll.tail != nil && ll.tail.prev == nil: // 1 element
-		v := ll.tail.Val
+		v := ll.tail.Value
 		ll.head = nil
 		ll.tail = nil
 
 		return v, nil
 	case ll.head != nil && ll.tail != nil && ll.tail.prev != nil: // >1 element
-		v := ll.tail.Val
+		v := ll.tail.Value
 		ll.tail.prev.next = nil
 		ll.tail = ll.tail.prev
 

--- a/exercises/practice/linked-list/linked_list.go
+++ b/exercises/practice/linked-list/linked_list.go
@@ -1,6 +1,7 @@
 package linkedlist
 
 // Define List and Node types here.
+// Note: The tests expect Node type to include an exported field with name Value to pass.
 
 func NewList(args ...interface{}) *List {
 	panic("Please implement the NewList function")

--- a/exercises/practice/linked-list/linked_list_test.go
+++ b/exercises/practice/linked-list/linked_list_test.go
@@ -45,8 +45,8 @@ func checkDoublyLinkedList(t *testing.T, ll *List, expected []interface{}) {
 	// check that length and elements are correct (scan once from begin -> end)
 	elem, count, idx := ll.First(), 0, 0
 	for ; elem != nil && idx < len(expected); elem, count, idx = elem.Next(), count+1, idx+1 {
-		if elem.Val != expected[idx] {
-			t.Errorf("wrong value from %d-th element, expected= %v, got= %v", idx, expected[idx], elem.Val)
+		if elem.Value != expected[idx] {
+			t.Errorf("wrong value from %d-th element, expected= %v, got= %v", idx, expected[idx], elem.Value)
 		}
 	}
 	if !(elem == nil && idx == len(expected)) {
@@ -98,7 +98,7 @@ func checkDoublyLinkedList(t *testing.T, ll *List, expected []interface{}) {
 	}
 }
 
-// debugString prints the linked list with both node's Val, next & prev pointers.
+// debugString prints the linked list with both node's Value, next & prev pointers.
 func (ll *List) debugString() string {
 	buf := bytes.NewBuffer([]byte{'{'})
 	buf.WriteString(fmt.Sprintf("First()= %p; ", ll.First()))
@@ -110,7 +110,7 @@ func (ll *List) debugString() string {
 		if counter > 100 {
 			panic("Possible infinite loop detected and stopped. Check the .Next() implementation")
 		}
-		buf.WriteString(fmt.Sprintf("[Prev()= %p, Val= %p (%v), Next()= %p] <-> ", cur.Prev(), cur, cur.Val, cur.Next()))
+		buf.WriteString(fmt.Sprintf("[Prev()= %p, Value= %p (%v), Next()= %p] <-> ", cur.Prev(), cur, cur.Value, cur.Next()))
 	}
 
 	buf.WriteString(fmt.Sprintf("; Last()= %p; ", ll.Last()))


### PR DESCRIPTION
## Motivation

Fixes #2090.

Per discussion in #2090, this PR provides a note as a hint for students to add a `Value` field to `Node`. This PR also changes the tests that access the `Val` field to favor `Value` field per track maintainer's judgement call.