### PR TITLE
census: add more tests for Count()

### DIFF
--- a/exercises/concept/census/census_test.go
+++ b/exercises/concept/census/census_test.go
@@ -228,6 +228,20 @@ func TestCount(t *testing.T) {
 					Age:     0,
 					Address: map[string]string{},
 				},
+				{
+					Name: "",
+					Age:  0,
+					Address: map[string]string{
+						"street": "Main St.",
+					},
+				},
+				{
+					Name: "",
+					Age:  0,
+					Address: map[string]string{
+						"city": "London",
+					},
+				},
 			},
 			want: 1,
 		},


### PR DESCRIPTION
Signed-off-by: Jasstkn <mariia.kotliarevskaia@gmail.com>

fixes #2386 

scope of changes:
- added one testCase with empty name and not empty address with street
- added one testCase with empty name and not empty address with other field than street

this code fails 2 cases from TestCount/some_data_collected now (was 0 before)
```go
func Count(residents []*Resident) int {
	counter := 0
	for _, resident := range residents {
		if len(resident.Address) != 0 {
	            counter += 1
		}
	}
	return counter
}
```

If user validates all fields or refer to already written function, it should be ok. 