### PR TITLE
meetup: revert stub to not include the solution

### DIFF
--- a/exercises/practice/meetup/meetup.go
+++ b/exercises/practice/meetup/meetup.go
@@ -2,21 +2,8 @@ package meetup
 
 import "time"
 
-type WeekSchedule int
-
-const (
-	First  WeekSchedule = 1
-	Second WeekSchedule = 8
-	Third  WeekSchedule = 15
-	Fourth WeekSchedule = 22
-	Teenth WeekSchedule = 13
-	Last   WeekSchedule = -6
-)
+// Define the WeekSchedule type here.
 
 func Day(wSched WeekSchedule, wDay time.Weekday, month time.Month, year int) int {
-	if wSched == Last {
-		month++
-	}
-	t := time.Date(year, month, int(wSched), 12, 0, 0, 0, time.UTC)
-	return t.Day() + int(wDay-t.Weekday()+7)%7
+	panic("Please implement the Day function")
 }


### PR DESCRIPTION
The solution for the exercise was included in the stub by mistake in #2343

This reverts the stub back to not include the solution.