### PR TITLE
[Functions Concept]: Added word statements to the return section for clarity

### DIFF
--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -49,7 +49,7 @@ The function parameters are followed by zero or more return values which must al
 Single return values are left bare, multiple return values are wrapped in parenthesis.
 Values are returned to the calling code from functions using the [`return` keyword][return].
 There can be multiple `return` statements in a function.
-The execution of the function ends as soon as it hits one of those `return`s.
+The execution of the function ends as soon as it hits one of those `return` statements.
 If multiple values are to be returned from a function, they are comma separated.
 More information about idiomatic use of [multiple return values][concept-multiple-return-values] can be found in the linked concept.
 

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -49,7 +49,7 @@ The function parameters are followed by zero or more return values which must al
 Single return values are left bare, multiple return values are wrapped in parenthesis.
 Values are returned to the calling code from functions using the `return` keyword.
 There can be multiple `return` statements in a function.
-The execution of the function ends as soon as it hits one of those `return`s.
+The execution of the function ends as soon as it hits one of those `return` statements.
 If multiple values are to be returned from a function, they are comma separated.
 
 ```go

--- a/exercises/concept/lasagna-master/.docs/introduction.md
+++ b/exercises/concept/lasagna-master/.docs/introduction.md
@@ -49,7 +49,7 @@ The function parameters are followed by zero or more return values which must al
 Single return values are left bare, multiple return values are wrapped in parenthesis.
 Values are returned to the calling code from functions using the `return` keyword.
 There can be multiple `return` statements in a function.
-The execution of the function ends as soon as it hits one of those `return`s.
+The execution of the function ends as soon as it hits one of those `return` statements.
 If multiple values are to be returned from a function, they are comma separated.
 
 ```go


### PR DESCRIPTION
Noticed when working through the Functions concept exercise that the `functions` concept doc has a weird break in it:

<image src="https://user-images.githubusercontent.com/5923094/178777530-037c4fec-5413-4e34-a411-9308d1df5233.png" width=500px>

<br>

Added the word `statements` in place of the `s` for clarity.