### PR TITLE
Fixes #2105: Need for Speed - Clarify instruction text on distance & battery condition

### DIFF
--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -54,7 +54,9 @@ car = Drive(car)
 
 ## 4. Check if a remote controlled car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `CanFinish` function that takes a `Car` and a `Track` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`. Assume the car is just starting the race:
+To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `CanFinish` function that takes a `Car` and a `Track` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`.
+
+Assume that you start the engine of the car for the race but take into account that the car might have some mileage already (`distance >= 0`) and its battery might not necessarily be fully charged (`battery <= 100`):
 
 ```go
 speed := 5


### PR DESCRIPTION
## Motivation

Fixes #2105. Added some explanation for the instruction to ensure some students would take into account that the `distance` and `battery` in the test cases might not be pristine.