### PR TITLE
grains: updated exercise generator to new test generator

### DIFF
--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -19,7 +19,8 @@
     "robphoenix",
     "sebito91",
     "strangeman",
-    "tleen"
+    "tleen",
+    "eklatzer"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/grains/cases_test.go
+++ b/exercises/practice/grains/cases_test.go
@@ -1,8 +1,7 @@
 package grains
 
 // Source: exercism/problem-specifications
-// Commit: 2ec42ab Grains: Fixed canonical data to have standard error indicator (#1322)
-// Problem Specifications Version: 1.2.0
+// Commit: d137db1 Format using prettier (#1917)
 
 // returns the number of grains on the square
 var squareTests = []struct {
@@ -12,53 +11,63 @@ var squareTests = []struct {
 	expectError bool
 }{
 	{
-		description: "1",
+		description: "grains on square 1",
 		input:       1,
 		expectedVal: 1,
+		expectError: false,
 	},
 	{
-		description: "2",
+		description: "grains on square 2",
 		input:       2,
 		expectedVal: 2,
+		expectError: false,
 	},
 	{
-		description: "3",
+		description: "grains on square 3",
 		input:       3,
 		expectedVal: 4,
+		expectError: false,
 	},
 	{
-		description: "4",
+		description: "grains on square 4",
 		input:       4,
 		expectedVal: 8,
+		expectError: false,
 	},
 	{
-		description: "16",
+		description: "grains on square 16",
 		input:       16,
 		expectedVal: 32768,
+		expectError: false,
 	},
 	{
-		description: "32",
+		description: "grains on square 32",
 		input:       32,
 		expectedVal: 2147483648,
+		expectError: false,
 	},
 	{
-		description: "64",
+		description: "grains on square 64",
 		input:       64,
 		expectedVal: 9223372036854775808,
+		expectError: false,
 	},
 	{
-		description: "square 0 returns an error",
+		description: "square 0 raises an exception",
 		input:       0,
+		expectedVal: 0,
 		expectError: true,
 	},
 	{
-		description: "negative square returns an error",
+		description: "negative square raises an exception",
 		input:       -1,
+		expectedVal: 0,
 		expectError: true,
 	},
 	{
-		description: "square greater than 64 returns an error",
+		description: "square greater than 64 raises an exception",
 		input:       65,
+		expectedVal: 0,
 		expectError: true,
 	},
 }

--- a/exercises/practice/grains/grains_test.go
+++ b/exercises/practice/grains/grains_test.go
@@ -5,31 +5,28 @@ import (
 )
 
 func TestSquare(t *testing.T) {
-	for _, test := range squareTests {
-		actualVal, actualErr := Square(test.input)
-
-		// check actualVal only if no error expected
-		if !test.expectError && actualVal != test.expectedVal {
-			t.Fatalf("FAIL: %s\nSquare(%d) expected %d, Actual %d", test.description, test.input, test.expectedVal, actualVal)
-		}
-
-		// if we expect an error and there isn't one
-		if test.expectError && actualErr == nil {
-			t.Fatalf("FAIL: %s\nSquare(%d) expected an error, but error is nil", test.description, test.input)
-		}
-		// if we don't expect an error and there is one
-		if !test.expectError && actualErr != nil {
-			var _ error = actualErr
-			t.Fatalf("FAIL: %s\nSquare(%d) expected no error, but error is: %s", test.description, test.input, actualErr)
-		}
-		t.Logf("PASS: %s", test.description)
+	for _, tc := range squareTests {
+		t.Run(tc.description, func(t *testing.T) {
+			actualVal, actualErr := Square(tc.input)
+			if tc.expectError {
+				if actualErr == nil {
+					t.Errorf("Square(%d) expected an error, got: %d", tc.input, actualVal)
+				}
+			} else {
+				if actualErr != nil {
+					t.Errorf("Square(%d) expected %d, but got error: %v", tc.input, actualVal, actualErr)
+				} else if actualVal != tc.expectedVal {
+					t.Errorf("Square(%d) = %d, want %d", tc.input, actualVal, tc.expectedVal)
+				}
+			}
+		})
 	}
 }
 
 func TestTotal(t *testing.T) {
 	var expected uint64 = 18446744073709551615
 	if actual := Total(); actual != expected {
-		t.Errorf("Total() expected %d, Actual %d", expected, actual)
+		t.Errorf("Total() = %d, want:%d", actual, expected)
 	}
 }
 
@@ -39,11 +36,9 @@ func BenchmarkSquare(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-
 		for _, test := range squareTests {
 			Square(test.input)
 		}
-
 	}
 }
 


### PR DESCRIPTION
One of #2302 

I left the expected value for `TestTotal` in `grains_test.go` as this seems better than having to parse the big value `18446744073709551615`