### PR TITLE
Added nil test case to census exercise

### DIFF
--- a/exercises/concept/census/.meta/exemplar.go
+++ b/exercises/concept/census/.meta/exemplar.go
@@ -23,10 +23,6 @@ func (r *Resident) HasRequiredInfo() bool {
 		return false
 	}
 
-	if _, ok := r.Address["street"]; !ok {
-		return false
-	}
-
 	if r.Address["street"] == "" {
 		return false
 	}

--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -74,6 +74,15 @@ func TestHasRequiredInfo(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "nil map as address",
+			resident: &Resident{
+				Name:    "Rob Pike",
+				Age:     0,
+				Address: nil,
+			},
+			want: false,
+		},
+		{
 			name: "empty map as address",
 			resident: &Resident{
 				Name:    "Rob Pike",


### PR DESCRIPTION
This PR adds missing test case to go [Census exercise](https://exercism.org/tracks/go/exercises/census).

1. Added `r.Address == nil` test case
2. Updated solution in exemplar.go file

Closes #2352.