### PR TITLE
Clock: Update instructions markdown links

### DIFF
--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -14,4 +14,4 @@ than pointers. Note also how most time.Time methods have value receivers
 rather than pointer receivers.
 
 For some useful guidelines on when to use a value receiver or a pointer
-receiver see: [https://github.com/golang/go/wiki/CodeReviewComments#receiver-type](https://github.com/golang/go/wiki/CodeReviewComments#receiver-type)
+receiver see [Go Wiki: Receiver Type](https://github.com/golang/go/wiki/CodeReviewComments#receiver-type)

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -7,11 +7,11 @@ your Clock type need to work with the == operator. This means that if your
 New function returns a pointer rather than a value, your clocks will
 probably not work with ==.
 
-While the time.Time type in the standard library (https://golang.org/pkg/time/#Time)
+While the time.Time type in the standard library [https://golang.org/pkg/time/#Time](https://golang.org/pkg/time/#Time)
 doesn't necessarily need to be used as a basis for your Clock type, it might
 help to look at how constructors there (Date and Now) return values rather
 than pointers. Note also how most time.Time methods have value receivers
 rather than pointer receivers.
 
 For some useful guidelines on when to use a value receiver or a pointer
-receiver see: https://github.com/golang/go/wiki/CodeReviewComments#receiver-type
+receiver see: [https://github.com/golang/go/wiki/CodeReviewComments#receiver-type](https://github.com/golang/go/wiki/CodeReviewComments#receiver-type)

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -7,7 +7,7 @@ your Clock type need to work with the == operator. This means that if your
 New function returns a pointer rather than a value, your clocks will
 probably not work with ==.
 
-While the time.Time type in the standard library [https://golang.org/pkg/time/#Time](https://golang.org/pkg/time/#Time)
+While the [time.Time](https://golang.org/pkg/time/#Time) type in the standard library
 doesn't necessarily need to be used as a basis for your Clock type, it might
 help to look at how constructors there (Date and Now) return values rather
 than pointers. Note also how most time.Time methods have value receivers


### PR DESCRIPTION
Description
----
Currently the links in the instructions aren't hyperlinks due to missing markdown formatting. This PR addresses that issue updating the link formatting :)

![image](https://user-images.githubusercontent.com/4511175/170873209-37c2bf1b-8b48-4c61-8f98-84e396212f50.png)
