### PR TITLE
Add missing test cases for Annalyn's Infiltration

### DIFF
--- a/exercises/concept/annalyns-infiltration/annalyns_infiltration_test.go
+++ b/exercises/concept/annalyns-infiltration/annalyns_infiltration_test.go
@@ -267,6 +267,22 @@ func TestCanFreePrisoner(t *testing.T) {
 			dogIsPresent:    true,
 			expected:        false,
 		},
+		{
+			desc:            "Knight and archer are awake. Prisoner is sleeping. Dog is not present",
+			knightIsAwake:   true,
+			archerIsAwake:   true,
+			prisonerIsAwake: false,
+			dogIsPresent:    false,
+			expected:        false,
+		},
+		{
+			desc:            "Everyone is sleeping. Dog is not present",
+			knightIsAwake:   false,
+			archerIsAwake:   false,
+			prisonerIsAwake: false,
+			dogIsPresent:    false,
+			expected:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
In this exercise the instructions say that the prisoner MUST be
awake in order to be rescued, as if they are sleeping they'll be
startled by the rescue attempt, which will alert the guards.

Today we saw a solution that would have allowed Annalyn to rescue
a sleeping prisoner if she didn't have her dog along.

This adds a couple of extra cases for that scenario.

The exemplar correctly implements the function, and should therefore
pass the new tests.