### PR TITLE
Clean up doc comments in concept exercises

### DIFF
--- a/exercises/concept/animal-magic/.meta/exemplar.go
+++ b/exercises/concept/animal-magic/.meta/exemplar.go
@@ -5,22 +5,22 @@ import (
 	"time"
 )
 
-// SeedWithTime seeds math/rand with the current computer time
+// SeedWithTime seeds math/rand with the current computer time.
 func SeedWithTime() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// RollADie returns a random int between 1 and 20
+// RollADie returns a random int between 1 and 20.
 func RollADie() int {
 	return 1 + rand.Intn(20)
 }
 
-// GenerateWandEnergy returns a random float64 f with 0.0 <= f < 12.0
+// GenerateWandEnergy returns a random float64 f with 0.0 <= f < 12.0.
 func GenerateWandEnergy() float64 {
 	return 12.0 * rand.Float64()
 }
 
-// ShuffleAnimals returns a slice with eight animal strings in random order
+// ShuffleAnimals returns a slice with eight animal strings in random order.
 func ShuffleAnimals() []string {
 	result := []string{"ant", "beaver", "cat", "dog", "elephant", "fox", "giraffe", "hedgehog"}
 	rand.Shuffle(len(result), func(i, j int) {

--- a/exercises/concept/animal-magic/animal_magic.go
+++ b/exercises/concept/animal-magic/animal_magic.go
@@ -1,21 +1,21 @@
 package chance
 
-// SeedWithTime seeds math/rand with the current computer time
+// SeedWithTime seeds math/rand with the current computer time.
 func SeedWithTime() {
 	panic("Please implement the SeedWithTime function")
 }
 
-// RollADie returns a random int d with 1 <= d <= 20
+// RollADie returns a random int d with 1 <= d <= 20.
 func RollADie() int {
 	panic("Please implement the RollADie function")
 }
 
-// GenerateWandEnergy returns a random float64 f with 0.0 <= f < 12.0
+// GenerateWandEnergy returns a random float64 f with 0.0 <= f < 12.0.
 func GenerateWandEnergy() float64 {
 	panic("Please implement the GenerateWandEnergy function")
 }
 
-// ShuffleAnimals returns a slice with all eight animal strings in random order
+// ShuffleAnimals returns a slice with all eight animal strings in random order.
 func ShuffleAnimals() []string {
 	panic("Please implement the ShuffleAnimals function")
 }

--- a/exercises/concept/annalyns-infiltration/.meta/exemplar.go
+++ b/exercises/concept/annalyns-infiltration/.meta/exemplar.go
@@ -1,22 +1,22 @@
 package annalyn
 
-// CanFastAttack can be executed only when the knight is sleeping
+// CanFastAttack can be executed only when the knight is sleeping.
 func CanFastAttack(knightIsAwake bool) bool {
 	return !knightIsAwake
 }
 
-// CanSpy can be executed if at least one of the characters is awake
+// CanSpy can be executed if at least one of the characters is awake.
 func CanSpy(knightIsAwake, archerIsAwake, prisonerIsAwake bool) bool {
 	return knightIsAwake || archerIsAwake || prisonerIsAwake
 }
 
-// CanSignalPrisoner can be executed if the prisoner is awake and the archer is sleeping
+// CanSignalPrisoner can be executed if the prisoner is awake and the archer is sleeping.
 func CanSignalPrisoner(archerIsAwake, prisonerIsAwake bool) bool {
 	return !archerIsAwake && prisonerIsAwake
 }
 
 // CanFreePrisoner can be executed if the prisoner is awake and the other 2 characters are asleep
-// or if Annalyn's pet dog is with her and the archer is sleeping
+// or if Annalyn's pet dog is with her and the archer is sleeping.
 func CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent bool) bool {
 	return !knightIsAwake && !archerIsAwake && prisonerIsAwake || !archerIsAwake && petDogIsPresent
 }

--- a/exercises/concept/annalyns-infiltration/annalyns_infiltration.go
+++ b/exercises/concept/annalyns-infiltration/annalyns_infiltration.go
@@ -1,22 +1,22 @@
 package annalyn
 
-// CanFastAttack can be executed only when the knight is sleeping
+// CanFastAttack can be executed only when the knight is sleeping.
 func CanFastAttack(knightIsAwake bool) bool {
 	panic("Please implement the CanFastAttack() function")
 }
 
-// CanSpy can be executed if at least one of the characters is awake
+// CanSpy can be executed if at least one of the characters is awake.
 func CanSpy(knightIsAwake, archerIsAwake, prisonerIsAwake bool) bool {
 	panic("Please implement the CanSpy() function")
 }
 
-// CanSignalPrisoner can be executed if the prisoner is awake and the archer is sleeping
+// CanSignalPrisoner can be executed if the prisoner is awake and the archer is sleeping.
 func CanSignalPrisoner(archerIsAwake, prisonerIsAwake bool) bool {
 	panic("Please implement the CanSignalPrisoner() function")
 }
 
 // CanFreePrisoner can be executed if the prisoner is awake and the other 2 characters are asleep
-// or if Annalyn's pet dog is with her and the archer is sleeping
+// or if Annalyn's pet dog is with her and the archer is sleeping.
 func CanFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent bool) bool {
 	panic("Please implement the CanFreePrisoner() function")
 }

--- a/exercises/concept/booking-up-for-beauty/.meta/exemplar.go
+++ b/exercises/concept/booking-up-for-beauty/.meta/exemplar.go
@@ -5,31 +5,31 @@ import (
 	"time"
 )
 
-// Schedule returns a time.Time from a string containing a date
+// Schedule returns a time.Time from a string containing a date.
 func Schedule(date string) time.Time {
 	t, _ := time.Parse("1/2/2006 15:04:05", date)
 	return t
 }
 
-// HasPassed returns whether a date has passed
+// HasPassed returns whether a date has passed.
 func HasPassed(date string) bool {
 	t, _ := time.Parse("January 2, 2006 15:04:05", date)
 	return t.Before(time.Now())
 }
 
-// IsAfternoonAppointment returns whether a time is in the afternoon
+// IsAfternoonAppointment returns whether a time is in the afternoon.
 func IsAfternoonAppointment(date string) bool {
 	t, _ := time.Parse("Monday, January 2, 2006 15:04:05", date)
 	return t.Hour() >= 12 && t.Hour() < 18
 }
 
-// Description returns a formatted string of the appointment time
+// Description returns a formatted string of the appointment time.
 func Description(date string) string {
 	t, _ := time.Parse("1/2/2006 15:04:05", date)
 	return fmt.Sprintf("You have an appointment on %s, %s %d, %d, at %d:%d.", t.Weekday(), t.Month(), t.Day(), t.Year(), t.Hour(), t.Minute())
 }
 
-// AnniversaryDate returns a Time with this year's anniversary
+// AnniversaryDate returns a Time with this year's anniversary.
 func AnniversaryDate() time.Time {
 	t, _ := time.Parse("1/2/2006", "9/15/2012")
 	return t.AddDate(time.Now().Year()-2012, 0, 0)

--- a/exercises/concept/booking-up-for-beauty/booking_up_for_beauty.go
+++ b/exercises/concept/booking-up-for-beauty/booking_up_for_beauty.go
@@ -2,27 +2,27 @@ package booking
 
 import "time"
 
-// Schedule returns a time.Time from a string containing a date
+// Schedule returns a time.Time from a string containing a date.
 func Schedule(date string) time.Time {
 	panic("Please implement the Schedule function")
 }
 
-// HasPassed returns whether a date has passed
+// HasPassed returns whether a date has passed.
 func HasPassed(date string) bool {
 	panic("Please implement the HasPassed function")
 }
 
-// IsAfternoonAppointment returns whether a time is in the afternoon
+// IsAfternoonAppointment returns whether a time is in the afternoon.
 func IsAfternoonAppointment(date string) bool {
 	panic("Please implement the IsAfternoonAppointment function")
 }
 
-// Description returns a formatted string of the appointment time
+// Description returns a formatted string of the appointment time.
 func Description(date string) string {
 	panic("Please implement the Description function")
 }
 
-// AnniversaryDate returns a Time with this year's anniversary
+// AnniversaryDate returns a Time with this year's anniversary.
 func AnniversaryDate() time.Time {
 	panic("Please implement the AnniversaryDate function")
 }

--- a/exercises/concept/card-tricks/.meta/exemplar.go
+++ b/exercises/concept/card-tricks/.meta/exemplar.go
@@ -6,7 +6,7 @@ func FavoriteCards() []int {
 }
 
 // GetItem retrieves an item from a slice at given position.
-// If the index is out of a range we want it to return -1
+// If the index is out of a range we want it to return -1.
 func GetItem(slice []int, index int) int {
 	if len(slice) <= index || index < 0 {
 		return -1

--- a/exercises/concept/cars-assemble/.meta/exemplar.go
+++ b/exercises/concept/cars-assemble/.meta/exemplar.go
@@ -1,18 +1,18 @@
 package cars
 
 // CalculateWorkingCarsPerHour calculates how many working cars are
-// produced by the assembly line every hour
+// produced by the assembly line every hour.
 func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float64 {
 	return float64(productionRate) * successRate / 100
 }
 
 // CalculateWorkingCarsPerMinute calculates how many working cars are
-// produced by the assembly line every minute
+// produced by the assembly line every minute.
 func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
 	return int(CalculateWorkingCarsPerHour(productionRate, successRate) / 60)
 }
 
-// CalculateCost works out the cost of producing the given number of cars
+// CalculateCost works out the cost of producing the given number of cars.
 func CalculateCost(carsCount int) uint {
 	return uint((carsCount/10)*95000 + (carsCount%10)*10000)
 }

--- a/exercises/concept/cars-assemble/cars_assemble.go
+++ b/exercises/concept/cars-assemble/cars_assemble.go
@@ -1,18 +1,18 @@
 package cars
 
 // CalculateWorkingCarsPerHour calculates how many working cars are
-// produced by the assembly line every hour
+// produced by the assembly line every hour.
 func CalculateWorkingCarsPerHour(productionRate int, successRate float64) float64 {
 	panic("CalculateWorkingCarsPerHour not implemented")
 }
 
 // CalculateWorkingCarsPerMinute calculates how many working cars are
-// produced by the assembly line every minute
+// produced by the assembly line every minute.
 func CalculateWorkingCarsPerMinute(productionRate int, successRate float64) int {
 	panic("CalculateWorkingCarsPerMinute not implemented")
 }
 
-// CalculateCost works out the cost of producing the given number of cars
+// CalculateCost works out the cost of producing the given number of cars.
 func CalculateCost(carsCount int) uint {
 	panic("CalculateCost not implemented")
 }

--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-// TestNewResident tests the NewResident function.
 func TestNewResident(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/exercises/concept/chessboard/.meta/exemplar.go
+++ b/exercises/concept/chessboard/.meta/exemplar.go
@@ -1,13 +1,13 @@
 package chessboard
 
-// Rank stores if a square is occupied by a piece
+// Rank stores if a square is occupied by a piece.
 type Rank []bool
 
-// Chessboard contains eight Ranks, accessed with keys from "A" to "H"
+// Chessboard contains eight Ranks, accessed with keys from "A" to "H".
 type Chessboard map[string]Rank
 
 // CountInRank returns how many squares are occupied in the chessboard,
-// within the given rank
+// within the given rank.
 func CountInRank(cb Chessboard, rank string) int {
 	count := 0
 	for _, r := range cb[rank] {
@@ -19,7 +19,7 @@ func CountInRank(cb Chessboard, rank string) int {
 }
 
 // CountInFile returns how many squares are occupied in the chessboard,
-// within the given file
+// within the given file.
 func CountInFile(cb Chessboard, file int) int {
 
 	if file < 1 || file > 8 {
@@ -35,7 +35,7 @@ func CountInFile(cb Chessboard, file int) int {
 	return count
 }
 
-// CountAll should count how many squares are present in the chessboard
+// CountAll should count how many squares are present in the chessboard.
 func CountAll(cb Chessboard) int {
 	count := 0
 	for _, rank := range cb {
@@ -46,7 +46,7 @@ func CountAll(cb Chessboard) int {
 	return count
 }
 
-// CountOccupied returns how many squares are occupied in the chessboard
+// CountOccupied returns how many squares are occupied in the chessboard.
 func CountOccupied(cb Chessboard) int {
 	count := 0
 	for rank := range cb {

--- a/exercises/concept/chessboard/chessboard.go
+++ b/exercises/concept/chessboard/chessboard.go
@@ -5,23 +5,23 @@ package chessboard
 // Declare a type named Chessboard which contains a map of eight Ranks, accessed with keys from "A" to "H"
 
 // CountInRank returns how many squares are occupied in the chessboard,
-// within the given rank
+// within the given rank.
 func CountInRank(cb Chessboard, rank string) int {
 	panic("Please implement CountInRank()")
 }
 
 // CountInFile returns how many squares are occupied in the chessboard,
-// within the given file
+// within the given file.
 func CountInFile(cb Chessboard, file int) int {
 	panic("Please implement CountInFile()")
 }
 
-// CountAll should count how many squares are present in the chessboard
+// CountAll should count how many squares are present in the chessboard.
 func CountAll(cb Chessboard) int {
 	panic("Please implement CountAll()")
 }
 
-// CountOccupied returns how many squares are occupied in the chessboard
+// CountOccupied returns how many squares are occupied in the chessboard.
 func CountOccupied(cb Chessboard) int {
 	panic("Please implement CountOccupied()")
 }

--- a/exercises/concept/deep-thought/.meta/exemplar.go
+++ b/exercises/concept/deep-thought/.meta/exemplar.go
@@ -7,10 +7,10 @@ import (
 
 const answer = 42
 
-// ErrCalculation is a general error that can be exported
+// ErrCalculation is a general error that can be exported.
 var ErrCalculation = errors.New("calculation error")
 
-// ComputerState determines if the deepthought computer is ready for its computation
+// ComputerState determines if the deepthought computer is ready for its computation.
 func ComputerState(isReady bool) error {
 	if !isReady {
 		return errors.New("computer still booting")
@@ -18,7 +18,7 @@ func ComputerState(isReady bool) error {
 	return nil
 }
 
-// AnswerToLife checks if the given number is the answer to life
+// AnswerToLife checks if the given number is the answer to life.
 func AnswerToLife(number int) (bool, error) {
 	if number != answer {
 		return false, fmt.Errorf("%s: wrong answer to life: %d", ErrCalculation.Error(), number)
@@ -26,7 +26,7 @@ func AnswerToLife(number int) (bool, error) {
 	return true, nil
 }
 
-// AskComputer checks if number is the answer to life, depending on the state of the computer
+// AskComputer checks if number is the answer to life, depending on the state of the computer.
 func AskComputer(isReady bool, number int) (bool, error) {
 	err := ComputerState(isReady)
 	if err != nil {

--- a/exercises/concept/election-day/.meta/exemplar.go
+++ b/exercises/concept/election-day/.meta/exemplar.go
@@ -16,12 +16,12 @@ func VoteCount(counter *int) int {
 	return *counter
 }
 
-// IncrementVoteCount increments the value in a vote counter
+// IncrementVoteCount increments the value in a vote counter.
 func IncrementVoteCount(counter *int, increment int) {
 	*counter = VoteCount(counter) + increment
 }
 
-// NewElectionResult creates a new election result
+// NewElectionResult creates a new election result.
 func NewElectionResult(candidateName string, votes int) *ElectionResult {
 	return &ElectionResult{
 		Name:  candidateName,
@@ -29,12 +29,12 @@ func NewElectionResult(candidateName string, votes int) *ElectionResult {
 	}
 }
 
-// DisplayResult creates a message with the result to be displayed
+// DisplayResult creates a message with the result to be displayed.
 func DisplayResult(result *ElectionResult) string {
 	return fmt.Sprintf("%s (%d)", result.Name, result.Votes)
 }
 
-// DecrementVotesOfCandidate decrements by one the vote count of a candidate in a map
+// DecrementVotesOfCandidate decrements by one the vote count of a candidate in a map.
 func DecrementVotesOfCandidate(results map[string]int, candidate string) {
 	results[candidate]--
 }

--- a/exercises/concept/election-day/election_day.go
+++ b/exercises/concept/election-day/election_day.go
@@ -11,22 +11,22 @@ func VoteCount(counter *int) int {
 	panic("Please implement the VoteCount() function")
 }
 
-// IncrementVoteCount increments the value in a vote counter
+// IncrementVoteCount increments the value in a vote counter.
 func IncrementVoteCount(counter *int, increment int) {
 	panic("Please implement the IncrementVoteCount() function")
 }
 
-// NewElectionResult creates a new election result
+// NewElectionResult creates a new election result.
 func NewElectionResult(candidateName string, votes int) *ElectionResult {
 	panic("Please implement the NewElectionResult() function")
 }
 
-// DisplayResult creates a message with the result to be displayed
+// DisplayResult creates a message with the result to be displayed.
 func DisplayResult(result *ElectionResult) string {
 	panic("Please implement the DisplayResult() function")
 }
 
-// DecrementVotesOfCandidate decrements by one the vote count of a candidate in a map
+// DecrementVotesOfCandidate decrements by one the vote count of a candidate in a map.
 func DecrementVotesOfCandidate(results map[string]int, candidate string) {
 	panic("Please implement the DecrementVotesOfCandidate() function")
 }

--- a/exercises/concept/election-day/election_result.go
+++ b/exercises/concept/election-day/election_result.go
@@ -1,9 +1,9 @@
 package electionday
 
-// ElectionResult represents an election result
+// ElectionResult represents an election result.
 type ElectionResult struct {
-	// Name of the candidate
+	// Name is the name of the candidate.
 	Name string
-	// Number of votes the candidate had
+	// Number is the total number of votes the candidate had.
 	Votes int
 }

--- a/exercises/concept/expenses/.meta/exemplar.go
+++ b/exercises/concept/expenses/.meta/exemplar.go
@@ -33,7 +33,7 @@ func Filter(in []Record, predicate func(Record) bool) []Record {
 }
 
 // ByDaysPeriod returns predicate function that returns true when
-// the day of the record is inside the period of day and false otherwise
+// the day of the record is inside the period of day and false otherwise.
 func ByDaysPeriod(p DaysPeriod) func(Record) bool {
 	return func(r Record) bool {
 		return p.Includes(r.Day)
@@ -42,7 +42,7 @@ func ByDaysPeriod(p DaysPeriod) func(Record) bool {
 
 // ByCategory returns predicate function that returns true when
 // the category of the record is the same as the provided category
-// and false otherwise
+// and false otherwise.
 func ByCategory(c string) func(Record) bool {
 	return func(r Record) bool {
 		return r.Category == c
@@ -50,7 +50,7 @@ func ByCategory(c string) func(Record) bool {
 }
 
 // TotalByPeriod returns total amount of expenses for records
-// inside the period p
+// inside the period p.
 func TotalByPeriod(in []Record, p DaysPeriod) float64 {
 	periodExpenses := Filter(in, ByDaysPeriod(p))
 	var total float64

--- a/exercises/concept/expenses/expenses.go
+++ b/exercises/concept/expenses/expenses.go
@@ -19,20 +19,20 @@ func Filter(in []Record, predicate func(Record) bool) []Record {
 }
 
 // ByDaysPeriod returns predicate function that returns true when
-// the day of the record is inside the period of day and false otherwise
+// the day of the record is inside the period of day and false otherwise.
 func ByDaysPeriod(p DaysPeriod) func(Record) bool {
 	panic("Please implement the ByDaysPeriod function")
 }
 
 // ByCategory returns predicate function that returns true when
 // the category of the record is the same as the provided category
-// and false otherwise
+// and false otherwise.
 func ByCategory(c string) func(Record) bool {
 	panic("Please implement the ByCategory function")
 }
 
 // TotalByPeriod returns total amount of expenses for records
-// inside the period p
+// inside the period p.
 func TotalByPeriod(in []Record, p DaysPeriod) float64 {
 	panic("Please implement the TotalByPeriod function")
 }

--- a/exercises/concept/gross-store/.meta/exemplar.go
+++ b/exercises/concept/gross-store/.meta/exemplar.go
@@ -1,6 +1,6 @@
 package gross
 
-// Units store the Gross Store unit measurement
+// Units stores the Gross Store unit measurement.
 func Units() map[string]int {
 	return map[string]int{
 		"quarter_of_a_dozen": 3,
@@ -12,12 +12,12 @@ func Units() map[string]int {
 	}
 }
 
-// NewBill create a new bill
+// NewBill creates a new bill.
 func NewBill() map[string]int {
 	return make(map[string]int)
 }
 
-// AddItem add item to customer bill
+// AddItem adds an item to the customer bill.
 func AddItem(bill, units map[string]int, item, unit string) bool {
 	if _, ok := units[unit]; !ok {
 		return false
@@ -28,7 +28,7 @@ func AddItem(bill, units map[string]int, item, unit string) bool {
 	return true
 }
 
-// RemoveItem remove item from customer bill
+// RemoveItem removes an item from the customer bill.
 func RemoveItem(bill, units map[string]int, item, unit string) bool {
 	if _, ok := bill[item]; !ok {
 		return false
@@ -51,7 +51,7 @@ func RemoveItem(bill, units map[string]int, item, unit string) bool {
 	return true
 }
 
-// GetItem return the quantity of item that the customer has in his/her bill
+// GetItem returns the quantity of item that the customer has in his/her bill.
 func GetItem(bill map[string]int, item string) (int, bool) {
 	if _, ok := bill[item]; !ok {
 		return 0, false

--- a/exercises/concept/interest-is-interesting/.meta/exemplar.go
+++ b/exercises/concept/interest-is-interesting/.meta/exemplar.go
@@ -27,7 +27,7 @@ func AnnualBalanceUpdate(balance float64) float64 {
 	return balance + Interest(balance)
 }
 
-// YearsBeforeDesiredBalance calculates the minimum number of years required to reach the desired balance:
+// YearsBeforeDesiredBalance calculates the minimum number of years required to reach the desired balance.
 func YearsBeforeDesiredBalance(balance, targetBalance float64) int {
 	var accumulatingBalance = balance
 	years := 0

--- a/exercises/concept/interest-is-interesting/interest_is_interesting.go
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting.go
@@ -15,7 +15,7 @@ func AnnualBalanceUpdate(balance float64) float64 {
 	panic("Please implement the AnnualBalanceUpdate function")
 }
 
-// YearsBeforeDesiredBalance calculates the minimum number of years required to reach the desired balance:
+// YearsBeforeDesiredBalance calculates the minimum number of years required to reach the desired balance.
 func YearsBeforeDesiredBalance(balance, targetBalance float64) int {
 	panic("Please implement the YearsBeforeDesiredBalance function")
 }

--- a/exercises/concept/lasagna-master/.meta/exemplar.go
+++ b/exercises/concept/lasagna-master/.meta/exemplar.go
@@ -1,6 +1,6 @@
 package lasagna
 
-// PreparationTim estimates the preparation time based on the number of layers and an average time per layer and returns it..
+// PreparationTim estimates the preparation time based on the number of layers and an average time per layer and returns it.
 func PreparationTime(layers []string, avgPrepTime int) int {
 	if avgPrepTime == 0 {
 		avgPrepTime = 2

--- a/exercises/concept/savings-account/.meta/exemplar.go
+++ b/exercises/concept/savings-account/.meta/exemplar.go
@@ -1,22 +1,22 @@
 package savings
 
-// FixedInterestRate has a value of 5%
+// FixedInterestRate has a value of 5%.
 const FixedInterestRate = 0.05
 
-// GetFixedInterestRate returns the FixedInterestRate constant and gives it a type of float32
+// GetFixedInterestRate returns the FixedInterestRate constant and gives it a type of float32.
 func GetFixedInterestRate() float32 {
 	return FixedInterestRate
 }
 
-// DaysPerYear has a value of 365
+// DaysPerYear has a value of 365.
 const DaysPerYear int = 365
 
-// GetDaysPerYear returns the DaysPerYear constant
+// GetDaysPerYear returns the DaysPerYear constant.
 func GetDaysPerYear() int {
 	return DaysPerYear
 }
 
-// Jan-Dec have values of 1-12
+// Jan-Dec have values of 1-12.
 const (
 	Jan = iota + 1
 	Feb
@@ -32,18 +32,18 @@ const (
 	Dec
 )
 
-// GetMonth returns the value for the given month, ie GetMonth(Nov) = 11
+// GetMonth returns the value for the given month, ie GetMonth(Nov) = 11.
 func GetMonth(month int) int {
 	return month
 }
 
-// AccNo type for a string - this is a stub type included to demonstrate how the untyped string constant can be used where this type is required
+// AccNo type for a string - this is a stub type included to demonstrate how the untyped string constant can be used where this type is required.
 type AccNo string
 
-// AccountNo has a value of XF348IJ
+// AccountNo has a value of XF348IJ.
 const AccountNo = "XF348IJ"
 
-// GetAccountNumber returns the AccountNo constant
+// GetAccountNumber returns the AccountNo constant.
 func GetAccountNumber() AccNo {
 	return AccountNo
 }

--- a/exercises/concept/savings-account/savings_account.go
+++ b/exercises/concept/savings-account/savings_account.go
@@ -2,31 +2,31 @@ package savings
 
 // FixedInterestRate has a value of 5% (5/100)
 
-// GetFixedInterestRate returns the FixedInterestRate constant
+// GetFixedInterestRate returns the FixedInterestRate constant.
 func GetFixedInterestRate() float32 {
 	panic("Please create the FixedInterestRate constant in the outer scope and then implement the GetFixedInterestRate function")
 }
 
 // DaysPerYear has a value of 365
 
-// GetDaysPerYear returns the DaysPerYear constant
+// GetDaysPerYear returns the DaysPerYear constant.
 func GetDaysPerYear() int {
 	panic("Please create the DaysPerYear constant in the outer scope and then implement the GetDaysPerYear function")
 }
 
 // Jan-Dec have values of 1-12
 
-// GetMonth returns the value for the given month
+// GetMonth returns the value for the given month.
 func GetMonth(month int) int {
 	panic("Please use a block and the Go enumerator in the outer scope to create twelve consecutive untyped numeric constants, one for each month of the year. January should have a value of 1. Name them 'Jan', 'Feb', 'Mar', etc., and then implement the GetMonth function")
 }
 
-// AccNo type for a string - this is a stub type included to demonstrate how the untyped string constant can be used where this type is required
+// AccNo type for a string - this is a stub type included to demonstrate how the untyped string constant can be used where this type is required.
 type AccNo string
 
 // AccountNo has a value of XF348IJ
 
-// GetAccountNumber returns the AccountNo constant
+// GetAccountNumber returns the AccountNo constant.
 func GetAccountNumber() AccNo {
 	panic("Please create the AccountNo untyped string constant in the outer scope and then implement the GetAccountNumber function")
 }

--- a/exercises/concept/sorting-room/.meta/exemplar.go
+++ b/exercises/concept/sorting-room/.meta/exemplar.go
@@ -19,7 +19,7 @@ func DescribeNumberBox(nb NumberBox) string {
 	return fmt.Sprintf("This is a box containing the number %.1f", float64(nb.Number()))
 }
 
-// FancyNumber holds an integer as a string
+// FancyNumber holds an integer as a string.
 type FancyNumber struct {
 	n string
 }

--- a/exercises/concept/the-farm/.meta/exemplar.go
+++ b/exercises/concept/the-farm/.meta/exemplar.go
@@ -15,7 +15,7 @@ func (sn *SillyNephewError) Error() string {
 	return fmt.Sprintf("silly nephew, there cannot be %d cows", sn.Cows)
 }
 
-// DivideFood computes the fodder amount per cow for the given cows
+// DivideFood computes the fodder amount per cow for the given cows.
 func DivideFood(weightFodder WeightFodder, cows int) (float64, error) {
 	fodder, err := weightFodder.FodderAmount()
 	if err != nil && err != ErrScaleMalfunction {


### PR DESCRIPTION
We have an exercise that explicitly teaches people to use proper punctuation for doc comments.

This adds punctuation where it's missing from doc comments in the stub files for other concept exercises.

I've also removed a doc-style comment from one of the concept exercise test files, since we don't want to implicitly encourage people to write doc comments for their tests.