### PR TITLE
Fixed "Output"- All remaining files

### DIFF
--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -5,16 +5,16 @@ Booleans in Go are represented by the `bool` type, which values can be either `t
 Go supports three [boolean operators][logical operators]: `!` (NOT), `&&` (AND), and `||` (OR).
 
 ```go
-true || false // Output: true
-true && false // Output: false
-!true // Output: false
+true || false // => true
+true && false // => false
+!true // => false
 ```
 
 The three boolean operators each have a different [_operator precedence_][operators]. As a consequence, they are evaluated in this order: `!` first, `&&` second, and finally `||`. If you want to 'escape' these rules, you can enclose a boolean expression in parentheses (`()`), as the parentheses have an even higher operator precedence.
 
 ```go
-!true && false   // Output: false
-!(true && false) // Output: true
+!true && false   // => false
+!(true && false) // => true
 ```
 
 [operators]: https://golang.org/ref/spec#Operators

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -6,9 +6,9 @@ A `bool` is either `true` or `false`.
 Go supports three boolean operators: `!` (NOT), `&&` (AND), and `||` (OR).
 
 ```go
-true || false // Output: true
-true && false // Output: false
-!true // Output: false
+true || false // => true
+true && false // => false
+!true // => false
 ```
 
 The three boolean operators each have a different _operator precedence_.
@@ -16,6 +16,6 @@ As a consequence, they are evaluated in this order: `!` first, `&&` second, and 
 If you want to force a different ordering, you can enclose a boolean expression in parentheses (ie. `()`), as the parentheses have an even higher operator precedence.
 
 ```go
-!true && false   // Output: false
-!(true && false) // Output: true
+!true && false   // => false
+!(true && false) // => true
 ```

--- a/concepts/conditionals-if/about.md
+++ b/concepts/conditionals-if/about.md
@@ -53,7 +53,7 @@ if v := 2 * num; v > 10 {
 } else {
     fmt.Println(num)
 }
-// Output: 14
+// => 14
 ```
 
 > Note: any variables created in the initialization statement go out of scope after the end of the if statement.

--- a/concepts/conditionals-if/introduction.md
+++ b/concepts/conditionals-if/introduction.md
@@ -39,7 +39,7 @@ if v := 2 * num; v > 10 {
 } else {
     fmt.Println(num)
 }
-// Output: 14
+// => 14
 ```
 
 > Note: any variables created in the initialization statement go out of scope after the end of the if statement.

--- a/concepts/constants/about.md
+++ b/concepts/constants/about.md
@@ -37,8 +37,8 @@ func main() {
     const m = map[int]int{2: 8}
     const s = []string{"exercism", "v3"}
 }
-// Output: const initializer map[int]int literal is not a constant
-// Output: const initializer []string literal is not a constant
+// => const initializer map[int]int literal is not a constant
+// => const initializer []string literal is not a constant
 ```
 
 For a fuller explanation please see the resources [here][const2], [here][const3], and [here][const4].

--- a/concepts/constants/introduction.md
+++ b/concepts/constants/introduction.md
@@ -25,5 +25,5 @@ const (
     g
 )
 fmt.Print(a, b, c, d, e, f, g)
-// Output: 9 9 9 3 4 5 6
+// => 9 9 9 3 4 5 6
 ```

--- a/concepts/first-class-functions/about.md
+++ b/concepts/first-class-functions/about.md
@@ -37,7 +37,7 @@ func espGreeting(name string) string {
 
 greeting := espGreeting
 dialog("Alice", greeting)
-// Output:
+// =>
 // ¡Hola Alice, mucho gusto!
 // I'm a dialog bot.
 ```

--- a/concepts/first-class-functions/introduction.md
+++ b/concepts/first-class-functions/introduction.md
@@ -37,7 +37,7 @@ func espGreeting(name string) string {
 
 greeting := espGreeting
 dialog("Alice", greeting)
-// Output:
+// =>
 // ¡Hola Alice, mucho gusto!
 // I'm a dialog bot.
 ```

--- a/concepts/for-loops/about.md
+++ b/concepts/for-loops/about.md
@@ -39,7 +39,7 @@ for sum < 1000 {
 	sum += sum
 }
 fmt.Println(sum)
-// Output: 1024
+// => 1024
 ```
 
 By omitting the init and post component in a for loop like shown above, you create a while loop in Go.
@@ -57,7 +57,7 @@ for n := 0; n <= 5; n++ {
   }
   fmt.Println(n)
 }
-// Output:
+// =>
 // 0
 // 1
 // 2
@@ -72,7 +72,7 @@ for n := 0; n <= 5; n++ {
   }
   fmt.Println(n)
 }
-// Output:
+// =>
 // 1
 // 3
 // 5

--- a/concepts/maps/about.md
+++ b/concepts/maps/about.md
@@ -78,7 +78,7 @@ import "reflect"
 
 equal := reflect.DeepEqual(map[string]int{}, map[string]int{})
 fmt.Println(equal)
-// Output: true
+// => true
 ```
 
 _But wait, if map isn't a comparable why are we able to compare them with `nil`? Well, the spec has made an exception for this, see the [comparable spec][gospec-comparable]_

--- a/concepts/methods/about.md
+++ b/concepts/methods/about.md
@@ -21,7 +21,7 @@ func (p Person) Greetings() string {
 
 s := Person{Name: "Bronson"}
 fmt.Println(s.Greetings())
-// Output: Welcome Bronson !
+// => Welcome Bronson !
 
 ```
 
@@ -43,11 +43,11 @@ func (r *rect) squareIt() {
 
 r := rect{width: 10, height: 20}
 fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-// Output: Width: 10, Height: 20
+// => Width: 10, Height: 20
 
 r.squareIt()
 fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-// Output: Width: 10, Height: 10
+// => Width: 10, Height: 10
 ```
 
 You can find several examples [here][pointers_receivers]. Also checkout this short tutorial about [methods][methods_tutorial].

--- a/concepts/methods/introduction.md
+++ b/concepts/methods/introduction.md
@@ -22,7 +22,7 @@ func (p Person) Greetings() string {
 
 s := Person{Name: "Bronson"}
 fmt.Println(s.Greetings())
-// Output: Welcome Bronson !
+// => Welcome Bronson !
 ```
 
 There are two types of receivers, value receivers, and pointer receivers.
@@ -43,10 +43,10 @@ func (r *rect) squareIt() {
 
 r := rect{width: 10, height: 20}
 fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-// Output: Width: 10, Height: 20
+// => Width: 10, Height: 20
 
 r.squareIt()
 fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-// Output: Width: 10, Height: 10
+// => Width: 10, Height: 10
 
 ```

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -35,10 +35,10 @@ var x int = 42
 f := float64(x)
 
 fmt.Printf("x is of type: %s\n", reflect.TypeOf(x))
-// Output: x is of type: int
+// => x is of type: int
 
 fmt.Printf("f is of type: %s\n", reflect.TypeOf(f))
-// Output: f is of type: float64
+// => f is of type: float64
 ```
 
 For more information on Type Conversion please see

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -26,8 +26,8 @@ var x int = 42
 f := float64(x)
 
 fmt.Printf("x is of type: %s\n", reflect.TypeOf(x))
-// Output: x is of type: int
+// => x is of type: int
 
 fmt.Printf("f is of type: %s\n", reflect.TypeOf(f))
-// Output: f is of type: float64
+// => f is of type: float64
 ```

--- a/concepts/pointers/about.md
+++ b/concepts/pointers/about.md
@@ -79,7 +79,7 @@ var pa *int
 pa = &a          // 'pa' now contains to the memory address of 'a'  
 *pa = *pa + 2    // increment by 2 the value at memory address 'pa'
 
-fmt.Println(a)   // Output: 4
+fmt.Println(a)   // => 4
                  // 'a' will have the new value that was changed via the pointer!
 ```
 
@@ -123,7 +123,7 @@ When we have a pointer to a struct, we don't need to dereference the pointer bef
 var p *Person
 p = &Person{Name: "Peter", Age: 22}
 
-fmt.Println(p.Name) // Output: "Peter" 
+fmt.Println(p.Name) // => "Peter" 
                     // Go automatically dereferences 'p' to allow
                     // access to the 'Name' field
 ```
@@ -147,7 +147,7 @@ ages := map[string]int{
 }
 incrementPeterAge(ages)
 fmt.Println(ages)
-// Output: map[Peter:22]
+// => map[Peter:22]
 // The changes the function 'incrementPeterAge' made to the map are visible after the function ends!
 ```
 

--- a/concepts/pointers/introduction.md
+++ b/concepts/pointers/introduction.md
@@ -79,7 +79,7 @@ var pa *int
 pa = &a          // 'pa' now contains to the memory address of 'a'
 *pa = *pa + 2    // increment by 2 the value at memory address 'pa'
 
-fmt.Println(a)   // Output: 4
+fmt.Println(a)   // => 4
                  // 'a' will have the new value that was changed via the pointer!
 ```
 
@@ -123,7 +123,7 @@ When we have a pointer to a struct, we don't need to dereference the pointer bef
 var p *Person
 p = &Person{Name: "Peter", Age: 22}
 
-fmt.Println(p.Name) // Output: "Peter"
+fmt.Println(p.Name) // => "Peter"
                     // Go automatically dereferences 'p' to allow
                     // access to the 'Name' field
 ```
@@ -147,7 +147,7 @@ ages := map[string]int{
 }
 incrementPeterAge(ages)
 fmt.Println(ages)
-// Output: map[Peter:22]
+// => map[Peter:22]
 // The changes the function 'incrementPeterAge' made to the map are visible after the function ends!
 ```
 

--- a/concepts/randomness/about.md
+++ b/concepts/randomness/about.md
@@ -64,7 +64,7 @@ func main() {
 }
 ```
 
-Every time this program runs, it will produce the same output:
+Every time this program runs, it will produce the same =>
 
 ```text
 498081 727887 131847

--- a/concepts/runes/about.md
+++ b/concepts/runes/about.md
@@ -38,7 +38,7 @@ Since `rune` is just an alias for `int32`, printing a rune's type will yield `in
 ```go
 myRune := '¿'
 fmt.Printf("myRune type: %T\n", myRune)
-// Output: myRune type: int32
+// => myRune type: int32
 ```
 
 Similarly, printing a rune's value will yield its integer (decimal) value:
@@ -46,7 +46,7 @@ Similarly, printing a rune's value will yield its integer (decimal) value:
 ```go
 myRune := '¿'
 fmt.Printf("myRune value: %v\n", myRune)
-// Output: myRune value: 191
+// => myRune value: 191
 ```
 
 To print the Unicode character represented by the rune, use the `%c` formatting verb:
@@ -54,7 +54,7 @@ To print the Unicode character represented by the rune, use the `%c` formatting 
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode character: %c\n", myRune)
-// Output: myRune Unicode character: ¿
+// => myRune Unicode character: ¿
 ```
 
 To print the Unicode code point represented by the rune, use the `%U` formatting verb:
@@ -62,7 +62,7 @@ To print the Unicode code point represented by the rune, use the `%U` formatting
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode code point: %U\n", myRune)
-// Output: myRune Unicode code point: U+00BF
+// => myRune Unicode code point: U+00BF
 ```
 
 Besides defining a rune by wrapping the character in single quotes, you can also specify the hexadecimal or decimal number:
@@ -71,7 +71,7 @@ Besides defining a rune by wrapping the character in single quotes, you can also
 myRune := rune(0xbf)
 myRune = 191
 fmt.Printf("myRune Unicode character: %c\n", myRune)
-// Output: myRune Unicode character: ¿
+// => myRune Unicode character: ¿
 ```
 
 ## Runes and Strings
@@ -85,7 +85,7 @@ myString := "❗hello"
 for index, char := range myString {
   fmt.Printf("Index: %d\tCharacter: %c\t\tCode Point: %U\n", index, char, char)
 }
-// Output:
+// =>
 // Index: 0	Character: ❗		Code Point: U+2757
 // Index: 3	Character: h		Code Point: U+0068
 // Index: 4	Character: e		Code Point: U+0065
@@ -104,7 +104,7 @@ stringLength := len(myString)
 numberOfRunes := utf8.RuneCountInString(myString)
 
 fmt.Printf("myString - Length: %d - Runes: %d\n", stringLength, numberOfRunes)
-// Output: myString - Length: 8 - Runes: 6
+// => myString - Length: 8 - Runes: 6
 ```
 
 ## Type Converting Runes
@@ -115,7 +115,7 @@ A slice of runes can be type converted to a string:
 myRuneSlice := []rune{'e', 'x', 'e', 'r', 'c', 'i', 's', 'm'}
 myString := string(myRuneSlice)
 fmt.Println(myString)
-// Output: exercism
+// => exercism
 ```
 
 Similarly, a string can be type converted to a slice of runes. Remember, without formatting verbs, printing a rune yields its integer (decimal) value:
@@ -124,5 +124,5 @@ Similarly, a string can be type converted to a slice of runes. Remember, without
 myString := "exercism"
 myRuneSlice := []rune(myString)
 fmt.Println(myRuneSlice)
-// Output: [101 120 101 114 99 105 115 109]
+// => [101 120 101 114 99 105 115 109]
 ```

--- a/concepts/runes/introduction.md
+++ b/concepts/runes/introduction.md
@@ -38,7 +38,7 @@ Since `rune` is just an alias for `int32`, printing a rune's type will yield `in
 ```go
 myRune := '¿'
 fmt.Printf("myRune type: %T\n", myRune)
-// Output: myRune type: int32
+// => myRune type: int32
 ```
 
 Similarly, printing a rune's value will yield its integer (decimal) value:
@@ -46,7 +46,7 @@ Similarly, printing a rune's value will yield its integer (decimal) value:
 ```go
 myRune := '¿'
 fmt.Printf("myRune value: %v\n", myRune)
-// Output: myRune value: 191
+// => myRune value: 191
 ```
 
 To print the Unicode character represented by the rune, use the `%c` formatting verb:
@@ -54,7 +54,7 @@ To print the Unicode character represented by the rune, use the `%c` formatting 
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode character: %c\n", myRune)
-// Output: myRune Unicode character: ¿
+// => myRune Unicode character: ¿
 ```
 
 To print the Unicode code point represented by the rune, use the `%U` formatting verb:
@@ -62,7 +62,7 @@ To print the Unicode code point represented by the rune, use the `%U` formatting
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode code point: %U\n", myRune)
-// Output: myRune Unicode code point: U+00BF
+// => myRune Unicode code point: U+00BF
 ```
 
 ## Runes and Strings
@@ -76,7 +76,7 @@ myString := "❗hello"
 for index, char := range myString {
   fmt.Printf("Index: %d\tCharacter: %c\t\tCode Point: %U\n", index, char, char)
 }
-// Output:
+// =>
 // Index: 0	Character: ❗		Code Point: U+2757
 // Index: 3	Character: h		Code Point: U+0068
 // Index: 4	Character: e		Code Point: U+0065
@@ -95,5 +95,5 @@ stringLength := len(myString)
 numberOfRunes := utf8.RuneCountInString(myString)
 
 fmt.Printf("myString - Length: %d - Runes: %d\n", stringLength, numberOfRunes)
-// Output: myString - Length: 8 - Runes: 6
+// => myString - Length: 8 - Runes: 6
 ```

--- a/concepts/strings-package/about.md
+++ b/concepts/strings-package/about.md
@@ -17,7 +17,7 @@ The [`strings` package](https://pkg.go.dev/strings) contains many useful functio
 ```go
 import "strings"
 
-strings.ToLower("Gopher")    // Output: "gopher"
-strings.Index("Apple", "le") // Output: 3
-strings.Count("test", "t")   // Output: 2
+strings.ToLower("Gopher")    // => "gopher"
+strings.Index("Apple", "le") // => 3
+strings.Count("test", "t")   // => 2
 ```

--- a/concepts/strings-package/introduction.md
+++ b/concepts/strings-package/introduction.md
@@ -5,5 +5,5 @@ The `strings` package contains many useful functions to work on strings.
 ```go
 import "strings"
 
-strings.ToUpper("test") // Output: "TEST"
+strings.ToUpper("test") // => "TEST"
 ```

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -51,7 +51,7 @@ Some special characters need to be escaped with a leading backslash:
 ```go
 fmt.Println("Joe\nWilliam\nJack\nAverell") 
 
-// Output:
+// =>
 // Joe
 // William
 // Jack

--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -28,7 +28,7 @@ To read or modify instance fields, use the `.` notation:
 // Update the age
 person.age = 23
 fmt.Printf("name: %s age: %d\n", person.name, person.age)
-// Output: name: John age: 23
+// => name: John age: 23
 ```
 
 Fields that don't have an initial value assigned, will have their zero value. For example:
@@ -36,7 +36,7 @@ Fields that don't have an initial value assigned, will have their zero value. Fo
 ```go
 person:= Person{}
 fmt.Printf("name: %s age: %d\n", person.name, person.age)
-// Output: name: age: 0
+// => name: age: 0
 ```
 
 You can create an instance of a `struct` without using the field names, as long as you define the fields _in order_:
@@ -63,8 +63,8 @@ person := Person{
     20,
 }
 // The compiler will fail with a similar error:
-// Output: cannot use 20 (type untyped int) as type string in field value
-// Output: too few values in Person{...}
+// => cannot use 20 (type untyped int) as type string in field value
+// => too few values in Person{...}
 ```
 
 Field names in structs follow the Go convention - fields whose name starts with a lower case letter are only visible to code in the same package, whereas those whose name starts with an upper case letter are visible in other packages.

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -29,5 +29,5 @@ To read or modify instance fields, use the `.` notation:
 // Update the age
 person.age = 23
 fmt.Printf("name: %s age: %d\n", person.name, person.age)
-// Output: name: John age: 23
+// => name: John age: 23
 ```

--- a/concepts/type-definitions/about.md
+++ b/concepts/type-definitions/about.md
@@ -26,7 +26,7 @@ func SayHello(n Name) {
 }
 n := Name("Fred")
 SayHello(n)
-// Output: Hello Fred
+// => Hello Fred
 ```
 
 You can also define non-struct types composed of arrays and maps.
@@ -40,7 +40,7 @@ func SayHello(n Names) {
 }
 n := Names([]string{"Fred", "Bill"})
 SayHello(n)
-// Output:
+// =>
 // Hello Fred
 // Hello Bill
 ```

--- a/concepts/type-definitions/introduction.md
+++ b/concepts/type-definitions/introduction.md
@@ -26,7 +26,7 @@ func SayHello(n Name) {
 }
 n := Name("Fred")
 SayHello(n)
-// Output: Hello Fred
+// => Hello Fred
 ```
 
 You can also define non-struct types composed of arrays and maps.
@@ -40,7 +40,7 @@ func SayHello(n Names) {
 }
 n := Names([]string{"Fred", "Bill"})
 SayHello(n)
-// Output:
+// =>
 // Hello Fred
 // Hello Bill
 ```

--- a/concepts/variadic-functions/about.md
+++ b/concepts/variadic-functions/about.md
@@ -57,17 +57,17 @@ func find(num int, nums ...int) {
 
 func main() {
     find(89, 90, 91, 95)
-    // Output:
+    // =>
     // type of nums is []int
     // 89 not found in  [90 91 95]
 
     find(45, 56, 67, 45, 90, 109)
-    // Output:
+    // =>
     // type of nums is []int
     // 45 found at index 2 in [56 67 45 90 109]
 
     find(87)
-    // Output:
+    // =>
     // type of nums is []int
     // 87 not found in  []
 }
@@ -85,7 +85,7 @@ The step described above where a slice is created will simply be omitted in this
 ```go
 list := []int{1,2,3}
 find(1, list...) // "find" defined as shown above
-// Output:
+// =>
 // type of nums is []int
 // 1 found at index 0 in [1 2 3]
 ```

--- a/concepts/variadic-functions/introduction.md
+++ b/concepts/variadic-functions/introduction.md
@@ -45,17 +45,17 @@ func find(num int, nums ...int) {
 
 func main() {
     find(89, 90, 91, 95)
-    // Output:
+    // =>
     // type of nums is []int
     // 89 not found in  [90 91 95]
 
     find(45, 56, 67, 45, 90, 109)
-    // Output:
+    // =>
     // type of nums is []int
     // 45 found at index 2 in [56 67 45 90 109]
 
     find(87)
-    // Output:
+    // =>
     // type of nums is []int
     // 87 not found in  []
 }

--- a/concepts/zero-values/about.md
+++ b/concepts/zero-values/about.md
@@ -29,13 +29,13 @@ The `var` keyword can be used to construct any type to its zero value:
 ```go
 var myBool bool
 fmt.Printf("Zero value boolean: %#v", myBool)
-// Output: Zero value boolean: false
+// => Zero value boolean: false
 ```
 
 ```go
 var mySlice []int
 fmt.Printf("Zero value slice: %#v", mySlice)
-// Output: Zero value slice: []int(nil)
+// => Zero value slice: []int(nil)
 ```
 
 When constructing the zero value for a struct type, all of the struct's fields will be set to their zero value:
@@ -48,7 +48,7 @@ type Person struct {
 
 var myPerson Person
 fmt.Printf("Zero value Person: %#v", myPerson)
-// Output: Zero value Person: main.Person{Name:"", Age:0}
+// => Zero value Person: main.Person{Name:"", Age:0}
 ```
 
 ## Comparing with Nil

--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -25,7 +25,7 @@ Define the `CanFastAttack()` function that takes a boolean value that indicates 
 ```go
 var knightIsAwake = true
 fmt.Println(CanFastAttack(knightIsAwake))
-// Output: false
+// => false
 ```
 
 ## 2. Check if the group can be spied upon
@@ -37,7 +37,7 @@ var knightIsAwake = false
 var archerIsAwake = true
 var prisonerIsAwake = false
 fmt.Println(CanSpy(knightIsAwake, archerIsAwake, prisonerIsAwake))
-// Output: true
+// => true
 ```
 
 ## 3. Check if the prisoner can be signaled
@@ -48,7 +48,7 @@ Define the `CanSignalPrisoner()` function that takes two boolean values, indicat
 var archerIsAwake = false
 var prisonerIsAwake = true
 fmt.Println(CanSignalPrisoner(archerIsAwake, prisonerIsAwake))
-// Output: true
+// => true
 ```
 
 ## 4. Check if the prisoner can be freed
@@ -61,5 +61,5 @@ var archerIsAwake = true
 var prisonerIsAwake = false
 var petDogIsPresent = false
 fmt.Println(CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent))
-// Output: false
+// => false
 ```

--- a/exercises/concept/blackjack/.docs/instructions.md
+++ b/exercises/concept/blackjack/.docs/instructions.md
@@ -38,7 +38,7 @@ Implement a function to calculate the numerical value of a card:
 ```go
 value := ParseCard("ace")
 fmt.Println(value)
-// Output: 11
+// => 11
 ```
 
 ## 2. Implement the decision logic for the first turn.

--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -10,7 +10,7 @@ Implement the `Schedule` function to parse a textual representation of an appoin
 
 ```go
 Schedule("7/25/2019 13:45:00")
-// Output: 2019-07-25 13:45:00 +0000 UTC
+// => 2019-07-25 13:45:00 +0000 UTC
 ```
 
 ## 2. Check if an appointment has already passed
@@ -19,7 +19,7 @@ Implement the `HasPassed` function that takes an appointment date and checks if 
 
 ```go
 HasPassed("July 25, 2019 13:45:00")
-// Output: true
+// => true
 ```
 
 ## 3. Check if appointment is in the afternoon
@@ -28,7 +28,7 @@ Implement the `IsAfternoonAppointment` function that takes an appointment date a
 
 ```go
 IsAfternoonAppointment("Thursday, July 25, 2019 13:45:00")
-// Output: true
+// => true
 ```
 
 ## 4. Describe the time and date of the appointment
@@ -37,7 +37,7 @@ Implement the `Description` function that takes an appointment date and returns 
 
 ```go
 Description("7/25/2019 13:45:00")
-// Output: "You have an appointment on Thursday, July 25, 2019, at 13:45."
+// => "You have an appointment on Thursday, July 25, 2019, at 13:45."
 ```
 
 ## 5. Return the anniversary date of the salon's opening
@@ -49,7 +49,7 @@ Assuming the current year is 2020:
 ```go
 AnniversaryDate()
 
-// Output: 2020-09-15 00:00:00 +0000 UTC
+// => 2020-09-15 00:00:00 +0000 UTC
 ```
 
 **Note:** the return value is a `time.Time` and the time of day doesn't matter.

--- a/exercises/concept/card-tricks/.docs/hints.md
+++ b/exercises/concept/card-tricks/.docs/hints.md
@@ -11,7 +11,7 @@ a := []int{1, 3}
 b := []int{4, 2, 6}
 c := append(a, b...)
 fmt.Println(c)
-// Output: [1 3 4 2 6]
+// => [1 3 4 2 6]
 ```
 
 ## 1. Create a slice with certain cards

--- a/exercises/concept/card-tricks/.docs/instructions.md
+++ b/exercises/concept/card-tricks/.docs/instructions.md
@@ -12,7 +12,7 @@ Write a function `FavoriteCards` that returns a slice with those cards in that o
 ```go
 cards := FavoriteCards()
 fmt.Println(cards)
-// Output: [2 6 9]
+// => [2 6 9]
 ```
 
 ## 2. Retrieve a card from a stack
@@ -39,7 +39,7 @@ index := 2
 newCard := 6
 cards := SetItem([]int{1, 2, 4, 1}, index, newCard)
 fmt.Println(cards)
-// Output: [1 2 6 1]
+// => [1 2 6 1]
 ```
 
 If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to append the new card to the end of the stack:
@@ -49,7 +49,7 @@ index := -1
 newCard := 6
 cards := SetItem([]int{1, 2, 4, 1}, index, newCard)
 fmt.Println(cards)
-// Output: [1 2 4 1 6]
+// => [1 2 4 1 6]
 ```
 
 ## 4. Add cards to the top of the stack
@@ -60,7 +60,7 @@ Add the card(s) specified in the `value` parameter at the top of the stack.
 slice := []int{3, 2, 6, 4, 8}
 cards := PrependItems(slice, 5, 1)
 fmt.Println(cards)
-// Output: [5 1 3 2 6 4 8]
+// => [5 1 3 2 6 4 8]
 ```
 
 If no argument is given for the `value` parameter, then the result equals the original slice.
@@ -69,7 +69,7 @@ If no argument is given for the `value` parameter, then the result equals the or
 slice := []int{3, 2, 6, 4, 8}
 cards := PrependItems(slice)
 fmt.Println(cards)
-// Output: [3 2 6 4 8]
+// => [3 2 6 4 8]
 ```
 
 ## 5. Remove a card from the stack
@@ -80,7 +80,7 @@ Note that this may modify the input slice which is ok.
 ```go
 cards := RemoveItem([]int{3, 2, 6, 4, 8}, 2)
 fmt.Println(cards)
-// Output: [3 2 4 8]
+// => [3 2 4 8]
 ```
 
 If the index is out of bounds (ie. if it is negative or after the end of the stack), we want to leave the stack unchanged:
@@ -88,5 +88,5 @@ If the index is out of bounds (ie. if it is negative or after the end of the sta
 ```go
 cards := RemoveItem([]int{3, 2, 6, 4, 8}, 11)
 fmt.Println(cards)
-// Output: [3 2 6 4 8]
+// => [3 2 6 4 8]
 ```

--- a/exercises/concept/card-tricks/.docs/introduction.md
+++ b/exercises/concept/card-tricks/.docs/introduction.md
@@ -84,17 +84,17 @@ func find(num int, nums ...int) {
 
 func main() {
     find(89, 90, 91, 95)
-    // Output:
+    // =>
     // type of nums is []int
     // 89 not found in  [90 91 95]
 
     find(45, 56, 67, 45, 90, 109)
-    // Output:
+    // =>
     // type of nums is []int
     // 45 found at index 2 in [56 67 45 90 109]
 
     find(87)
-    // Output:
+    // =>
     // type of nums is []int
     // 87 not found in  []
 }

--- a/exercises/concept/cars-assemble/.docs/instructions.md
+++ b/exercises/concept/cars-assemble/.docs/instructions.md
@@ -13,7 +13,7 @@ Implement a function that takes in the number of cars produced per hour and the 
 
 ```go
 rate := CalculateWorkingCarsPerHour(1547, 90)
-// Output: 1392.3
+// => 1392.3
 ```
 
 **Note:** the return value should be a `float64`.
@@ -24,7 +24,7 @@ Implement a function that takes in the number of cars produced per hour and the 
 
 ```go
 rate := CalculateWorkingCarsPerMinute(1105, 90)
-// Output: 16
+// => 16
 ```
 
 **Note:** the return value should be an `int`.
@@ -44,10 +44,10 @@ Implement the function `CalculateCost` that calculates the cost of producing a n
 
 ```go
 cost := CalculateCost(37)
-// Output: 355000
+// => 355000
 
 cost = CalculateCost(21)
-// Output: 200000
+// => 200000
 ```
 
 **Note:** the return value should be an `uint`.

--- a/exercises/concept/chessboard/.docs/introduction.md
+++ b/exercises/concept/chessboard/.docs/introduction.md
@@ -88,7 +88,7 @@ func SayHello(n Name) {
 }
 n := Name("Fred")
 SayHello(n)
-// Output: Hello Fred
+// => Hello Fred
 ```
 
 You can also define non-struct types composed of arrays and maps.
@@ -102,7 +102,7 @@ func SayHello(n Names) {
 }
 n := Names([]string{"Fred", "Bill"})
 SayHello(n)
-// Output:
+// =>
 // Hello Fred
 // Hello Bill
 ```

--- a/exercises/concept/election-day/.docs/instructions.md
+++ b/exercises/concept/election-day/.docs/instructions.md
@@ -37,11 +37,11 @@ var voteCounter *int
 voteCounter = &votes
 
 VoteCount(voteCounter)
-// Output: 3
+// => 3
 
 var nilVoteCounter *int
 VoteCount(nilVoteCounter)
-// Output: 0
+// => 0
 ```
 
 ## 3. Increment the votes of a counter
@@ -108,7 +108,7 @@ result = &ElectionResult{
 }
 
 DisplayResult(result)
-// Output: John (32)
+// => John (32)
 ```
 
 ## 6. Vote recounting
@@ -126,5 +126,5 @@ var finalResults = map[string]int{
 DecrementVotesOfCandidate(finalResults, "Mary")
 
 finalResults["Mary"]
-// Output: 9
+// => 9
 ```

--- a/exercises/concept/election-day/.docs/introduction.md
+++ b/exercises/concept/election-day/.docs/introduction.md
@@ -79,7 +79,7 @@ var pa *int
 pa = &a          // 'pa' now contains to the memory address of 'a'
 *pa = *pa + 2    // increment by 2 the value at memory address 'pa'
 
-fmt.Println(a)   // Output: 4
+fmt.Println(a)   // => 4
                  // 'a' will have the new value that was changed via the pointer!
 ```
 
@@ -123,7 +123,7 @@ When we have a pointer to a struct, we don't need to dereference the pointer bef
 var p *Person
 p = &Person{Name: "Peter", Age: 22}
 
-fmt.Println(p.Name) // Output: "Peter"
+fmt.Println(p.Name) // => "Peter"
                     // Go automatically dereferences 'p' to allow
                     // access to the 'Name' field
 ```
@@ -147,7 +147,7 @@ ages := map[string]int{
 }
 incrementPeterAge(ages)
 fmt.Println(ages)
-// Output: map[Peter:22]
+// => map[Peter:22]
 // The changes the function 'incrementPeterAge' made to the map are visible after the function ends!
 ```
 

--- a/exercises/concept/elons-toys/.docs/instructions.md
+++ b/exercises/concept/elons-toys/.docs/instructions.md
@@ -39,7 +39,7 @@ batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 
 fmt.Println(car.DisplayDistance())
-// Output: "Driven 0 meters"
+// => "Driven 0 meters"
 ```
 
 ## 3. Display the battery percentage
@@ -52,7 +52,7 @@ batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 
 fmt.Println(car.DisplayBattery())
-// Output: "Battery at 100%"
+// => "Battery at 100%"
 ```
 
 ## 4. Check if a remote control car can finish a race
@@ -67,5 +67,5 @@ car := NewCar(speed, batteryDrain)
 trackDistance := 100
 
 car.CanFinish(trackDistance)
-// Output: true
+// => true
 ```

--- a/exercises/concept/elons-toys/.docs/introduction.md
+++ b/exercises/concept/elons-toys/.docs/introduction.md
@@ -20,7 +20,7 @@ func (p Person) Greetings() string {
 
 p := Person{Name: "Bronson"}
 fmt.Println(p.Greetings())
-// Output: Welcome Bronson !
+// => Welcome Bronson !
 ```
 
 Notice the way we called the method `Greetings()` on the `Person` instance `p`.
@@ -66,9 +66,9 @@ func (r *rect) squareIt() {
 
 r := rect{width: 10, height: 20}
 fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-// Output: Width: 10, Height: 20
+// => Width: 10, Height: 20
 
 r.squareIt()
 fmt.Printf("Width: %d, Height: %d\n", r.width, r.height)
-// Output: Width: 10, Height: 10
+// => Width: 10, Height: 10
 ```

--- a/exercises/concept/expenses/.docs/instructions.md
+++ b/exercises/concept/expenses/.docs/instructions.md
@@ -56,7 +56,7 @@ func Day1Records(Record r) bool {
 }
 
 Filter(records, Day1Records)
-// Output:
+// =>
 // [
 //   {Day: 1, Amount: 15, Category: "groceries"}
 // ]
@@ -81,7 +81,7 @@ records := []Record{
 period := DaysPeriod{From: 1, To: 15}
 
 Filter(records, ByDaysPeriod(period))
-// Output:
+// =>
 // [
 //   {Day: 1, Amount: 15, Category: "groceries"},
 //   {Day: 11, Amount: 300, Category: "utility-bills"},
@@ -105,7 +105,7 @@ records := []Record{
 }
 
 Filter(records, ByCategory("groceries"))
-// Output:
+// =>
 // [
 //   {Day: 1, Amount: 15, Category: "groceries"},
 //   {Day: 12, Amount: 28, Category: "groceries"},
@@ -129,10 +129,10 @@ p1 := DaysPeriod{From: 1, To: 30}
 p2 := DaysPeriod{From: 31, To: 60}
 
 TotalByPeriod(records, p1)
-// Output: 16
+// => 16
 
 TotalByPeriod(records, p2)
-// Output: 50
+// => 50
 ```
 
 ## 5. Calculate the total expenses for records of a category in a period
@@ -156,11 +156,11 @@ records := []Record{
 }
 
 CategoryExpenses(records, p1, "entertainment")
-// Output: 0, error(unknown category entertainment)
+// => 0, error(unknown category entertainment)
 
 CategoryExpenses(records, p1, "rent")
-// Output: 1300, nil
+// => 1300, nil
 
 CategoryExpenses(records, p2, "rent")
-// Output: 0, nil
+// => 0, nil
 ```

--- a/exercises/concept/expenses/.docs/introduction.md
+++ b/exercises/concept/expenses/.docs/introduction.md
@@ -37,7 +37,7 @@ func espGreeting(name string) string {
 
 greeting := espGreeting
 dialog("Alice", greeting)
-// Output:
+// =>
 // ¡Hola Alice, mucho gusto!
 // I'm a dialog bot.
 ```

--- a/exercises/concept/gross-store/.docs/instructions.md
+++ b/exercises/concept/gross-store/.docs/instructions.md
@@ -23,7 +23,7 @@ In order to use the measurement, you need to store the measurement in your progr
 ```go
 units := Units()
 fmt.Println(units)
-// Output: map[...] with entries like ("dozen": 12)
+// => map[...] with entries like ("dozen": 12)
 ```
 
 ## 2. Create a new customer bill
@@ -33,7 +33,7 @@ You need to implement a function that create a new (empty) bill for the customer
 ```go
 bill := NewBill()
 fmt.Println(bill)
-// Output: map[]
+// => map[]
 ```
 
 ## 3. Add an item to the customer bill
@@ -49,7 +49,7 @@ bill := NewBill()
 units := Units()
 ok := AddItem(bill, units, "carrot", "dozen")
 fmt.Println(ok)
-// Output: true (since dozen is a valid unit)
+// => true (since dozen is a valid unit)
 ```
 
 > Note that the returned value is type `bool`.
@@ -69,7 +69,7 @@ bill := NewBill()
 units := Units()
 ok := RemoveItem(bill, units, "carrot", "dozen")
 fmt.Println(ok)
-// Output: false (because there are no carrots in the bill)
+// => false (because there are no carrots in the bill)
 ```
 
 > Note that the returned value is type `bool`.
@@ -85,9 +85,9 @@ To implement this, you'll need to:
 bill := map[string]int{"carrot": 12, "grapes": 3}
 qty, ok := GetItem(bill, "carrot")
 fmt.Println(qty)
-// Output: 12
+// => 12
 fmt.Println(ok)
-// Output: true
+// => true
 ```
 
 > Note that the returned value are types `int` and `bool`.

--- a/exercises/concept/interest-is-interesting/.docs/instructions.md
+++ b/exercises/concept/interest-is-interesting/.docs/instructions.md
@@ -17,7 +17,7 @@ Implement the `InterestRate()` function to calculate the interest rate based on 
 
 ```go
 InterestRate(200.75)
-// Output: 0.5
+// => 0.5
 ```
 
 Note that the value returned is a `float32`.
@@ -28,7 +28,7 @@ Implement the `Interest()` function to calculate the interest based on the speci
 
 ```go
 Interest(200.75)
-// Output: 1.003750
+// => 1.003750
 ```
 
 Note that the value returned is a `float64`.
@@ -39,7 +39,7 @@ Implement the `AnnualBalanceUpdate()` function to calculate the annual balance u
 
 ```go
 AnnualBalanceUpdate(200.75)
-// Output: 201.75375
+// => 201.75375
 ```
 
 Note that the value returned is a `float64`.
@@ -55,7 +55,7 @@ And so on, until the current year's balance is greater than or equal to the targ
 balance := 200.75
 targetBalance := 214.88
 YearsBeforeDesiredBalance(balance, targetBalance)
-// Output: 14
+// => 14
 ```
 
 Note that the value returned is an `int`.

--- a/exercises/concept/logs-logs-logs/.docs/instructions.md
+++ b/exercises/concept/logs-logs-logs/.docs/instructions.md
@@ -20,7 +20,7 @@ If a log line does not contain one of the characters from the above table, retur
 
 ```go
 Application("❗ recommended search product 🔍")
-// Output: recommendation
+// => recommendation
 ```
 
 ## 2. Fix corrupted logs
@@ -33,7 +33,7 @@ Implement the `Replace` function that takes a log line, a corrupted character, a
 log := "please replace '👎' with '👍'"
 
 Replace(log, '👎', '👍')
-// Output: please replace '👍' with '👍'"
+// => please replace '👍' with '👍'"
 ```
 
 ## 3. Determine if a log can be displayed
@@ -44,5 +44,5 @@ Implement the `WithinLimit` function that takes a log line and character limit a
 
 ```go
 WithinLimit("hello❗", 6)
-// Output: true
+// => true
 ```

--- a/exercises/concept/logs-logs-logs/.docs/introduction.md
+++ b/exercises/concept/logs-logs-logs/.docs/introduction.md
@@ -38,7 +38,7 @@ Since `rune` is just an alias for `int32`, printing a rune's type will yield `in
 ```go
 myRune := '¿'
 fmt.Printf("myRune type: %T\n", myRune)
-// Output: myRune type: int32
+// => myRune type: int32
 ```
 
 Similarly, printing a rune's value will yield its integer (decimal) value:
@@ -46,7 +46,7 @@ Similarly, printing a rune's value will yield its integer (decimal) value:
 ```go
 myRune := '¿'
 fmt.Printf("myRune value: %v\n", myRune)
-// Output: myRune value: 191
+// => myRune value: 191
 ```
 
 To print the Unicode character represented by the rune, use the `%c` formatting verb:
@@ -54,7 +54,7 @@ To print the Unicode character represented by the rune, use the `%c` formatting 
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode character: %c\n", myRune)
-// Output: myRune Unicode character: ¿
+// => myRune Unicode character: ¿
 ```
 
 To print the Unicode code point represented by the rune, use the `%U` formatting verb:
@@ -62,7 +62,7 @@ To print the Unicode code point represented by the rune, use the `%U` formatting
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode code point: %U\n", myRune)
-// Output: myRune Unicode code point: U+00BF
+// => myRune Unicode code point: U+00BF
 ```
 
 ## Runes and Strings
@@ -76,7 +76,7 @@ myString := "❗hello"
 for index, char := range myString {
   fmt.Printf("Index: %d\tCharacter: %c\t\tCode Point: %U\n", index, char, char)
 }
-// Output:
+// =>
 // Index: 0	Character: ❗		Code Point: U+2757
 // Index: 3	Character: h		Code Point: U+0068
 // Index: 4	Character: e		Code Point: U+0065
@@ -95,5 +95,5 @@ stringLength := len(myString)
 numberOfRunes := utf8.RuneCountInString(myString)
 
 fmt.Printf("myString - Length: %d - Runes: %d\n", stringLength, numberOfRunes)
-// Output: myString - Length: 8 - Runes: 6
+// => myString - Length: 8 - Runes: 6
 ```

--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -26,7 +26,7 @@ and the battery drain percentage as its two parameters (both of type `int`) and 
 speed := 5
 batteryDrain := 2
 car := NewCar(speed, batteryDrain)
-// Output: Car{speed: 5, batteryDrain: 2, battery:100, distance: 0}
+// => Car{speed: 5, batteryDrain: 2, battery:100, distance: 0}
 ```
 
 ## 2. Creating a race track
@@ -37,7 +37,7 @@ Allow creating a race track by defining a function `NewTrack` that takes the tra
 ```go
 distance := 800
 raceTrack := NewTrack(distance)
-// Output: Track{distance: 800}
+// => Track{distance: 800}
 ```
 
 ## 3. Drive the car
@@ -49,7 +49,7 @@ speed := 5
 batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 car = Drive(car)
-// Output: Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
+// => Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
 ```
 
 ## 4. Check if a remote controlled car can finish a race
@@ -67,5 +67,5 @@ distance := 100
 raceTrack := NewTrack(distance)
 
 CanFinish(car, raceTrack)
-// Output: true
+// => true
 ```

--- a/exercises/concept/need-for-speed/.docs/introduction.md
+++ b/exercises/concept/need-for-speed/.docs/introduction.md
@@ -29,5 +29,5 @@ To read or modify instance fields, use the `.` notation:
 // Update the age
 person.age = 23
 fmt.Printf("name: %s age: %d\n", person.name, person.age)
-// Output: name: John age: 23
+// => name: John age: 23
 ```

--- a/exercises/concept/party-robot/.docs/instructions.md
+++ b/exercises/concept/party-robot/.docs/instructions.md
@@ -12,7 +12,7 @@ Implement the `Welcome` function to return a welcome message using the given nam
 
 ```go
 Welcome("Christiane")
-// Output: Welcome to my party, Christiane!
+// => Welcome to my party, Christiane!
 ```
 
 ## 2. Welcome a new guest to the party whose birthday is today
@@ -22,7 +22,7 @@ Unfortunately the programmer is a bit of a show-off, so the robot has to demonst
 
 ```go
 HappyBirthday("Frank", 58)
-// Output: Happy birthday Frank! You are now 58 years old!
+// => Happy birthday Frank! You are now 58 years old!
 ```
 
 ## 3. Give directions
@@ -45,7 +45,7 @@ Fortunately only with a precision that's limited to 1 digit.
 
 ```go
 AssignTable("Christiane", 27, "Frank", "on the left", 23.7834298)
-// Output:
+// =>
 // Welcome to my party, Christiane!
 // You have been assigned to table 027. Your table is on the left, exactly 23.8 meters from here.
 // You will be sitting next to Frank.

--- a/exercises/concept/savings-account/.docs/instructions.md
+++ b/exercises/concept/savings-account/.docs/instructions.md
@@ -10,7 +10,7 @@ Create the `FixedInterestRate` untyped numeric constant to hold the value of 5% 
 
 ```go
 GetFixedInterestRate()
-// Output: 0.05
+// => 0.05
 ```
 
 ## 2. Represent the number of days in a year
@@ -19,7 +19,7 @@ Create the `DaysPerYear` constant with type `int` to hold the value 365, then im
 
 ```go
 GetDaysPerYear()
-// Output: 365
+// => 365
 ```
 
 ## 3. Represent the months of the year
@@ -28,7 +28,7 @@ In a block, use the Go enumerator to create twelve untyped numeric constants to 
 
 ```go
 GetMonth(Jan)
-// Output: 1
+// => 1
 ```
 
 ## 4. Represent an account number
@@ -37,5 +37,5 @@ Create the `AccountNo` untyped string constant to hold the value XF348IJ, then i
 
 ```go
 GetAccountNumber()
-// Output: "XF348IJ"
+// => "XF348IJ"
 ```

--- a/exercises/concept/savings-account/.docs/introduction.md
+++ b/exercises/concept/savings-account/.docs/introduction.md
@@ -25,5 +25,5 @@ const (
     g
 )
 fmt.Print(a, b, c, d, e, f, g)
-// Output: 9 9 9 3 4 5 6
+// => 9 9 9 3 4 5 6
 ```

--- a/exercises/concept/sorting-room/.docs/instructions.md
+++ b/exercises/concept/sorting-room/.docs/instructions.md
@@ -20,7 +20,7 @@ Jen wants numbers to return strings like `"This is the number 2.0"` (including o
 
 ```go
 fmt.Println(DescribeNumber(-12.345))
-// Output: This is the number -12.3
+// => This is the number -12.3
 ```
 
 ## 2. Describe a number box
@@ -29,7 +29,7 @@ Jen wants number boxes to return strings like `"This is a box containing the num
 
 ```go
 fmt.Println(DescribeNumberBox(numberBoxContaining{12}))
-// Output: This is a box containing the number 12.0
+// => This is a box containing the number 12.0
 ```
 
 ## 3. Implement a method extracting the number from a fancy number box
@@ -40,9 +40,9 @@ Any other type of `FancyNumberBox` should return 0.
 
 ```go
 fmt.Println(ExtractFancyNumber(FancyNumber{"10"}))
-// Output: 10
+// => 10
 fmt.Println(ExtractFancyNumber(AnotherFancyNumber{"4"}))
-// Output: 0
+// => 0
 ```
 
 ## 4. Describe a fancy number box
@@ -52,9 +52,9 @@ Any other type of `FancyNumberBox` should say `"This is a fancy box containing t
 
 ```go
 fmt.Println(DescribeFancyNumberBox(FancyNumber{"10"}))
-// Output: This is a fancy box containing the number 10.0
+// => This is a fancy box containing the number 10.0
 fmt.Println(DescribeFancyNumberBox(AnotherFancyNumber{"4"}))
-// Output: This is a fancy box containing the number 0.0
+// => This is a fancy box containing the number 0.0
 ```
 
 NOTE: we should use the `ExtractFancyNumber` function!
@@ -72,7 +72,7 @@ More specifically:
 
 ```go
 fmt.Println(DescribeAnything(numberBoxContaining{12.345}))
-// Output: This is a box containing the number 12.3
+// => This is a box containing the number 12.3
 fmt.Println(DescribeAnything("some string"))
-// Output: Return to sender
+// => Return to sender
 ```

--- a/exercises/concept/vehicle-purchase/.docs/instructions.md
+++ b/exercises/concept/vehicle-purchase/.docs/instructions.md
@@ -13,10 +13,10 @@ Implement the `NeedsLicense(kind)` function that takes the kind of vehicle and r
 
 ```go
 needLicense := NeedsLicense("car")
-// Output: true
+// => true
 
 needLicense = NeedsLicense("bike")
-// Output: false
+// => false
 ```
 
 ## 2. Choose between two potential vehicles to buy
@@ -27,10 +27,10 @@ For that, implement the function `ChooseVehicle(option1, option2)` that takes tw
 
 ```go
 vehicle := ChooseVehicle("Wuling Hongguang", "Toyota Corolla")
-// Output: "Toyota Corolla is clearly the better choice."
+// => "Toyota Corolla is clearly the better choice."
 
 ChooseVehicle("Volkswagen Beetle", "Volkswagen Golf")
-// Output: "Volkswagen Beetle is clearly the better choice."
+// => "Volkswagen Beetle is clearly the better choice."
 ```
 
 ## 3. Calculate an estimation for the price of a used vehicle
@@ -46,13 +46,13 @@ It takes the original price and the age of the vehicle as arguments and returns 
 
 ```go
 CalculateResellPrice(1000, 1)
-// Output: 800
+// => 800
 
 CalculateResellPrice(1000, 5)
-// Output: 700
+// => 700
 
 CalculateResellPrice(1000, 15)
-// Output: 500
+// => 500
 ```
 
 **Note** the return value is a `float64`.

--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -72,7 +72,7 @@ if v := 2 * num; v > 10 {
 } else {
     fmt.Println(num)
 }
-// Output: 14
+// => 14
 ```
 
 > Note: any variables created in the initialization statement go out of scope after the end of the if statement. 

--- a/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
+++ b/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
@@ -14,7 +14,7 @@ Implement the function `WelcomeMessage` that accepts the name of the customer as
 
 ```go
 WelcomeMessage("Judy")
-// Output: Welcome to the Tech Palace, JUDY
+// => Welcome to the Tech Palace, JUDY
 ```
 
 ## 2. Add a fancy border
@@ -27,7 +27,7 @@ It should return a `string` that consists of 3 lines, a line with the desired nu
 
 ```go
 AddBorder("Welcome!", 10)
-// Output:
+// =>
 // **********
 // Welcome!
 // **********
@@ -52,5 +52,5 @@ message := `
 `
 
 CleanUpMessage(message)
-// Output: BUY NOW, SAVE 10%
+// => BUY NOW, SAVE 10%
 ```

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -8,4 +8,4 @@ For Example
 
 input: [1,[2,3,null,4],[null],5]
 
-output: [1,2,3,4,5]
+=> [1,2,3,4,5]

--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -4,4 +4,4 @@ Reverse a string
 
 For example:
 input: "cool"
-output: "looc"
+=> "looc"


### PR DESCRIPTION
Replace "Output:" for "=>" in example codes.

Related issue: https://github.com/exercism/go/issues/2202