### PR TITLE
card-tricks: use "values" instead of "value" in `PrependItems` function

### DIFF
--- a/exercises/concept/card-tricks/.meta/exemplar.go
+++ b/exercises/concept/card-tricks/.meta/exemplar.go
@@ -25,8 +25,8 @@ func SetItem(slice []int, index, value int) []int {
 }
 
 // PrependItems adds an arbitrary number of values at the front of a slice.
-func PrependItems(slice []int, value ...int) []int {
-	return append(value, slice...)
+func PrependItems(slice []int, values ...int) []int {
+	return append(values, slice...)
 }
 
 // RemoveItem removes an item from a slice by modifying the existing slice.

--- a/exercises/concept/card-tricks/card_tricks.go
+++ b/exercises/concept/card-tricks/card_tricks.go
@@ -18,7 +18,7 @@ func SetItem(slice []int, index, value int) []int {
 }
 
 // PrependItems adds an arbitrary number of values at the front of a slice.
-func PrependItems(slice []int, value ...int) []int {
+func PrependItems(slice []int, values ...int) []int {
 	panic("Please implement the PrependItems function")
 }
 


### PR DESCRIPTION
This gets me every time I mentor this exercise.