### PR TITLE
atbash-cipher: updated exercise generator to new test generator

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -16,7 +16,8 @@
     "sebito91",
     "strangeman",
     "tleen",
-    "tompao"
+    "tompao",
+    "eklatzer"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -28,18 +28,24 @@ description = "encode all the letters"
 
 [bb50e087-7fdf-48e7-9223-284fe7e69851]
 description = "decode exercism"
+include = false
 
 [ac021097-cd5d-4717-8907-b0814b9e292c]
 description = "decode a sentence"
+include = false
 
 [18729de3-de74-49b8-b68c-025eaf77f851]
 description = "decode numbers"
+include = false
 
 [0f30325f-f53b-415d-ad3e-a7a4f63de034]
 description = "decode all the letters"
+include = false
 
 [39640287-30c6-4c8c-9bac-9d613d1a5674]
 description = "decode with too many spaces"
+include = false
 
 [b34edf13-34c0-49b5-aa21-0768928000d5]
 description = "decode with no spaces"
+include = false

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.go
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.go
@@ -3,11 +3,13 @@ package atbash
 import "testing"
 
 func TestAtbash(t *testing.T) {
-	for _, test := range tests {
-		actual := Atbash(test.s)
-		if actual != test.expected {
-			t.Errorf("Atbash('%s'): expected '%s', actual '%s'", test.s, test.expected, actual)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := Atbash(tc.phrase)
+			if actual != tc.expected {
+				t.Errorf("Atbash('%s'): expected '%s', actual '%s'", tc.phrase, tc.expected, actual)
+			}
+		})
 	}
 }
 
@@ -16,10 +18,8 @@ func BenchmarkAtbash(b *testing.B) {
 		b.Skip("skipping benchmark in short mode.")
 	}
 	for i := 0; i < b.N; i++ {
-
-		for _, test := range tests {
-			Atbash(test.s)
+		for _, test := range testCases {
+			Atbash(test.phrase)
 		}
-
 	}
 }

--- a/exercises/practice/atbash-cipher/cases_test.go
+++ b/exercises/practice/atbash-cipher/cases_test.go
@@ -1,61 +1,44 @@
 package atbash
 
 // Source: exercism/problem-specifications
-// Commit: dda678b atbash-cipher: Apply new "input" policy
-// Problem Specifications Version: 1.1.0
+// Commit: d137db1 Format using prettier (#1917)
 
-type atbashTest struct {
-	s        string
-	expected string
-}
-
-var tests = []atbashTest{
+var testCases = []struct {
+	description string
+	phrase      string
+	expected    string
+}{
 	{
-		s:        "yes",
-		expected: "bvh",
-	},
-	{
-		s:        "no",
-		expected: "ml",
-	},
-	{
-		s:        "OMG",
-		expected: "lnt",
-	},
-	{
-		s:        "O M G",
-		expected: "lnt",
-	},
-	{
-		s:        "mindblowingly",
-		expected: "nrmwy oldrm tob",
-	},
-	{
-		s:        "Testing,1 2 3, testing.",
-		expected: "gvhgr mt123 gvhgr mt",
-	},
-	{
-		s:        "Truth is fiction.",
-		expected: "gifgs rhurx grlm",
-	},
-	{
-		s:        "The quick brown fox jumps over the lazy dog.",
-		expected: "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
-	},
-	{
-		s:        "exercism",
-		expected: "vcvix rhn",
-	},
-	{
-		s:        "anobstacleisoftenasteppingstone",
-		expected: "zmlyh gzxov rhlug vmzhg vkkrm thglm v",
-	},
-	{
-		s:        "testing123testing",
-		expected: "gvhgr mt123 gvhgr mt",
-	},
-	{
-		s:        "thequickbrownfoxjumpsoverthelazydog",
-		expected: "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
+		description: "encode yes",
+		phrase:      "yes",
+		expected:    "bvh",
+	}, {
+		description: "encode no",
+		phrase:      "no",
+		expected:    "ml",
+	}, {
+		description: "encode OMG",
+		phrase:      "OMG",
+		expected:    "lnt",
+	}, {
+		description: "encode spaces",
+		phrase:      "O M G",
+		expected:    "lnt",
+	}, {
+		description: "encode mindblowingly",
+		phrase:      "mindblowingly",
+		expected:    "nrmwy oldrm tob",
+	}, {
+		description: "encode numbers",
+		phrase:      "Testing,1 2 3, testing.",
+		expected:    "gvhgr mt123 gvhgr mt",
+	}, {
+		description: "encode deep thought",
+		phrase:      "Truth is fiction.",
+		expected:    "gifgs rhurx grlm",
+	}, {
+		description: "encode all the letters",
+		phrase:      "The quick brown fox jumps over the lazy dog.",
+		expected:    "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
 	},
 }


### PR DESCRIPTION
One of #2302 

Regarding to [canonical-data.json](https://github.com/exercism/problem-specifications/blob/main/exercises/atbash-cipher/canonical-data.json) there are also test cases for decoding. Do we want to add the decoding to this exercise, or is there a reason why it is no here?