### PR TITLE
added struct literal example as a counterpart to `new` buitin

### DIFF
--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -77,6 +77,16 @@ s := Shape{
 // Output: too few values in Shape{...}
 ```
 
+To create an instance of a `struct` and get a pointer to it use a struct literal:
+
+```go
+s := &Shape {
+    name: "Square",
+    size: 25,
+}
+// s type is *Shape
+```
+
 ## "New" functions
 
 Sometimes it can be nice to have functions that help us create struct instances.

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -77,6 +77,16 @@ s := Shape{
 // Output: too few values in Shape{...}
 ```
 
+To create an instance of a `struct` and get a pointer to it use a struct literal:
+
+```go
+s := &Shape {
+    name: "Square",
+    size: 25,
+}
+// s type is *Shape
+```
+
 ## "New" functions
 
 Sometimes it can be nice to have functions that help us create struct instances.


### PR DESCRIPTION
Hi all,
since this struct intro aritcle contains "`new` builtin" section that reasons that `new` is not a great way to instantiate a struct, maybe it makes sense to add a struct literal alternative to it? 