### PR TITLE
Fix typo in slices and maps paragraph

### DIFF
--- a/concepts/pointers/about.md
+++ b/concepts/pointers/about.md
@@ -130,7 +130,7 @@ fmt.Println(p.Name) // Output: "Peter"
 
 ## Slices and maps are already pointers
 
-Slices and maps are special types because they already have pointers in their implementation. This means that more often that not, we don't need to create pointers for these types to share the memory address for their values. Imagine we have a function that increments the value of a key in a map:
+Slices and maps are special types because they already have pointers in their implementation. This means that more often than not, we don't need to create pointers for these types to share the memory address for their values. Imagine we have a function that increments the value of a key in a map:
 
 
 ```go

--- a/concepts/pointers/introduction.md
+++ b/concepts/pointers/introduction.md
@@ -1,11 +1,11 @@
 # Introduction
 
-Like many other languages, Go has pointers. 
+Like many other languages, Go has pointers.
 If you're new to pointers, they can feel a little mysterious but once you get used to them, they're quite straight-forward.
 They're a crucial part of Go, so take some time to really understand them.
 
 Before digging into the details, it's worth understanding the use of pointers. Pointers are a way to share memory with other parts of our program, which is useful for two major reasons:
-1. When we have large amounts of data, making copies to pass between functions is very inefficient. 
+1. When we have large amounts of data, making copies to pass between functions is very inefficient.
   By passing the memory location of where the data is stored instead, we can dramatically reduce the resource-footprint of our programs.
 2. By passing pointers between functions, we can access and modify the single copy of the data directly, meaning that any changes made by one function are immediately visible to other parts of the program when the function ends.
 
@@ -31,7 +31,7 @@ The piece of memory that is associated with `a` will now be storing the value `3
 
 ## Pointers
 
-While variables allow us to refer to values in memory, sometimes it's useful to know the **memory address** to which the variable is pointing. **Pointers** hold the memory addresses of those values. You declare a variable with a pointer type by prefixing the underlying type with an asterisk: 
+While variables allow us to refer to values in memory, sometimes it's useful to know the **memory address** to which the variable is pointing. **Pointers** hold the memory addresses of those values. You declare a variable with a pointer type by prefixing the underlying type with an asterisk:
 
 ```go
 var p *int // 'p' contains the memory address of an integer
@@ -41,7 +41,7 @@ Here we declare a variable `p` of type "pointer to int" (`*int`). This means tha
 
 ### Getting a pointer to a variable
 
-To find the memory address of the value of a variable, we can use the `&` operator. 
+To find the memory address of the value of a variable, we can use the `&` operator.
 For example, if we want to find and store the memory address of variable `a` in the pointer `p`, we can do the following:
 
 ```go
@@ -57,10 +57,10 @@ p = &a // the variable 'p' contains the memory address of 'a'
 When we have a pointer, we might want to know the value stored in the memory address the pointer represents. We can do this using the `*` operator:
 
 ```go
-var a int 
+var a int
 a = 2
 
-var p *int 
+var p *int
 p = &a // the variable 'p' contains the memory address of 'a'
 
 var b int
@@ -76,14 +76,14 @@ var a int        // declare int variable 'a'
 a = 2            // assign 'a' the value of 2
 
 var pa *int
-pa = &a          // 'pa' now contains to the memory address of 'a'  
+pa = &a          // 'pa' now contains to the memory address of 'a'
 *pa = *pa + 2    // increment by 2 the value at memory address 'pa'
 
 fmt.Println(a)   // Output: 4
                  // 'a' will have the new value that was changed via the pointer!
 ```
 
-Assigning to `*pa` will change the value stored at the memory address `pa` holds. Since `pa` holds the memory address of `a`, by assigning to `*pa` we are effectively changing the value of `a`! 
+Assigning to `*pa` will change the value stored at the memory address `pa` holds. Since `pa` holds the memory address of `a`, by assigning to `*pa` we are effectively changing the value of `a`!
 
 A note of caution however: always check if a pointer is not `nil` before dereferencing. Dereferencing a `nil` pointer will make the program crash at runtime!
 
@@ -123,14 +123,14 @@ When we have a pointer to a struct, we don't need to dereference the pointer bef
 var p *Person
 p = &Person{Name: "Peter", Age: 22}
 
-fmt.Println(p.Name) // Output: "Peter" 
+fmt.Println(p.Name) // Output: "Peter"
                     // Go automatically dereferences 'p' to allow
                     // access to the 'Name' field
 ```
 
 ## Slices and maps are already pointers
 
-Slices and maps are special types because they already have pointers in their implementation. This means that more often that not, we don't need to create pointers for these types to share the memory address for their values. Imagine we have a function that increments the value of a key in a map:
+Slices and maps are special types because they already have pointers in their implementation. This means that more often than not, we don't need to create pointers for these types to share the memory address for their values. Imagine we have a function that increments the value of a key in a map:
 
 
 ```go

--- a/exercises/concept/election-day/.docs/introduction.md
+++ b/exercises/concept/election-day/.docs/introduction.md
@@ -1,11 +1,11 @@
 # Introduction
 
-Like many other languages, Go has pointers. 
+Like many other languages, Go has pointers.
 If you're new to pointers, they can feel a little mysterious but once you get used to them, they're quite straight-forward.
 They're a crucial part of Go, so take some time to really understand them.
 
 Before digging into the details, it's worth understanding the use of pointers. Pointers are a way to share memory with other parts of our program, which is useful for two major reasons:
-1. When we have large amounts of data, making copies to pass between functions is very inefficient. 
+1. When we have large amounts of data, making copies to pass between functions is very inefficient.
   By passing the memory location of where the data is stored instead, we can dramatically reduce the resource-footprint of our programs.
 2. By passing pointers between functions, we can access and modify the single copy of the data directly, meaning that any changes made by one function are immediately visible to other parts of the program when the function ends.
 
@@ -31,7 +31,7 @@ The piece of memory that is associated with `a` will now be storing the value `3
 
 ## Pointers
 
-While variables allow us to refer to values in memory, sometimes it's useful to know the **memory address** to which the variable is pointing. **Pointers** hold the memory addresses of those values. You declare a variable with a pointer type by prefixing the underlying type with an asterisk: 
+While variables allow us to refer to values in memory, sometimes it's useful to know the **memory address** to which the variable is pointing. **Pointers** hold the memory addresses of those values. You declare a variable with a pointer type by prefixing the underlying type with an asterisk:
 
 ```go
 var p *int // 'p' contains the memory address of an integer
@@ -41,7 +41,7 @@ Here we declare a variable `p` of type "pointer to int" (`*int`). This means tha
 
 ### Getting a pointer to a variable
 
-To find the memory address of the value of a variable, we can use the `&` operator. 
+To find the memory address of the value of a variable, we can use the `&` operator.
 For example, if we want to find and store the memory address of variable `a` in the pointer `p`, we can do the following:
 
 ```go
@@ -57,10 +57,10 @@ p = &a // the variable 'p' contains the memory address of 'a'
 When we have a pointer, we might want to know the value stored in the memory address the pointer represents. We can do this using the `*` operator:
 
 ```go
-var a int 
+var a int
 a = 2
 
-var p *int 
+var p *int
 p = &a // the variable 'p' contains the memory address of 'a'
 
 var b int
@@ -76,14 +76,14 @@ var a int        // declare int variable 'a'
 a = 2            // assign 'a' the value of 2
 
 var pa *int
-pa = &a          // 'pa' now contains to the memory address of 'a'  
+pa = &a          // 'pa' now contains to the memory address of 'a'
 *pa = *pa + 2    // increment by 2 the value at memory address 'pa'
 
 fmt.Println(a)   // Output: 4
                  // 'a' will have the new value that was changed via the pointer!
 ```
 
-Assigning to `*pa` will change the value stored at the memory address `pa` holds. Since `pa` holds the memory address of `a`, by assigning to `*pa` we are effectively changing the value of `a`! 
+Assigning to `*pa` will change the value stored at the memory address `pa` holds. Since `pa` holds the memory address of `a`, by assigning to `*pa` we are effectively changing the value of `a`!
 
 A note of caution however: always check if a pointer is not `nil` before dereferencing. Dereferencing a `nil` pointer will make the program crash at runtime!
 
@@ -123,14 +123,14 @@ When we have a pointer to a struct, we don't need to dereference the pointer bef
 var p *Person
 p = &Person{Name: "Peter", Age: 22}
 
-fmt.Println(p.Name) // Output: "Peter" 
+fmt.Println(p.Name) // Output: "Peter"
                     // Go automatically dereferences 'p' to allow
                     // access to the 'Name' field
 ```
 
 ## Slices and maps are already pointers
 
-Slices and maps are special types because they already have pointers in their implementation. This means that more often that not, we don't need to create pointers for these types to share the memory address for their values. Imagine we have a function that increments the value of a key in a map:
+Slices and maps are special types because they already have pointers in their implementation. This means that more often than not, we don't need to create pointers for these types to share the memory address for their values. Imagine we have a function that increments the value of a key in a map:
 
 
 ```go


### PR DESCRIPTION
Description
----
There's a small typo in the explanation for the "Slices and maps are already pointers" paragraph `that not` becomes `than not` :)