### PR TITLE
Wrong formatted example

### DIFF
--- a/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
+++ b/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
@@ -27,8 +27,7 @@ It should return a `string` that consists of 3 lines, a line with the desired nu
 
 ```go
 AddBorder("Welcome!", 10)
-// =>
-// **********
+// => **********
 // Welcome!
 // **********
 ```

--- a/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
+++ b/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
@@ -27,7 +27,12 @@ It should return a `string` that consists of 3 lines, a line with the desired nu
 
 ```go
 AddBorder("Welcome!", 10)
-// => **********
+```
+
+Should return the following:
+
+```go
+// **********
 // Welcome!
 // **********
 ```


### PR DESCRIPTION
Following the others examples starting with `=> ` the previuos example was wronlgy suggesting `\n` at the start of the string.