### PR TITLE
Tree Building: Tests accept tree in any order

### DIFF
--- a/exercises/practice/tree-building/tree_building_test.go
+++ b/exercises/practice/tree-building/tree_building_test.go
@@ -3,6 +3,7 @@ package tree
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 )
 
@@ -362,6 +363,12 @@ func nodeEqual(node1, node2 *Node) bool {
 	}
 }
 
+func SortNodesByID(nodes []*Node) {
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].ID < nodes[j].ID
+	})
+}
+
 func nodeSliceEqual(nodes1, nodes2 []*Node) bool {
 	if len(nodes1) == 0 && len(nodes2) == 0 {
 		return true
@@ -369,6 +376,10 @@ func nodeSliceEqual(nodes1, nodes2 []*Node) bool {
 	if len(nodes1) != len(nodes2) {
 		return false
 	}
+
+	SortNodesByID(nodes1)
+	SortNodesByID(nodes2)
+
 	for i := range nodes1 {
 		if !nodeEqual(nodes1[i], nodes2[i]) {
 			return false


### PR DESCRIPTION
Currently the tests assume an order of a node's children, however the description does not specify anything about the order.

Example:
Build for test case "three nodes in order" returned 0:[2:[] 1:[]] but was expected to return 0:[1:[] 2:[]].

I added an additional step in the test-code where the expected nodes and the actual nodes are sorted by their ID before comparing them and now the above example is accepted. I think that the order shouldn't matter in a tree, if anyone thinks otherwise I'm happy to extend the description instead.