### PR TITLE
anagram: updated exercise generator to new test generator

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,8 +1,13 @@
 # Instructions
 
-An anagram is a rearrangement of letters to form a new word.
-Given a word and a list of candidates, select the sublist of anagrams of the given word.
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
 
-Given `"listen"` and a list of candidates like `"enlists" "google"
-"inlets" "banana"` the program should return a list containing
-`"inlets"`.
+Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -20,7 +20,8 @@
     "sebito91",
     "strangeman",
     "tleen",
-    "tompao"
+    "tompao",
+    "eklatzer"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/anagram/.meta/gen.go
+++ b/exercises/practice/anagram/.meta/gen.go
@@ -12,28 +12,21 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	var j js
-	if err := gen.Gen("anagram", &j, t); err != nil {
+	var j = map[string]interface{}{
+		"findAnagrams": &[]testCase{},
+	}
+	if err := gen.Gen("anagram", j, t); err != nil {
 		log.Fatal(err)
 	}
 }
 
-// The JSON structure we expect to be able to unmarshal into
-type js struct {
-	Exercise string
-	Version  string
-	Comments []string
-	Cases    []OneCase
-}
-
-// The JSON structure we expect to be able to unmarshal into
-type OneCase struct {
-	Description string
+type testCase struct {
+	Description string `json:"description"`
 	Input       struct {
-		Subject    string
-		Candidates []string
-	}
-	Expected []string
+		Subject    string   `json:"subject"`
+		Candidates []string `json:"candidates"`
+	} `json:"input"`
+	Expected []string `json:"expected"`
 }
 
 // template applied to above data structure generates the Go test cases
@@ -46,12 +39,12 @@ var testCases = []struct {
 	subject     string
 	candidates  []string
 	expected    []string
-}{ {{range .J.Cases}}
+}{ {{range .J.findAnagrams}}
 {
 	description: {{printf "%q"   .Description}},
-	subject: {{printf "%q"   .Input.Subject}},
-	candidates: []string { {{range $line := .Input.Candidates}}{{printf "\n%q," $line}}{{end}}},
-	expected: []string { {{range $line := .Expected}}{{printf "\n%q," $line}}{{end}}},
+	subject: {{printf "%q"       .Input.Subject}},
+	candidates: {{printf "%#v"   .Input.Candidates}},
+	expected: {{printf "%#v"     .Expected}},
 	},{{end}}
 }
 `

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -14,7 +14,6 @@ description = "no matches"
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
-include = false
 
 [03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
 description = "detects two anagrams"
@@ -67,7 +66,6 @@ reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
-include = false
 
 [33d3f67e-fbb9-49d3-a90e-0beb00861da7]
 description = "words other than themselves can be anagrams"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -51,6 +51,7 @@ description = "anagrams must use all letters exactly once"
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
+include = false
 
 [68934ed0-010b-4ef9-857a-20c9012d1ebf]
 description = "words are not anagrams of themselves"
@@ -66,6 +67,7 @@ reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
+include = false
 
 [33d3f67e-fbb9-49d3-a90e-0beb00861da7]
 description = "words other than themselves can be anagrams"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,12 +1,24 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
+include = false
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"
@@ -41,5 +53,22 @@ description = "anagrams must use all letters exactly once"
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
 
+[68934ed0-010b-4ef9-857a-20c9012d1ebf]
+description = "words are not anagrams of themselves"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
+description = "words are not anagrams of themselves even if letter case is partially different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
+description = "words are not anagrams of themselves even if letter case is completely different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
+include = false
+
+[33d3f67e-fbb9-49d3-a90e-0beb00861da7]
+description = "words other than themselves can be anagrams"
+reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"

--- a/exercises/practice/anagram/anagram_test.go
+++ b/exercises/practice/anagram/anagram_test.go
@@ -17,19 +17,13 @@ func equal(a, b []string) bool {
 }
 
 func TestDetectAnagrams(t *testing.T) {
-	for _, tt := range testCases {
-		actual := Detect(tt.subject, tt.candidates)
-		if !equal(tt.expected, actual) {
-			msg := `FAIL: %s
-	Subject %s
-	Candidates %q
-	Expected %q
-	Got %q
-				`
-			t.Fatalf(msg, tt.description, tt.subject, tt.candidates, tt.expected, actual)
-		} else {
-			t.Logf("PASS: %s", tt.description)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := Detect(tc.subject, tc.candidates)
+			if !equal(tc.expected, actual) {
+				t.Errorf("Detect(%q, %#v) = %#v, want: %#v", tc.subject, tc.candidates, actual, tc.expected)
+			}
+		})
 	}
 }
 

--- a/exercises/practice/anagram/cases_test.go
+++ b/exercises/practice/anagram/cases_test.go
@@ -88,12 +88,6 @@ var testCases = []struct {
 		expected:    []string{},
 	},
 	{
-		description: "words are not anagrams of themselves (case-insensitive)",
-		subject:     "BANANA",
-		candidates:  []string{"BANANA", "Banana", "banana"},
-		expected:    []string{},
-	},
-	{
 		description: "words are not anagrams of themselves",
 		subject:     "BANANA",
 		candidates:  []string{"BANANA"},
@@ -110,12 +104,6 @@ var testCases = []struct {
 		subject:     "BANANA",
 		candidates:  []string{"banana"},
 		expected:    []string{},
-	},
-	{
-		description: "words other than themselves can be anagrams",
-		subject:     "LISTEN",
-		candidates:  []string{"Listen", "Silent", "LISTEN"},
-		expected:    []string{"Silent"},
 	},
 	{
 		description: "words other than themselves can be anagrams",

--- a/exercises/practice/anagram/cases_test.go
+++ b/exercises/practice/anagram/cases_test.go
@@ -1,8 +1,7 @@
 package anagram
 
 // Source: exercism/problem-specifications
-// Commit: baaf092 anagram: words are not anagrams of themselves
-// Problem Specifications Version: 1.4.0
+// Commit: 6373ab6 anagram: reimplement cases where `candidates` isn't a set (#1943)
 
 var testCases = []struct {
 	description string
@@ -13,116 +12,103 @@ var testCases = []struct {
 	{
 		description: "no matches",
 		subject:     "diaper",
-		candidates: []string{
-			"hello",
-			"world",
-			"zombies",
-			"pants"},
-		expected: []string{},
+		candidates:  []string{"hello", "world", "zombies", "pants"},
+		expected:    []string{},
 	},
 	{
 		description: "detects two anagrams",
-		subject:     "master",
-		candidates: []string{
-			"stream",
-			"pigeon",
-			"maters"},
-		expected: []string{
-			"stream",
-			"maters"},
+		subject:     "solemn",
+		candidates:  []string{"lemons", "cherry", "melons"},
+		expected:    []string{"lemons", "melons"},
 	},
 	{
 		description: "does not detect anagram subsets",
 		subject:     "good",
-		candidates: []string{
-			"dog",
-			"goody"},
-		expected: []string{},
+		candidates:  []string{"dog", "goody"},
+		expected:    []string{},
 	},
 	{
 		description: "detects anagram",
 		subject:     "listen",
-		candidates: []string{
-			"enlists",
-			"google",
-			"inlets",
-			"banana"},
-		expected: []string{
-			"inlets"},
+		candidates:  []string{"enlists", "google", "inlets", "banana"},
+		expected:    []string{"inlets"},
 	},
 	{
 		description: "detects three anagrams",
 		subject:     "allergy",
-		candidates: []string{
-			"gallery",
-			"ballerina",
-			"regally",
-			"clergy",
-			"largely",
-			"leading"},
-		expected: []string{
-			"gallery",
-			"regally",
-			"largely"},
+		candidates:  []string{"gallery", "ballerina", "regally", "clergy", "largely", "leading"},
+		expected:    []string{"gallery", "regally", "largely"},
+	},
+	{
+		description: "detects multiple anagrams with different case",
+		subject:     "nose",
+		candidates:  []string{"Eons", "ONES"},
+		expected:    []string{"Eons", "ONES"},
 	},
 	{
 		description: "does not detect non-anagrams with identical checksum",
 		subject:     "mass",
-		candidates: []string{
-			"last"},
-		expected: []string{},
+		candidates:  []string{"last"},
+		expected:    []string{},
 	},
 	{
 		description: "detects anagrams case-insensitively",
 		subject:     "Orchestra",
-		candidates: []string{
-			"cashregister",
-			"Carthorse",
-			"radishes"},
-		expected: []string{
-			"Carthorse"},
+		candidates:  []string{"cashregister", "Carthorse", "radishes"},
+		expected:    []string{"Carthorse"},
 	},
 	{
 		description: "detects anagrams using case-insensitive subject",
 		subject:     "Orchestra",
-		candidates: []string{
-			"cashregister",
-			"carthorse",
-			"radishes"},
-		expected: []string{
-			"carthorse"},
+		candidates:  []string{"cashregister", "carthorse", "radishes"},
+		expected:    []string{"carthorse"},
 	},
 	{
 		description: "detects anagrams using case-insensitive possible matches",
 		subject:     "orchestra",
-		candidates: []string{
-			"cashregister",
-			"Carthorse",
-			"radishes"},
-		expected: []string{
-			"Carthorse"},
+		candidates:  []string{"cashregister", "Carthorse", "radishes"},
+		expected:    []string{"Carthorse"},
 	},
 	{
-		description: "does not detect a anagram if the original word is repeated",
+		description: "does not detect an anagram if the original word is repeated",
 		subject:     "go",
-		candidates: []string{
-			"go Go GO"},
-		expected: []string{},
+		candidates:  []string{"go Go GO"},
+		expected:    []string{},
 	},
 	{
 		description: "anagrams must use all letters exactly once",
 		subject:     "tapper",
-		candidates: []string{
-			"patter"},
-		expected: []string{},
+		candidates:  []string{"patter"},
+		expected:    []string{},
 	},
 	{
 		description: "words are not anagrams of themselves (case-insensitive)",
 		subject:     "BANANA",
-		candidates: []string{
-			"BANANA",
-			"Banana",
-			"banana"},
-		expected: []string{},
+		candidates:  []string{"BANANA", "Banana", "banana"},
+		expected:    []string{},
+	},
+	{
+		description: "words are not anagrams of themselves",
+		subject:     "BANANA",
+		candidates:  []string{"BANANA"},
+		expected:    []string{},
+	},
+	{
+		description: "words are not anagrams of themselves even if letter case is partially different",
+		subject:     "BANANA",
+		candidates:  []string{"Banana"},
+		expected:    []string{},
+	},
+	{
+		description: "words are not anagrams of themselves even if letter case is completely different",
+		subject:     "BANANA",
+		candidates:  []string{"banana"},
+		expected:    []string{},
+	},
+	{
+		description: "words other than themselves can be anagrams",
+		subject:     "LISTEN",
+		candidates:  []string{"LISTEN", "Silent"},
+		expected:    []string{"Silent"},
 	},
 }

--- a/exercises/practice/anagram/cases_test.go
+++ b/exercises/practice/anagram/cases_test.go
@@ -17,6 +17,12 @@ var testCases = []struct {
 	},
 	{
 		description: "detects two anagrams",
+		subject:     "master",
+		candidates:  []string{"stream", "pigeon", "maters"},
+		expected:    []string{"stream", "maters"},
+	},
+	{
+		description: "detects two anagrams",
 		subject:     "solemn",
 		candidates:  []string{"lemons", "cherry", "melons"},
 		expected:    []string{"lemons", "melons"},
@@ -104,6 +110,12 @@ var testCases = []struct {
 		subject:     "BANANA",
 		candidates:  []string{"banana"},
 		expected:    []string{},
+	},
+	{
+		description: "words other than themselves can be anagrams",
+		subject:     "LISTEN",
+		candidates:  []string{"Listen", "Silent", "LISTEN"},
+		expected:    []string{"Silent"},
 	},
 	{
 		description: "words other than themselves can be anagrams",


### PR DESCRIPTION
One of #2302 

Here I am not completely sure which of the test cases with `reimplements` to include. Especially for the `words are not anagrams of themselves` thing. 