### PR TITLE
elons-toys: improve description for first stage

### DIFF
--- a/exercises/concept/elons-toys/.docs/instructions.md
+++ b/exercises/concept/elons-toys/.docs/instructions.md
@@ -27,7 +27,7 @@ car.Drive()
 // car is now Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
 ```
 
-Note: If as a result of execution `car.Drive()` car's battery is below 0, you can't drive the car anymore.
+Note: You should not try to drive the car if doing so will cause the car's battery to be below 0.
 
 ## 2. Display the distance driven
 

--- a/exercises/concept/elons-toys/.docs/instructions.md
+++ b/exercises/concept/elons-toys/.docs/instructions.md
@@ -27,7 +27,7 @@ car.Drive()
 // car is now Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
 ```
 
-Note: If a car's battery is below its battery drain percentage, you can't drive the car anymore.
+Note: If as a result of execution `car.Drive()` car's battery is below 0, you can't drive the car anymore.
 
 ## 2. Display the distance driven
 


### PR DESCRIPTION
It seems to be not clear what does the note mean:
> Note: If a car's battery is below **its battery drain percentage**, you can't drive the car anymore.

Changed to the more clear definition. 

Signed-off-by: Jasstkn <mariia.kotliarevskaia@gmail.com>