### PR TITLE
Add punctuation to function comments in concept instructions

### DIFF
--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -70,12 +70,12 @@ Single line comments are preceded by `//` and multiline comments are inserted be
 ```go
 package greeting
 
-// Hello is a public function
+// Hello is a public function.
 func Hello (name string) string {
     return hi(name)
 }
 
-// hi is a private function
+// hi is a private function.
 func hi (name string) string {
     return "hi " + name
 }


### PR DESCRIPTION
This does not fix an open issue, and is not strictly necessary.

I noticed as I was going through the introductory Hello World exercise that the doc comments in the instructions didn't follow the best practices that we're trying to encourage people to follow. This adds punctuation to a couple of example function comments.