### PR TITLE
scale-generator: updated exercise generator to new test generator

### DIFF
--- a/exercises/practice/scale-generator/.docs/instructions.md
+++ b/exercises/practice/scale-generator/.docs/instructions.md
@@ -1,36 +1,47 @@
 # Instructions
 
-Given a tonic, or starting note, and a set of intervals, generate
-the musical scale starting with the tonic and following the
-specified interval pattern.
+## Chromatic Scales
 
 Scales in Western music are based on the chromatic (12-note) scale. This
 scale can be expressed as the following group of pitches:
 
-A, A#, B, C, C#, D, D#, E, F, F#, G, G#
+> A, A♯, B, C, C♯, D, D♯, E, F, F♯, G, G♯
 
-A given sharp note (indicated by a #) can also be expressed as the flat
-of the note above it (indicated by a b) so the chromatic scale can also be
+A given sharp note (indicated by a ♯) can also be expressed as the flat
+of the note above it (indicated by a ♭) so the chromatic scale can also be
 written like this:
 
-A, Bb, B, C, Db, D, Eb, E, F, Gb, G, Ab
+> A, B♭, B, C, D♭, D, E♭, E, F, G♭, G, A♭
 
 The major and minor scale and modes are subsets of this twelve-pitch
 collection. They have seven pitches, and are called diatonic scales.
 The collection of notes in these scales is written with either sharps or
-flats, depending on the tonic. Here is a list of which are which:
+flats, depending on the tonic (starting note). Here is a table indicating
+whether the flat expression or sharp expression of the scale would be used for
+a given tonic:
 
-No Sharps or Flats:
-C major
-a minor
+| Key Signature | Major                 | Minor                |
+| ------------- | --------------------- | -------------------- |
+| Natural       | C                     | a                    |
+| Sharp         | G, D, A, E, B, F♯     | e, b, f♯, c♯, g♯, d♯ |
+| Flat          | F, B♭, E♭, A♭, D♭, G♭ | d, g, c, f, b♭, e♭   |
 
-Use Sharps:
-G, D, A, E, B, F# major
-e, b, f#, c#, g#, d# minor
+Note that by common music theory convention the natural notes "C" and "a"
+follow the sharps scale when ascending and the flats scale when descending.
+For the scope of this exercise the scale is only ascending.
 
-Use Flats:
-F, Bb, Eb, Ab, Db, Gb major
-d, g, c, f, bb, eb minor
+### Task
+
+Given a tonic, generate the 12 note chromatic scale starting with the tonic.
+
+- Shift the base scale appropriately so that all 12 notes are returned
+starting with the given tonic.
+- For the given tonic, determine if the scale is to be returned with flats
+or sharps.
+- Return all notes in uppercase letters (except for the `b` for flats)
+irrespective of the casing of the given tonic.
+
+## Diatonic Scales
 
 The diatonic scales, and all other scales that derive from the
 chromatic scale, are built upon intervals. An interval is the space
@@ -44,6 +55,29 @@ diatonic scales are built using only these two intervals between
 adjacent notes.
 
 Non-diatonic scales can contain other intervals.  An "augmented second"
-interval, written "A", has two interceding notes (e.g., from A to C or Db to E)
+interval, written "A", has two interceding notes (e.g., from A to C or D♭ to E)
 or a "whole step" plus a "half step". There are also smaller and larger
 intervals, but they will not figure into this exercise.
+
+### Task
+
+Given a tonic and a set of intervals, generate the musical scale starting with
+the tonic and following the specified interval pattern.
+
+This is similar to generating chromatic scales except that instead of returning
+12 notes, you will return N+1 notes for N intervals.
+The first note is always the given tonic.
+Then, for each interval in the pattern, the next note is determined by starting from the previous note and skipping the number of notes indicated by the interval.
+
+For example, starting with G and using the seven intervals MMmMMMm, there would be the following eight notes:
+
+Note | Reason
+--|--
+G | Tonic
+A | M indicates a whole step from G, skipping G♯
+B | M indicates a whole step from A, skipping A♯
+C | m indicates a half step from B, skipping nothing
+D | M indicates a whole step from C, skipping C♯
+E | M indicates a whole step from D, skipping D♯
+F♯ | M indicates a whole step from E, skipping F
+G | m indicates a half step from F♯, skipping nothing

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
+  "blurb": "Generate musical scales, given a starting note and a set of intervals.",
   "authors": [
     "sunilgopinath"
   ],

--- a/exercises/practice/scale-generator/.meta/example.go
+++ b/exercises/practice/scale-generator/.meta/example.go
@@ -5,17 +5,14 @@ import (
 	"strings"
 )
 
-var chromaticScale = []string{"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A",
-	"A#", "B"}
-var flatChromaticScale = []string{"C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab",
-	"A", "Bb", "B"}
-var flatKeys = []string{"F", "Bb", "Eb", "Ab", "Db", "Gb", "d", "g", "c", "f", "bb",
-	"eb"}
+var chromaticScale = []string{"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
+var flatChromaticScale = []string{"C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"}
+var flatKeys = []string{"F", "Bb", "Eb", "Ab", "Db", "Gb", "d", "g", "c", "f", "bb", "eb"}
 
 // Scale returns a type of scale based on the inputs
 func Scale(tonic, interval string) []string {
 	if interval == "" {
-		interval = strings.Repeat("m", 12)
+		interval = strings.Repeat("m", 11)
 	}
 	ft := formatTonic(tonic)
 	scale := chromaticScale
@@ -28,7 +25,7 @@ func Scale(tonic, interval string) []string {
 
 func printScale(tonic, interval string, start int, arr []string) []string {
 	res := []string{tonic}
-	for _, e := range interval[:len(interval)-1] {
+	for _, e := range interval {
 		switch e {
 		case 'm':
 			start++

--- a/exercises/practice/scale-generator/.meta/gen.go
+++ b/exercises/practice/scale-generator/.meta/gen.go
@@ -12,27 +12,24 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	var j js
-	if err := gen.Gen("scale-generator", &j, t); err != nil {
+	var j = map[string]interface{}{
+		"chromatic" : &[]testCase{},
+		"interval" : &[]testCase{},
+	}
+	if err := gen.Gen("scale-generator", j, t); err != nil {
 		log.Fatal(err)
 	}
 }
 
-// The JSON structure we expect to be able to unmarshal into
-type js struct {
-	Cases []struct {
-		Comments    []string
-		Description string
-		Cases       []struct {
-			Description string
-			Property    string
-			Input       struct {
-				Tonic     string
-				Intervals string
-			}
-			Expected []string
-		}
-	}
+type testCase struct {
+	Uuid        string `json:"uuid"`
+	Description string `json:"description"`
+	Property    string `json:"property"`
+	Input       struct {
+		Tonic     string `json:"tonic"`
+		Intervals string `json:"intervals"`
+	} `json:"input"`
+	Expected []string `json:"expected"`
 }
 
 // template applied to above data structure generates the Go test cases
@@ -48,12 +45,19 @@ type scaleTest struct {
 }
 
 var scaleTestCases = []scaleTest {
-{{range .J.Cases}} {{range .Cases}}{
+{{range .J.chromatic}}{
 	description: {{printf "%q" .Description }},
 	tonic: {{printf "%q" .Input.Tonic }},
 	interval: {{printf "%q" .Input.Intervals }},
 	expected: {{printf "%#v" .Expected }},
 },
-{{end}}{{end}}
+{{end}}
+{{range .J.interval}}{
+	description: {{printf "%q" .Description }},
+	tonic: {{printf "%q" .Input.Tonic }},
+	interval: {{printf "%q" .Input.Intervals }},
+	expected: {{printf "%#v" .Expected }},
+},
+{{end}}
 }
 `

--- a/exercises/practice/scale-generator/.meta/tests.toml
+++ b/exercises/practice/scale-generator/.meta/tests.toml
@@ -1,54 +1,136 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [10ea7b14-8a49-40be-ac55-7c62b55f9b47]
-description = "Chromatic scale with sharps"
+description = "Chromatic scales -> Chromatic scale with sharps"
 
 [af8381de-9a72-4efd-823a-48374dbfe76f]
-description = "Chromatic scale with flats"
+description = "Chromatic scales -> Chromatic scale with flats"
+
+[7195998a-7be7-40c9-8877-a1d7949e061b]
+description = "Scales with specified intervals -> Simple major scale"
+reimplements = "6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e"
+
+[fe853b97-1878-4090-b218-4029246abb91]
+description = "Scales with specified intervals -> Major scale with sharps"
+reimplements = "13a92f89-a83e-40b5-b9d4-01136931ba02"
+
+[d60cb414-cc02-4fcb-ad7a-fc7ef0a9eead]
+description = "Scales with specified intervals -> Major scale with flats"
+reimplements = "aa3320f6-a761-49a1-bcf6-978e0c81080a"
+
+[77dab9b3-1bbc-4f9a-afd8-06da693bcc67]
+description = "Scales with specified intervals -> Minor scale with sharps"
+reimplements = "63daeb2f-c3f9-4c45-92be-5bf97f61ff94"
+
+[5fa1728f-5b66-4b43-9b7c-84359b7069d4]
+description = "Scales with specified intervals -> Minor scale with flats"
+reimplements = "616594d0-9c48-4301-949e-af1d4fad16fd"
+
+[f3f1c353-8f7b-4a85-a5b5-ae06c2645823]
+description = "Scales with specified intervals -> Dorian mode"
+reimplements = "390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a"
+
+[5fe14e5a-3ddc-4202-a158-2c1158beb5d0]
+description = "Scales with specified intervals -> Mixolydian mode"
+reimplements = "846d0862-0f3e-4f3b-8a2d-9cc74f017848"
+
+[e6307799-b7f6-43fc-a6d8-a4834d6e2bdb]
+description = "Scales with specified intervals -> Lydian mode"
+reimplements = "7d49a8bb-b5f7-46ad-a207-83bd5032291a"
+
+[7c4a95cd-ecf4-448d-99bc-dbbca51856e0]
+description = "Scales with specified intervals -> Phrygian mode"
+reimplements = "a4e4dac5-1891-4160-a19f-bb06d653d4d0"
+
+[f476f9c9-5a13-473d-bb6c-f884cf8fd9f2]
+description = "Scales with specified intervals -> Locrian mode"
+reimplements = "ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa"
+
+[87fdbcca-d3dd-46d5-9c56-ec79e25b19f4]
+description = "Scales with specified intervals -> Harmonic minor"
+reimplements = "70517400-12b7-4530-b861-fa940ae69ee8"
+
+[b28ecc18-88db-4fd5-a973-cfe6361e2b24]
+description = "Scales with specified intervals -> Octatonic"
+reimplements = "37114c0b-c54d-45da-9f4b-3848201470b0"
+
+[a1c7d333-6fb3-4f3b-9178-8a0cbe043134]
+description = "Scales with specified intervals -> Hexatonic"
+reimplements = "496466e7-aa45-4bbd-a64d-f41030feed9c"
+
+[9acfd139-0781-4926-8273-66a478c3b287]
+description = "Scales with specified intervals -> Pentatonic"
+reimplements = "bee5d9ec-e226-47b6-b62b-847a9241f3cc"
+
+[31c933ca-2251-4a5b-92dd-9d5831bc84ad]
+description = "Scales with specified intervals -> Enigmatic"
+reimplements = "dbee06a6-7535-4ab7-98e8-d8a36c8402d1"
 
 [6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e]
-description = "Simple major scale"
+description = "Scales with specified intervals -> Simple major scale"
+include = false
 
 [13a92f89-a83e-40b5-b9d4-01136931ba02]
-description = "Major scale with sharps"
+description = "Scales with specified intervals -> Major scale with sharps"
+include = false
 
 [aa3320f6-a761-49a1-bcf6-978e0c81080a]
-description = "Major scale with flats"
+description = "Scales with specified intervals -> Major scale with flats"
+include = false
 
 [63daeb2f-c3f9-4c45-92be-5bf97f61ff94]
-description = "Minor scale with sharps"
+description = "Scales with specified intervals -> Minor scale with sharps"
+include = false
 
 [616594d0-9c48-4301-949e-af1d4fad16fd]
-description = "Minor scale with flats"
+description = "Scales with specified intervals -> Minor scale with flats"
+include = false
 
 [390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a]
-description = "Dorian mode"
+description = "Scales with specified intervals -> Dorian mode"
+include = false
 
 [846d0862-0f3e-4f3b-8a2d-9cc74f017848]
-description = "Mixolydian mode"
+description = "Scales with specified intervals -> Mixolydian mode"
+include = false
 
 [7d49a8bb-b5f7-46ad-a207-83bd5032291a]
-description = "Lydian mode"
+description = "Scales with specified intervals -> Lydian mode"
+include = false
 
 [a4e4dac5-1891-4160-a19f-bb06d653d4d0]
-description = "Phrygian mode"
+description = "Scales with specified intervals -> Phrygian mode"
+include = false
 
 [ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa]
-description = "Locrian mode"
+description = "Scales with specified intervals -> Locrian mode"
+include = false
 
 [70517400-12b7-4530-b861-fa940ae69ee8]
-description = "Harmonic minor"
+description = "Scales with specified intervals -> Harmonic minor"
+include = false
 
 [37114c0b-c54d-45da-9f4b-3848201470b0]
-description = "Octatonic"
+description = "Scales with specified intervals -> Octatonic"
+include = false
 
 [496466e7-aa45-4bbd-a64d-f41030feed9c]
-description = "Hexatonic"
+description = "Scales with specified intervals -> Hexatonic"
+include = false
 
 [bee5d9ec-e226-47b6-b62b-847a9241f3cc]
-description = "Pentatonic"
+description = "Scales with specified intervals -> Pentatonic"
+include = false
 
 [dbee06a6-7535-4ab7-98e8-d8a36c8402d1]
-description = "Enigmatic"
+description = "Scales with specified intervals -> Enigmatic"
+include = false

--- a/exercises/practice/scale-generator/cases_test.go
+++ b/exercises/practice/scale-generator/cases_test.go
@@ -1,8 +1,7 @@
 package scale
 
 // Source: exercism/problem-specifications
-// Commit: 65cc51b Update scale-generator version to 2.0.0
-// Problem Specifications Version: 2.0.0
+// Commit: 2e820e1 Auto-format portions of some JSON files (#1967)
 
 type scaleTest struct {
 	description string
@@ -24,94 +23,95 @@ var scaleTestCases = []scaleTest{
 		interval:    "",
 		expected:    []string{"F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E"},
 	},
+
 	{
 		description: "Simple major scale",
 		tonic:       "C",
 		interval:    "MMmMMMm",
-		expected:    []string{"C", "D", "E", "F", "G", "A", "B"},
+		expected:    []string{"C", "D", "E", "F", "G", "A", "B", "C"},
 	},
 	{
 		description: "Major scale with sharps",
 		tonic:       "G",
 		interval:    "MMmMMMm",
-		expected:    []string{"G", "A", "B", "C", "D", "E", "F#"},
+		expected:    []string{"G", "A", "B", "C", "D", "E", "F#", "G"},
 	},
 	{
 		description: "Major scale with flats",
 		tonic:       "F",
 		interval:    "MMmMMMm",
-		expected:    []string{"F", "G", "A", "Bb", "C", "D", "E"},
+		expected:    []string{"F", "G", "A", "Bb", "C", "D", "E", "F"},
 	},
 	{
 		description: "Minor scale with sharps",
 		tonic:       "f#",
 		interval:    "MmMMmMM",
-		expected:    []string{"F#", "G#", "A", "B", "C#", "D", "E"},
+		expected:    []string{"F#", "G#", "A", "B", "C#", "D", "E", "F#"},
 	},
 	{
 		description: "Minor scale with flats",
 		tonic:       "bb",
 		interval:    "MmMMmMM",
-		expected:    []string{"Bb", "C", "Db", "Eb", "F", "Gb", "Ab"},
+		expected:    []string{"Bb", "C", "Db", "Eb", "F", "Gb", "Ab", "Bb"},
 	},
 	{
 		description: "Dorian mode",
 		tonic:       "d",
 		interval:    "MmMMMmM",
-		expected:    []string{"D", "E", "F", "G", "A", "B", "C"},
+		expected:    []string{"D", "E", "F", "G", "A", "B", "C", "D"},
 	},
 	{
 		description: "Mixolydian mode",
 		tonic:       "Eb",
 		interval:    "MMmMMmM",
-		expected:    []string{"Eb", "F", "G", "Ab", "Bb", "C", "Db"},
+		expected:    []string{"Eb", "F", "G", "Ab", "Bb", "C", "Db", "Eb"},
 	},
 	{
 		description: "Lydian mode",
 		tonic:       "a",
 		interval:    "MMMmMMm",
-		expected:    []string{"A", "B", "C#", "D#", "E", "F#", "G#"},
+		expected:    []string{"A", "B", "C#", "D#", "E", "F#", "G#", "A"},
 	},
 	{
 		description: "Phrygian mode",
 		tonic:       "e",
 		interval:    "mMMMmMM",
-		expected:    []string{"E", "F", "G", "A", "B", "C", "D"},
+		expected:    []string{"E", "F", "G", "A", "B", "C", "D", "E"},
 	},
 	{
 		description: "Locrian mode",
 		tonic:       "g",
 		interval:    "mMMmMMM",
-		expected:    []string{"G", "Ab", "Bb", "C", "Db", "Eb", "F"},
+		expected:    []string{"G", "Ab", "Bb", "C", "Db", "Eb", "F", "G"},
 	},
 	{
 		description: "Harmonic minor",
 		tonic:       "d",
 		interval:    "MmMMmAm",
-		expected:    []string{"D", "E", "F", "G", "A", "Bb", "Db"},
+		expected:    []string{"D", "E", "F", "G", "A", "Bb", "Db", "D"},
 	},
 	{
 		description: "Octatonic",
 		tonic:       "C",
 		interval:    "MmMmMmMm",
-		expected:    []string{"C", "D", "D#", "F", "F#", "G#", "A", "B"},
+		expected:    []string{"C", "D", "D#", "F", "F#", "G#", "A", "B", "C"},
 	},
 	{
 		description: "Hexatonic",
 		tonic:       "Db",
 		interval:    "MMMMMM",
-		expected:    []string{"Db", "Eb", "F", "G", "A", "B"},
+		expected:    []string{"Db", "Eb", "F", "G", "A", "B", "Db"},
 	},
 	{
 		description: "Pentatonic",
 		tonic:       "A",
 		interval:    "MMAMA",
-		expected:    []string{"A", "B", "C#", "E", "F#"},
+		expected:    []string{"A", "B", "C#", "E", "F#", "A"},
 	},
 	{
 		description: "Enigmatic",
 		tonic:       "G",
 		interval:    "mAMMMmm",
-		expected:    []string{"G", "G#", "B", "C#", "D#", "F", "F#"},
+		expected:    []string{"G", "G#", "B", "C#", "D#", "F", "F#", "G"},
 	},
 }

--- a/exercises/practice/scale-generator/scale_generator_test.go
+++ b/exercises/practice/scale-generator/scale_generator_test.go
@@ -6,12 +6,13 @@ import (
 )
 
 func TestScale(t *testing.T) {
-	for _, test := range scaleTestCases {
-		actual := Scale(test.tonic, test.interval)
-		if fmt.Sprintf("%q", actual) != fmt.Sprintf("%q", test.expected) {
-			t.Fatalf("FAIL: %s - Scale(%q, %q)\nExpected: %q\nActual: %q", test.description, test.tonic, test.interval, test.expected, actual)
-		}
-		t.Logf("PASS: %s", test.description)
+	for _, tc := range scaleTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := Scale(tc.tonic, tc.interval)
+			if fmt.Sprintf("%q", actual) != fmt.Sprintf("%q", tc.expected) {
+				t.Fatalf("Scale(%q, %q)\n got:%#v\nwant:%#v", tc.tonic, tc.interval, actual, tc.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
One of #2302

Here I also had the refactor `example.go` as the there was a big change in the test cases: https://github.com/exercism/problem-specifications/pull/1888