### PR TITLE
isbn_verifier task: run each test dataset in a separate TC

### DIFF
--- a/exercises/practice/isbn-verifier/isbn_verifier_test.go
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.go
@@ -6,13 +6,13 @@ import (
 
 func TestIsValidISBN(t *testing.T) {
 	for _, test := range testCases {
-		observed := IsValidISBN(test.isbn)
-		if observed == test.expected {
-			t.Logf("PASS: %s", test.description)
-		} else {
-			t.Errorf("FAIL: %s\nIsValidISBN(%q)\nExpected: %t, Actual: %t",
-				test.description, test.isbn, test.expected, observed)
-		}
+		t.Run(test.description, func(t *testing.T) {
+			observed := IsValidISBN(test.isbn)
+			if observed != test.expected {
+				t.Errorf("IsValidISBN(%q)\nExpected: %t, Actual: %t",
+					test.isbn, test.expected, observed)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes:
- made each dataset execute in a separate TC
It allows IDEs to differentiate test runs with different data. VS Code as an example below.
- removed PASS logs so only fails are displayed on `go test`

### Before

- CLI output

```
PS C:\Users\iavto\Documents\go\isbn-verifier> go test
--- FAIL: TestIsValidISBN (0.00s)
    isbn_verifier_test.go:25: FAIL: valid isbn number
        IsValidISBN("3-598-21508-8")
        Expected: true, Actual: false
    isbn_verifier_test.go:23: PASS: invalid isbn check digit
    isbn_verifier_test.go:23: PASS: valid isbn number with a check digit of 10
    isbn_verifier_test.go:23: PASS: check digit is a character other than X   
    isbn_verifier_test.go:23: PASS: invalid character in isbn
    isbn_verifier_test.go:23: PASS: X is only valid as a check digit
    isbn_verifier_test.go:25: FAIL: valid isbn without separating dashes      
        IsValidISBN("3598215088")
        Expected: true, Actual: false
    isbn_verifier_test.go:23: PASS: isbn without separating dashes and X as check digit
    isbn_verifier_test.go:23: PASS: isbn without check digit and dashes
    isbn_verifier_test.go:23: PASS: too long isbn and no dashes
    isbn_verifier_test.go:23: PASS: too short isbn
    isbn_verifier_test.go:23: PASS: isbn without check digit
    isbn_verifier_test.go:23: PASS: check digit of X should not be used for 0
    isbn_verifier_test.go:23: PASS: empty isbn
    isbn_verifier_test.go:23: PASS: input is 9 characters
    isbn_verifier_test.go:23: PASS: invalid characters are not ignored
    isbn_verifier_test.go:23: PASS: input is too long but contains a valid isbn
FAIL
exit status 1
FAIL    isbn    0.485s
```
- VS Code (no dataset visibility)

![image](https://user-images.githubusercontent.com/15168980/173111272-1212e14b-4200-4cce-b40e-31ed877590f0.png)

### After
- CLI output
```
PS C:\Users\iavto\Documents\go\isbn-verifier> go test
--- FAIL: TestIsValidISBN (0.00s)
    --- FAIL: TestIsValidISBN/valid_isbn_number (0.00s)
        isbn_verifier_test.go:12: IsValidISBN("3-598-21508-8")
            Expected: true, Actual: false
    --- FAIL: TestIsValidISBN/valid_isbn_without_separating_dashes (0.00s)
        isbn_verifier_test.go:12: IsValidISBN("3598215088")
            Expected: true, Actual: false
FAIL
exit status 1
FAIL    isbn    0.574s
```
- VS Code

![image](https://user-images.githubusercontent.com/15168980/173111653-7b61d4ca-b9c6-4c8f-8452-1e1fdbdb86da.png)
