### PR TITLE
Fixed "Output" (#2202) - Some Remaining files

### DIFF
--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -5,16 +5,16 @@ Booleans in Go are represented by the `bool` type, which values can be either `t
 Go supports three [boolean operators][logical operators]: `!` (NOT), `&&` (AND), and `||` (OR).
 
 ```go
-true || false // Output: true
-true && false // Output: false
-!true // Output: false
+true || false // => true
+true && false // => false
+!true // => false
 ```
 
 The three boolean operators each have a different [_operator precedence_][operators]. As a consequence, they are evaluated in this order: `!` first, `&&` second, and finally `||`. If you want to 'escape' these rules, you can enclose a boolean expression in parentheses (`()`), as the parentheses have an even higher operator precedence.
 
 ```go
-!true && false   // Output: false
-!(true && false) // Output: true
+!true && false   // => false
+!(true && false) // => true
 ```
 
 [operators]: https://golang.org/ref/spec#Operators

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -6,9 +6,9 @@ A `bool` is either `true` or `false`.
 Go supports three boolean operators: `!` (NOT), `&&` (AND), and `||` (OR).
 
 ```go
-true || false // Output: true
-true && false // Output: false
-!true // Output: false
+true || false // => true
+true && false // => false
+!true // => false
 ```
 
 The three boolean operators each have a different _operator precedence_.
@@ -16,6 +16,6 @@ As a consequence, they are evaluated in this order: `!` first, `&&` second, and 
 If you want to force a different ordering, you can enclose a boolean expression in parentheses (ie. `()`), as the parentheses have an even higher operator precedence.
 
 ```go
-!true && false   // Output: false
-!(true && false) // Output: true
+!true && false   // => false
+!(true && false) // => true
 ```

--- a/concepts/strings-package/about.md
+++ b/concepts/strings-package/about.md
@@ -17,7 +17,7 @@ The [`strings` package](https://pkg.go.dev/strings) contains many useful functio
 ```go
 import "strings"
 
-strings.ToLower("Gopher")    // Output: "gopher"
-strings.Index("Apple", "le") // Output: 3
-strings.Count("test", "t")   // Output: 2
+strings.ToLower("Gopher")    // => "gopher"
+strings.Index("Apple", "le") // => 3
+strings.Count("test", "t")   // => 2
 ```

--- a/concepts/strings-package/introduction.md
+++ b/concepts/strings-package/introduction.md
@@ -5,5 +5,5 @@ The `strings` package contains many useful functions to work on strings.
 ```go
 import "strings"
 
-strings.ToUpper("test") // Output: "TEST"
+strings.ToUpper("test") // => "TEST"
 ```


### PR DESCRIPTION
Replace "Output:" for "=>" in some remaining files

Related issue: #2202 