### PR TITLE
Additional test cases for logs-logs-logs

### DIFF
--- a/exercises/concept/logs-logs-logs/logs_logs_logs_test.go
+++ b/exercises/concept/logs-logs-logs/logs_logs_logs_test.go
@@ -121,6 +121,24 @@ func TestWithinLimit(t *testing.T) {
 			limit: 8,
 			want:  false,
 		},
+		{
+			name:  "exact limit",
+			log:   "exercism🔍",
+			limit: 9,
+			want:  true,
+		},
+		{
+			name:  "under limit",
+			log:   "exercism🔍",
+			limit: 10,
+			want:  true,
+		},
+		{
+			name:  "exact limit",
+			log:   "exercism🔍",
+			limit: 8,
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/exercises/concept/logs-logs-logs/logs_logs_logs_test.go
+++ b/exercises/concept/logs-logs-logs/logs_logs_logs_test.go
@@ -134,7 +134,7 @@ func TestWithinLimit(t *testing.T) {
 			want:  true,
 		},
 		{
-			name:  "exact limit",
+			name:  "over limit",
 			log:   "exercism🔍",
 			limit: 8,
 			want:  false,


### PR DESCRIPTION
Fixes #2292

- added more test cases for exercise in accordance with [issue](https://github.com/exercism/go/issues/2292)

This hardcoded function was able to pass all tests.

```
func WithinLimit(log string, limit int) bool {
	return limit >= len(log)-2
}
```
_Before_

```
PASS
ok      test    0.001s
```

_Now_ 

```
--- FAIL: TestWithinLimit (0.00s)
    --- FAIL: TestWithinLimit/exact_limit#01 (0.00s)
        main_test.go:147: WithinLimit("exercism🔍", 9) = false, want true
FAIL
exit status 1
FAIL    test    0.002s
```

