### PR TITLE
logs-logs-logs: add more tests to better cover multiple characters case

### DIFF
--- a/exercises/concept/logs-logs-logs/.docs/instructions.md
+++ b/exercises/concept/logs-logs-logs/.docs/instructions.md
@@ -20,7 +20,7 @@ If a log line does not contain one of the characters from the above table, retur
 
 ```go
 Application("❗ recommended search product 🔍")
-// Output: recommendation
+// => recommendation
 ```
 
 ## 2. Fix corrupted logs
@@ -33,7 +33,7 @@ Implement the `Replace` function that takes a log line, a corrupted character, a
 log := "please replace '👎' with '👍'"
 
 Replace(log, '👎', '👍')
-// Output: please replace '👍' with '👍'"
+// => please replace '👍' with '👍'"
 ```
 
 ## 3. Determine if a log can be displayed
@@ -44,5 +44,5 @@ Implement the `WithinLimit` function that takes a log line and character limit a
 
 ```go
 WithinLimit("hello❗", 6)
-// Output: true
+// => true
 ```

--- a/exercises/concept/logs-logs-logs/.docs/introduction.md
+++ b/exercises/concept/logs-logs-logs/.docs/introduction.md
@@ -38,7 +38,7 @@ Since `rune` is just an alias for `int32`, printing a rune's type will yield `in
 ```go
 myRune := '¿'
 fmt.Printf("myRune type: %T\n", myRune)
-// Output: myRune type: int32
+// => myRune type: int32
 ```
 
 Similarly, printing a rune's value will yield its integer (decimal) value:
@@ -46,7 +46,7 @@ Similarly, printing a rune's value will yield its integer (decimal) value:
 ```go
 myRune := '¿'
 fmt.Printf("myRune value: %v\n", myRune)
-// Output: myRune value: 191
+// => myRune value: 191
 ```
 
 To print the Unicode character represented by the rune, use the `%c` formatting verb:
@@ -54,7 +54,7 @@ To print the Unicode character represented by the rune, use the `%c` formatting 
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode character: %c\n", myRune)
-// Output: myRune Unicode character: ¿
+// => myRune Unicode character: ¿
 ```
 
 To print the Unicode code point represented by the rune, use the `%U` formatting verb:
@@ -62,7 +62,7 @@ To print the Unicode code point represented by the rune, use the `%U` formatting
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode code point: %U\n", myRune)
-// Output: myRune Unicode code point: U+00BF
+// => myRune Unicode code point: U+00BF
 ```
 
 ## Runes and Strings
@@ -76,7 +76,7 @@ myString := "❗hello"
 for index, char := range myString {
   fmt.Printf("Index: %d\tCharacter: %c\t\tCode Point: %U\n", index, char, char)
 }
-// Output:
+// =>
 // Index: 0	Character: ❗		Code Point: U+2757
 // Index: 3	Character: h		Code Point: U+0068
 // Index: 4	Character: e		Code Point: U+0065
@@ -95,5 +95,5 @@ stringLength := len(myString)
 numberOfRunes := utf8.RuneCountInString(myString)
 
 fmt.Printf("myString - Length: %d - Runes: %d\n", stringLength, numberOfRunes)
-// Output: myString - Length: 8 - Runes: 6
+// => myString - Length: 8 - Runes: 6
 ```

--- a/exercises/concept/logs-logs-logs/.docs/introduction.md
+++ b/exercises/concept/logs-logs-logs/.docs/introduction.md
@@ -38,7 +38,7 @@ Since `rune` is just an alias for `int32`, printing a rune's type will yield `in
 ```go
 myRune := '¿'
 fmt.Printf("myRune type: %T\n", myRune)
-// => myRune type: int32
+// Output: myRune type: int32
 ```
 
 Similarly, printing a rune's value will yield its integer (decimal) value:
@@ -46,7 +46,7 @@ Similarly, printing a rune's value will yield its integer (decimal) value:
 ```go
 myRune := '¿'
 fmt.Printf("myRune value: %v\n", myRune)
-// => myRune value: 191
+// Output: myRune value: 191
 ```
 
 To print the Unicode character represented by the rune, use the `%c` formatting verb:
@@ -54,7 +54,7 @@ To print the Unicode character represented by the rune, use the `%c` formatting 
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode character: %c\n", myRune)
-// => myRune Unicode character: ¿
+// Output: myRune Unicode character: ¿
 ```
 
 To print the Unicode code point represented by the rune, use the `%U` formatting verb:
@@ -62,7 +62,7 @@ To print the Unicode code point represented by the rune, use the `%U` formatting
 ```go
 myRune := '¿'
 fmt.Printf("myRune Unicode code point: %U\n", myRune)
-// => myRune Unicode code point: U+00BF
+// Output: myRune Unicode code point: U+00BF
 ```
 
 ## Runes and Strings
@@ -76,7 +76,7 @@ myString := "❗hello"
 for index, char := range myString {
   fmt.Printf("Index: %d\tCharacter: %c\t\tCode Point: %U\n", index, char, char)
 }
-// =>
+// Output:
 // Index: 0	Character: ❗		Code Point: U+2757
 // Index: 3	Character: h		Code Point: U+0068
 // Index: 4	Character: e		Code Point: U+0065
@@ -95,5 +95,5 @@ stringLength := len(myString)
 numberOfRunes := utf8.RuneCountInString(myString)
 
 fmt.Printf("myString - Length: %d - Runes: %d\n", stringLength, numberOfRunes)
-// => myString - Length: 8 - Runes: 6
+// Output: myString - Length: 8 - Runes: 6
 ```

--- a/exercises/concept/logs-logs-logs/logs_logs_logs_test.go
+++ b/exercises/concept/logs-logs-logs/logs_logs_logs_test.go
@@ -31,9 +31,19 @@ func TestApplication(t *testing.T) {
 			want: "default",
 		},
 		{
-			name: "multiple characters recommendation",
+			name: "multiple characters recommendation(1/3)",
 			log:  "❗ recommended search product 🔍",
 			want: "recommendation",
+		},
+		{
+			name: "multiple characters recommendation(2/3)",
+			log:  "🔍 search recommended product ❗",
+			want: "search",
+		},
+		{
+			name: "multiple characters recommendation(3/3)",
+			log:  "☀ weather is sunny ❗",
+			want: "weather",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Jasstkn <mariia.kotliarevskaia@gmail.com>

Add more tests to cover case that is described here https://github.com/exercism/go/issues/2232

With logic from issue:
```golang
type Applications struct {
	Key   rune
	Value string
}

//mapping based on struct to have an as defined ordered array
var mapping = []Applications{
	{ Key:   '❗', Value: "recommendation" },
	{Key:   '🔍', Value: "search"},
	{Key:   '☀',Value: "weather"},
}

// Application identifies the application emitting the given log.
func Application(log string) string {
	for _, val := range mapping {
		if strings.ContainsRune(log, val.Key) {
			return val.Value
		}
	}
	return "default"
}
```

With new tests it catches case where the first element in the variable `mapping` isn't the same as in the input log for `Application` function.
```golang
--- FAIL: TestApplication (0.00s)
    --- FAIL: TestApplication/multiple_characters_recommendation(2/3) (0.00s)
        logs_logs_logs_test.go:53: Application("🔍 search recommended product ❗") = "recommendation", want "search"
    --- FAIL: TestApplication/multiple_characters_recommendation(3/3) (0.00s)
        logs_logs_logs_test.go:53: Application("☀ weather is sunny ❗") = "recommendation", want "weather"
```

Also it fixes formatting that is described here: #2202
