### PR TITLE
Added the test-cases from canonical-data.json to exercise diamond

### DIFF
--- a/exercises/practice/diamond/.meta/example.go
+++ b/exercises/practice/diamond/.meta/example.go
@@ -24,7 +24,7 @@ func gen(char byte) string {
 	for i := currentIndex - 1; i > -1; i-- {
 		output = append(output, getLine(currentIndex, i))
 	}
-	return strings.Join(output, "\n") + "\n"
+	return strings.Join(output, "\n")
 }
 
 func getLine(currentStart, current int) string {

--- a/exercises/practice/diamond/.meta/example.go
+++ b/exercises/practice/diamond/.meta/example.go
@@ -24,7 +24,7 @@ func gen(char byte) string {
 	for i := currentIndex - 1; i > -1; i-- {
 		output = append(output, getLine(currentIndex, i))
 	}
-	return strings.Join(output, "\n")
+	return strings.Join(output, "\n") + "\n"
 }
 
 func getLine(currentStart, current int) string {

--- a/exercises/practice/diamond/.meta/gen.go
+++ b/exercises/practice/diamond/.meta/gen.go
@@ -38,10 +38,12 @@ var testCases = []struct {
 	description string
 	input       string
 	expected    []string
+	expectedError error
 }{
 {{range .J.Cases}}{
 		description: {{printf "%q"   .Description}},
 	input: {{printf "%q"   .Input.Letter}},
+	expectedError: nil,
 	expected: []string { {{range $line := .Expected}}{{printf "\n%q," $line}}{{end}}
 },
 },

--- a/exercises/practice/diamond/.meta/gen.go
+++ b/exercises/practice/diamond/.meta/gen.go
@@ -29,14 +29,6 @@ type js struct {
 	} `json:"cases"`
 }
 
-/*
-type testCases struct {
-	description string
-	input       string
-	expected    []string
-}
-*/
-
 // template applied to above data structure generates the Go test cases
 var tmpl = `package diamond
 

--- a/exercises/practice/diamond/.meta/gen.go
+++ b/exercises/practice/diamond/.meta/gen.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("diamond", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string `json:"description"`
+		Input       struct {
+			Letter string `json:"letter"`
+		} `json:"input"`
+		Expected []string `json:"expected"`
+	} `json:"cases"`
+}
+
+/*
+type testCases struct {
+	description string
+	input       string
+	expected    []string
+}
+*/
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package diamond
+
+{{.Header}}
+
+var testCases = []struct {
+	description string
+	input       string
+	expected    []string
+}{
+{{range .J.Cases}}{
+		description: {{printf "%q"   .Description}},
+	input: {{printf "%q"   .Input.Letter}},
+	expected: []string { {{range $line := .Expected}}{{printf "\n%q," $line}}{{end}}
+},
+},
+{{end}}
+}`

--- a/exercises/practice/diamond/.meta/tests.toml
+++ b/exercises/practice/diamond/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [202fb4cc-6a38-4883-9193-a29d5cb92076]
 description = "Degenerate case with a single 'A' row"

--- a/exercises/practice/diamond/cases_test.go
+++ b/exercises/practice/diamond/cases_test.go
@@ -1,0 +1,108 @@
+package diamond
+
+// Source: exercism/problem-specifications
+// Commit: d137db1 Format using prettier (#1917)
+
+var testCases = []struct {
+	description string
+	input       string
+	expected    []string
+}{
+	{
+		description: "Degenerate case with a single 'A' row",
+		input:       "A",
+		expected: []string{
+			"A",
+		},
+	},
+	{
+		description: "Degenerate case with no row containing 3 distinct groups of spaces",
+		input:       "B",
+		expected: []string{
+			" A ",
+			"B B",
+			" A ",
+		},
+	},
+	{
+		description: "Smallest non-degenerate case with odd diamond side length",
+		input:       "C",
+		expected: []string{
+			"  A  ",
+			" B B ",
+			"C   C",
+			" B B ",
+			"  A  ",
+		},
+	},
+	{
+		description: "Smallest non-degenerate case with even diamond side length",
+		input:       "D",
+		expected: []string{
+			"   A   ",
+			"  B B  ",
+			" C   C ",
+			"D     D",
+			" C   C ",
+			"  B B  ",
+			"   A   ",
+		},
+	},
+	{
+		description: "Largest possible diamond",
+		input:       "Z",
+		expected: []string{
+			"                         A                         ",
+			"                        B B                        ",
+			"                       C   C                       ",
+			"                      D     D                      ",
+			"                     E       E                     ",
+			"                    F         F                    ",
+			"                   G           G                   ",
+			"                  H             H                  ",
+			"                 I               I                 ",
+			"                J                 J                ",
+			"               K                   K               ",
+			"              L                     L              ",
+			"             M                       M             ",
+			"            N                         N            ",
+			"           O                           O           ",
+			"          P                             P          ",
+			"         Q                               Q         ",
+			"        R                                 R        ",
+			"       S                                   S       ",
+			"      T                                     T      ",
+			"     U                                       U     ",
+			"    V                                         V    ",
+			"   W                                           W   ",
+			"  X                                             X  ",
+			" Y                                               Y ",
+			"Z                                                 Z",
+			" Y                                               Y ",
+			"  X                                             X  ",
+			"   W                                           W   ",
+			"    V                                         V    ",
+			"     U                                       U     ",
+			"      T                                     T      ",
+			"       S                                   S       ",
+			"        R                                 R        ",
+			"         Q                               Q         ",
+			"          P                             P          ",
+			"           O                           O           ",
+			"            N                         N            ",
+			"             M                       M             ",
+			"              L                     L              ",
+			"               K                   K               ",
+			"                J                 J                ",
+			"                 I               I                 ",
+			"                  H             H                  ",
+			"                   G           G                   ",
+			"                    F         F                    ",
+			"                     E       E                     ",
+			"                      D     D                      ",
+			"                       C   C                       ",
+			"                        B B                        ",
+			"                         A                         ",
+		},
+	},
+}

--- a/exercises/practice/diamond/cases_test.go
+++ b/exercises/practice/diamond/cases_test.go
@@ -4,20 +4,23 @@ package diamond
 // Commit: d137db1 Format using prettier (#1917)
 
 var testCases = []struct {
-	description string
-	input       string
-	expected    []string
+	description   string
+	input         string
+	expected      []string
+	expectedError error
 }{
 	{
-		description: "Degenerate case with a single 'A' row",
-		input:       "A",
+		description:   "Degenerate case with a single 'A' row",
+		input:         "A",
+		expectedError: nil,
 		expected: []string{
 			"A",
 		},
 	},
 	{
-		description: "Degenerate case with no row containing 3 distinct groups of spaces",
-		input:       "B",
+		description:   "Degenerate case with no row containing 3 distinct groups of spaces",
+		input:         "B",
+		expectedError: nil,
 		expected: []string{
 			" A ",
 			"B B",
@@ -25,8 +28,9 @@ var testCases = []struct {
 		},
 	},
 	{
-		description: "Smallest non-degenerate case with odd diamond side length",
-		input:       "C",
+		description:   "Smallest non-degenerate case with odd diamond side length",
+		input:         "C",
+		expectedError: nil,
 		expected: []string{
 			"  A  ",
 			" B B ",
@@ -36,8 +40,9 @@ var testCases = []struct {
 		},
 	},
 	{
-		description: "Smallest non-degenerate case with even diamond side length",
-		input:       "D",
+		description:   "Smallest non-degenerate case with even diamond side length",
+		input:         "D",
+		expectedError: nil,
 		expected: []string{
 			"   A   ",
 			"  B B  ",
@@ -49,8 +54,9 @@ var testCases = []struct {
 		},
 	},
 	{
-		description: "Largest possible diamond",
-		input:       "Z",
+		description:   "Largest possible diamond",
+		input:         "Z",
+		expectedError: nil,
 		expected: []string{
 			"                         A                         ",
 			"                        B B                        ",

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -1,6 +1,7 @@
 package diamond
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -221,12 +222,13 @@ func TestCharOutOfRangeShouldGiveError(t *testing.T) {
 
 func TestDiamond(t *testing.T) {
 	for _, testCase := range testCases {
-		got, _ := Gen([]byte(testCase.input)[0])
+		t.Run(testCase.description, func(t *testing.T) {
+			expected := fmt.Sprintf("%s\n", strings.Join(testCase.expected, "\n"))
+			got, _ := Gen([]byte(testCase.input)[0])
 
-		if got != strings.Join(testCase.expected, "\n") {
-			t.Fatalf("Gen(%s): %s\n\t Expected: %s\n\t Got: %s", testCase.input, testCase.description, strings.Join(testCase.expected, "\n"), got)
-		} else {
-			t.Logf("PASS: Gen(%s)", testCase.input)
-		}
+			if got != expected {
+				t.Fatalf("Gen(%q): %q\n\t Expected: %q\n\t Got: %q", testCase.input, testCase.description, expected, got)
+			}
+		})
 	}
 }

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -28,10 +28,10 @@ func checkCorrect(requirement func(byte, []string) bool, keepSeparator bool, t *
 			separator = strings.SplitAfter
 		}
 		rows := separator(d, "\n")
-		if len(rows) < 2 {
+		if len(rows) < 1 {
 			return false
 		}
-		return requirement(byte(char), rows[:len(rows)-1])
+		return requirement(byte(char), rows)
 	}
 	if err := quick.Check(assertion, config); err != nil {
 		t.Error(err)
@@ -103,7 +103,7 @@ func TestDiamondIsHorizontallySymmetric(t *testing.T) {
 func TestDiamondIsVerticallySymmetric(t *testing.T) {
 	requirement := func(char byte, rows []string) bool {
 		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
-			if rows[i] != rows[j] {
+			if strings.TrimSpace(rows[i]) != strings.TrimSpace(rows[j]) {
 				return false
 			}
 		}

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -226,11 +226,11 @@ func TestDiamond(t *testing.T) {
 			expected := fmt.Sprintf("%s\n", strings.Join(testCase.expected, "\n"))
 			got, err := Gen(testCase.input[0])
 
+			if err != testCase.expectedError {
+				t.Fatalf("Gen(%q)\nExpected:%v\nGot:%v", testCase.input, testCase.expectedError, err)
+			}
 			if got != expected {
-				t.Fatalf("Gen(%q)\nExpected:\n%s\n(len=%d)\nGot:\n%s\n(len=%d)",
-					testCase.input,
-					expected, len(expected),
-					got, len(got))
+				t.Fatalf("Gen(%q)\nExpected:\n%s\n(len=%d)\nGot:\n%s\n(len=%d)", testCase.input, expected, len(expected), got, len(got))
 			}
 		})
 	}

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -39,6 +39,22 @@ func checkCorrect(requirement func(byte, []string) bool, keepSeparator bool, t *
 	}
 }
 
+func TestDiamond(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			expected := fmt.Sprintf("%s\n", strings.Join(testCase.expected, "\n"))
+			got, err := Gen(testCase.input[0])
+
+			if err != testCase.expectedError {
+				t.Fatalf("Gen(%q)\nExpected:%v\nGot:%v", testCase.input, testCase.expectedError, err)
+			}
+			if got != expected {
+				t.Fatalf("Gen(%q)\nExpected:\n%s\n(len=%d)\nGot:\n%s\n(len=%d)", testCase.input, expected, len(expected), got, len(got))
+			}
+		})
+	}
+}
+
 func TestFirstRowContainsOneA(t *testing.T) {
 	requirement := func(char byte, rows []string) bool {
 		return len(rows) > 0 && strings.Count(rows[0], "A") == 1
@@ -217,21 +233,5 @@ func TestCharOutOfRangeShouldGiveError(t *testing.T) {
 	}
 	if err := quick.Check(assertion, config); err != nil {
 		t.Error(err)
-	}
-}
-
-func TestDiamond(t *testing.T) {
-	for _, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
-			expected := fmt.Sprintf("%s\n", strings.Join(testCase.expected, "\n"))
-			got, err := Gen(testCase.input[0])
-
-			if err != testCase.expectedError {
-				t.Fatalf("Gen(%q)\nExpected:%v\nGot:%v", testCase.input, testCase.expectedError, err)
-			}
-			if got != expected {
-				t.Fatalf("Gen(%q)\nExpected:\n%s\n(len=%d)\nGot:\n%s\n(len=%d)", testCase.input, expected, len(expected), got, len(got))
-			}
-		})
 	}
 }

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -218,3 +218,15 @@ func TestCharOutOfRangeShouldGiveError(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestDiamond(t *testing.T) {
+	for _, testCase := range testCases {
+		got, _ := Gen([]byte(testCase.input)[0])
+
+		if got != strings.Join(testCase.expected, "\n") {
+			t.Fatalf("Gen(%s): %s\n\t Expected: %s\n\t Got: %s", testCase.input, testCase.description, strings.Join(testCase.expected, "\n"), got)
+		} else {
+			t.Logf("PASS: Gen(%s)", testCase.input)
+		}
+	}
+}

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -224,7 +224,7 @@ func TestDiamond(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			expected := fmt.Sprintf("%s\n", strings.Join(testCase.expected, "\n"))
-			got, _ := Gen([]byte(testCase.input)[0])
+			got, err := Gen(testCase.input[0])
 
 			if got != expected {
 				t.Fatalf("Gen(%q): %q\n\t Expected: %q\n\t Got: %q", testCase.input, testCase.description, expected, got)

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -227,7 +227,10 @@ func TestDiamond(t *testing.T) {
 			got, err := Gen(testCase.input[0])
 
 			if got != expected {
-				t.Fatalf("Gen(%q): %q\n\t Expected: %q\n\t Got: %q", testCase.input, testCase.description, expected, got)
+				t.Fatalf("Gen(%q)\nExpected:\n%s\n(len=%d)\nGot:\n%s\n(len=%d)",
+					testCase.input,
+					expected, len(expected),
+					got, len(got))
 			}
 		})
 	}

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -28,10 +28,10 @@ func checkCorrect(requirement func(byte, []string) bool, keepSeparator bool, t *
 			separator = strings.SplitAfter
 		}
 		rows := separator(d, "\n")
-		if len(rows) < 1 {
+		if len(rows) < 2 {
 			return false
 		}
-		return requirement(byte(char), rows)
+		return requirement(byte(char), rows[:len(rows)-1])
 	}
 	if err := quick.Check(assertion, config); err != nil {
 		t.Error(err)
@@ -103,7 +103,7 @@ func TestDiamondIsHorizontallySymmetric(t *testing.T) {
 func TestDiamondIsVerticallySymmetric(t *testing.T) {
 	requirement := func(char byte, rows []string) bool {
 		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
-			if strings.TrimSpace(rows[i]) != strings.TrimSpace(rows[j]) {
+			if rows[i] != rows[j] {
 				return false
 			}
 		}


### PR DESCRIPTION
Hey, I have done the following steps:

- added a test-case generator for the test-cases defined in [canonical-data.json](https://github.com/exercism/problem-specifications/blob/main/exercises/diamond/canonical-data.json) in `gen.go`
- regenerated the `tests.toml` using configlet
- generated the `cases_test.go` using the `gen.go`
- added `func TestDiamond` using this test-cases

I additionally adjusted the existing tests, as they expected a `\n` at the end. Regarding to the `instructions.md` there should not be a new-line at the end, for example:
Diamond for letter 'E':
```text
····A····
···B·B···
··C···C··
·D·····D·
E·······E
·D·····D·
··C···C··
···B·B···
····A····
```

Reach out to me if this change should be reverted and a `\n` should be expected at the end.

Closes #2222 