### PR TITLE
parsing-log-files: added test case

### DIFF
--- a/exercises/concept/parsing-log-files/.meta/config.json
+++ b/exercises/concept/parsing-log-files/.meta/config.json
@@ -3,6 +3,7 @@
      "norbs57" 
   ],
   "contributors": [
+    "eklatzer"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/parsing-log-files/parsing_log_files_test.go
+++ b/exercises/concept/parsing-log-files/parsing_log_files_test.go
@@ -33,6 +33,11 @@ func TestIsValidLine(t *testing.T) {
 			text:        "[BOB] Any old text",
 			expected:    false,
 		},
+		{
+			description: "Line with less characters than 5",
+			text:        "text",
+			expected:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {

--- a/exercises/concept/parsing-log-files/parsing_log_files_test.go
+++ b/exercises/concept/parsing-log-files/parsing_log_files_test.go
@@ -38,6 +38,11 @@ func TestIsValidLine(t *testing.T) {
 			text:        "text",
 			expected:    false,
 		},
+		{
+			description: "Empty line",
+			text:        "",
+			expected:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {


### PR DESCRIPTION
Hey, when doing the exercise `parsing-log-files` I have seen that the following solution passes all tests:
```
var validLinePrefixes = map[string]struct{}{"[TRC]": {}, "[DBG]": {}, "[INF]": {}, "[WRN]": {}, "[ERR]": {}, "[FTL]": {}}

func IsValidLine(text string) bool {
	_, validPrefix := validLinePrefixes[text[:5]]
	return validPrefix
}
```
Therefore I have added a test case that is covering a line that is shorter than 5 characters
