### PR TITLE
Pin actions to SHAs

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -31,9 +31,9 @@ jobs:
             race: ''
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/gomod-sync.yml
+++ b/.github/workflows/gomod-sync.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
         with:
           go-version: 1.17
 

--- a/.github/workflows/stale-contributor.yml
+++ b/.github/workflows/stale-contributor.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Ignore issues

--- a/.github/workflows/stale-maintainer.yml
+++ b/.github/workflows/stale-maintainer.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Ignore issues


### PR DESCRIPTION
Makes actions pinned to SHAs instead of versions, as recommended by [Exercism Docs: GHA Best Practices](https://exercism.org/docs/building/github/gha-best-practices).

Commit references:

- [actions/setup-go@v3.2.0](https://github.com/actions/setup-go/releases/tag/v3.2.0)
- [actions/chekout@v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2)
- [actions/stale@5.0.0](https://github.com/actions/stale/releases/tag/v5.0.0)