### PR TITLE
add a cross-reference to a (base) need-for-speed exercise

### DIFF
--- a/exercises/concept/elons-toys/.docs/instructions.md
+++ b/exercises/concept/elons-toys/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Note: This exercise is a continuation of the `need-for-speed` exercise.
+Note: This exercise is a continuation of the [`need-for-speed` exercise](https://exercism.org/tracks/go/exercises/need-for-speed).
 
 In this exercise you'll be organizing races between various types of remote controlled cars. Each car has its own speed and battery drain characteristics.
 


### PR DESCRIPTION
I think it makes sense make a link to the exercise that is a precursor to this exercise. Otherwise students won't be able to easily refresh what they implemented in the previous exerciese.