### PR TITLE
docs: update a faulty link in leap exercise document

### DIFF
--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -13,4 +13,4 @@ file. The Go specific transformation of that data lives in the `cases_test.go` f
 
 [problem-specifications-leap]: https://github.com/exercism/problem-specifications/tree/master/exercises/leap
 [problem-specifications-leap-json]: https://github.com/exercism/problem-specifications/blob/master/exercises/leap/canonical-data.json
-[local-leap-gen]: https://github.com/exercism/go/blob/master/exercises/leap/.meta/gen.go
+[local-leap-gen]: https://github.com/exercism/go/blob/main/exercises/practice/leap/.meta/gen.go


### PR DESCRIPTION
Just a quick updating of a faulty link. the file structure apparantly has been updated, but the instruction was not updated to reflect that change.