### PR TITLE
Fix headers in bank account instructions append

### DIFF
--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,23 +1,25 @@
 # Instructions append
 
-## Opening an account
+## Implementation Notes
+
+### Opening an account
 
 An account can be opened. On opening, its initial balance should not be negative. If a negative balance is given to the `Open` function, `nil` must be returned, otherwise the newly created account must be returned.
 
-## Closing an account
+### Closing an account
 
 An account can be closed. When closing an account, the `Close` method must return the balance the account has and a boolean `true` indicating the account was closed successfully. Closing an account does not succeed if the account is already closed. When an account is closed, its balance must be set to `0`.
 
-## Getting the account balance
+### Getting the account balance
 
 The `Balance` method allows a user to check the current balance of an account. It must return the balance of the account and a boolean indicating if the operation succeeded. Checking the balance only doesn't succeed if the account is closed.
 
-## Deposits / Withrawals
+### Deposits / Withrawals
 
 Deposits and withdrawals are both handled by the `Deposit` method. If the argument given to the method it's a positive amount, then that amount of money must be deposited in the account. If the amount given is negative, that amount of money must be withdrawn from the account.
 The return value of `Deposit` indicates if the operation succeeded. A deposit always succeeds, however a withdrawal might fail if there is not enough money in the account.
 
-## Implementation Notes
+## Testing
 
 The tests will execute some operations concurrently. You should strive
 to ensure that operations on the Account leave it in a consistent state.
@@ -32,6 +34,8 @@ data races, run tests with `-race` flag on.
 $ cd exercism/project/directory/go/bank-account
 $ go test -race
 ```
+
+## Resources
 
 If you are new to concurrent operations in Go it will be worth looking
 at the sync package, specifically Mutexes:


### PR DESCRIPTION
The h2 header that differentiates the problem spec instructions from the language specific one was removed with https://github.com/exercism/go/pull/2260. Now the rendered instructions on the website look strange because after "Have fun!" there is "Opening an account". https://exercism.org/tracks/go/exercises/bank-account 

This PR changes the headers so they should result in a better flow when put together with the canonical instructions.