### PR TITLE
improved output for simple_cipher test

### DIFF
--- a/exercises/practice/simple-cipher/simple_cipher_test.go
+++ b/exercises/practice/simple-cipher/simple_cipher_test.go
@@ -23,7 +23,7 @@ func TestCaesarPrepped(t *testing.T) {
 	c := NewCaesar()
 	for _, test := range caesarPrepped {
 		if enc := c.Encode(test.pt); enc != test.ct {
-			t.Fatalf("Caesar Encode(%q) = %q, want %q.", test.pt, enc, test.ct)
+			t.Errorf("Caesar Encode(%q) = %q, want %q.", test.pt, enc, test.ct)
 		}
 	}
 }
@@ -55,11 +55,11 @@ func TestCaesar(t *testing.T) {
 func testCipher(name string, c Cipher, tests []cipherTest, t *testing.T) {
 	for _, test := range tests {
 		if enc := c.Encode(test.source); enc != test.cipher {
-			t.Fatalf("%s Encode(%q) = %q, want %q.",
-				name, test.plain, enc, test.cipher)
+			t.Errorf("%s Encode(%q) = %q, want %q.",
+				name, test.source, enc, test.cipher)
 		}
 		if dec := c.Decode(test.cipher); dec != test.plain {
-			t.Fatalf("%s Decode(%q) = %q, want %q.",
+			t.Errorf("%s Decode(%q) = %q, want %q.",
 				name, test.cipher, dec, test.plain)
 		}
 	}


### PR DESCRIPTION
### Fixes
- made tests to output all failed data examples instead of one only

_Before_
```
=== RUN   TestShift
    simple_cipher_test.go:58: Shift(3) Encode("Go, go, gophers") = "jrWjrWjrskhuv", want "jrjrjrskhuv".
```
_Now_
```
=== RUN   TestShift
    simple_cipher_test.go:58: Shift(3) Encode("Go, go, gophers") = "jrWjrWjrskhuv", want "jrjrjrskhuv".
    simple_cipher_test.go:58: Shift(3) Encode("I am a panda bear.") = "lWdpWdWsdqgdWehdu", want "ldpdsdqgdehdu".
    simple_cipher_test.go:58: Shift(3) Encode("Programming is AWESOME!") = "surjudpplqjWlvWdzhvrph", want "surjudpplqjlvdzhvrph". 
```
- changed Encode test error log to contain an original string instead of the one with cleared extra symbols

_Before_
```
simple_cipher_test.go:26: Caesar Encode("todayisholiday") = "wrgdlvkrolgd", want "wrgdblvkrolgdb".
```
_Now_
```
simple_cipher_test.go:58: Caesar Encode("today is holiday") = "wrgdlvkrolgd", want "wrgdblvkrolgdb".
```

Related issue: #2098