### PR TITLE
fix function arguments and parameters missmatch

### DIFF
--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -45,7 +45,7 @@ PrintGreetingName("Hello", "Katrina")
 
 ## Return Values
 
-The function arguments are followed by zero or more return values which must also be explicitly typed.
+The function parameters are followed by zero or more return values which must also be explicitly typed.
 Single return values are left bare, multiple return values are wrapped in parenthesis.
 Values are returned to the calling code from functions using the [`return` keyword][return].
 There can be multiple `return` statements in a function.

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -45,7 +45,7 @@ PrintGreetingName("Hello", "Katrina")
 
 ## Return Values
 
-The function arguments are followed by zero or more return values which must also be explicitly typed.
+The function parameters are followed by zero or more return values which must also be explicitly typed.
 Single return values are left bare, multiple return values are wrapped in parenthesis.
 Values are returned to the calling code from functions using the `return` keyword.
 There can be multiple `return` statements in a function.

--- a/exercises/concept/lasagna-master/.docs/introduction.md
+++ b/exercises/concept/lasagna-master/.docs/introduction.md
@@ -45,7 +45,7 @@ PrintGreetingName("Hello", "Katrina")
 
 ## Return Values
 
-The function arguments are followed by zero or more return values which must also be explicitly typed.
+The function parameters are followed by zero or more return values which must also be explicitly typed.
 Single return values are left bare, multiple return values are wrapped in parenthesis.
 Values are returned to the calling code from functions using the `return` keyword.
 There can be multiple `return` statements in a function.


### PR DESCRIPTION
I am afraid that there is a mismatch of "arguments" and "parameters" in the Functions introduction. Regarding the description above (Parameters vs. Arguments) the sentence discusses "parameters" instead of "arguments".