### PR TITLE
#2155: Clarify when an exercise is tested with the `-race` flag

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -7,6 +7,15 @@ $ cd exercism/project/directory/go/leap
 $ go test
 ```
 
+# Tests with Data Race Detector
+
+In addition to running `go test`, some exercises should be run with a flag for [data race detector](https://go.dev/doc/articles/race_detector) so as to check that your solution does not introduce data race bugs. You will find a reminder to run tests with the data race detector flag `-race` in the relevant exercises. Run `go test -race` to check for data race.
+
+```bash
+$ cd exercism/project/directory/go/bank-account
+$ go test -race
+```
+
 ## Running benchmarks
 
 Most exercises contain benchmarks, that you can use to determine how changes to your solution affect its performance. To run the benchmarks for an exercise use the command `go test -v --bench . --benchmem` inside the exercise directory.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -9,7 +9,7 @@ $ go test
 
 # Tests with Data Race Detector
 
-In addition to running `go test`, some exercises should be run with a flag for [data race detector](https://go.dev/doc/articles/race_detector) so as to check that your solution does not introduce data race bugs. You will find a reminder to run tests with the data race detector flag `-race` in the relevant exercises. Run `go test -race` to check for data race.
+In addition to running `go test`, some exercises should be run with a flag for [data race detector](https://go.dev/doc/articles/race_detector) to check that your solution does not introduce data race bugs. You will find a reminder to run tests with the data race detector flag `-race` in the relevant exercises. Run `go test -race` to check for data race. For example:
 
 ```bash
 $ cd exercism/project/directory/go/bank-account

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -14,6 +14,14 @@ For example: multiple goroutines may be depositing and withdrawing money
 simultaneously, two withdrawals occurring concurrently should not be able
 to bring the balance into the negative.
 
+To test that your code handles concurrency properly and does not introduce
+data races, run tests with `-race` flag on.
+
+```bash
+$ cd exercism/project/directory/go/bank-account
+$ go test -race
+```
+
 If you are new to concurrent operations in Go it will be worth looking
 at the sync package, specifically Mutexes:
 

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -14,7 +14,7 @@ For example: multiple goroutines may be depositing and withdrawing money
 simultaneously, two withdrawals occurring concurrently should not be able
 to bring the balance into the negative.
 
-To test that your code handles concurrency properly and does not introduce
+When working locally, you can test that your code handles concurrency properly and does not introduce
 data races, run tests with `-race` flag on.
 
 ```bash


### PR DESCRIPTION
## Motivation

Fixes #2155.

## Note
Workflow job for Windows failed due to timeout. Cannot re-run jobs so maybe a maintainer could help out? 🙏 