### PR TITLE
concepts/type-assertion: fix change fmt.Println to fmt.Printf and improve type switch example

### DIFF
--- a/concepts/type-assertion/about.md
+++ b/concepts/type-assertion/about.md
@@ -40,12 +40,14 @@ It has the same syntax as a type assertion (`interfaceVariable.(concreteType)`),
 Here is an example:
 
 ```go
+var i interface{} = 12 // try: 12.3, true, int64(12), []int{}, map[string]int{}
+
 switch v := i.(type) {
 case int:
-    fmt.Println("the integer %d", v)
+    fmt.Printf("the integer %d\n", v)
 case string:
-    fmt.Println("the string %s", v)
+    fmt.Printf("the string %s\n", v)
 default:
-    fmt.Println("some type we did not handle explicitly")
+    fmt.Printf("type, %T, not handled explicitly: %#v\n", v, v)
 }
 ```

--- a/concepts/type-assertion/introduction.md
+++ b/concepts/type-assertion/introduction.md
@@ -30,12 +30,14 @@ It has the same syntax as a type assertion (`interfaceVariable.(concreteType)`),
 Here is an example:
 
 ```go
+var i interface{} = 12 // try: 12.3, true, int64(12), []int{}, map[string]int{}
+
 switch v := i.(type) {
 case int:
-    fmt.Println("the integer %d", v)
+    fmt.Printf("the integer %d\n", v)
 case string:
-    fmt.Println("the string %s", v)
+    fmt.Printf("the string %q\n", v)
 default:
-    fmt.Println("some type we did not handle explicitly")
+    fmt.Printf("type, %T, not handled explicitly: %#v\n", v, v)
 }
 ```

--- a/exercises/concept/sorting-room/.docs/introduction.md
+++ b/exercises/concept/sorting-room/.docs/introduction.md
@@ -57,12 +57,14 @@ It has the same syntax as a type assertion (`interfaceVariable.(concreteType)`),
 Here is an example:
 
 ```go
+var i interface{} = 12 // try: 12.3, true, int64(12), []int{}, map[string]int{}
+
 switch v := i.(type) {
 case int:
-    fmt.Println("the integer %d", v)
+    fmt.Printf("the integer %d\n", v)
 case string:
-    fmt.Println("the string %s", v)
+    fmt.Printf("the string %s\n", v)
 default:
-    fmt.Println("some type we did not handle explicitly")
+    fmt.Printf("type, %T, not handled explicitly: %#v\n", v, v)
 }
 ```


### PR DESCRIPTION
While reading the [Type Assertion](https://exercism.org/tracks/go/concepts/type-assertion) for the [Sorting Room](https://exercism.org/tracks/go/exercises/sorting-room) exercise I noticed that the [Type Switch example](https://exercism.org/tracks/go/concepts/type-assertion#:~:text=default%20value%22%0A%7D-,Type%20Switches,-A%20type%20switch) is using `Println` with `Printf` format strings.

```go
switch v := i.(type) {
case int:
    fmt.Println("the integer %d", v)
case string:
    fmt.Println("the string %s", v)
default:
    fmt.Println("some type we did not handle explicitly")
}
```

This pull-request fixes that in two files and improves the example a little.

