### PR TITLE
census: added test case

### DIFF
--- a/exercises/concept/census/.meta/config.json
+++ b/exercises/concept/census/.meta/config.json
@@ -5,7 +5,8 @@
     "sudomateo"
   ],
   "contributors": [
-    "tehsphinx"
+    "tehsphinx",
+    "eklatzer"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -105,6 +105,16 @@ func TestHasRequiredInfo(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "unknown key with value that is not empty",
+			resident: &Resident{
+				Name: "Rob Pike",
+				Address: map[string]string{
+					"unknown key": "with value",
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hey, when mentoring I got the following solution:
```
// HasRequiredInfo determines if a given resident has all of the required information.
func (r *Resident) HasRequiredInfo() bool {
	if r.Name == "" {
        return false
    }
    for _, v := range r.Address{
        if v != "" {
            return true
        }
    }
	return false
}
```
Instructions: In order to be counted, a resident must provide a non-zero value for their name and an address that contains a non-zero value for the `street` key.
It only checks if any key in `r.Address` is set, but not if `street` is set and this passes the tests.

Therefore I have added a test case