### PR TITLE
Animal Magic: Added test case for GenerateWandEnergy()

### DIFF
--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -62,17 +62,19 @@ func TestWandEnergy(t *testing.T) {
 		last = got
 	}
 	if !foundDifferent {
-		t.Errorf("GenerateWandEnergy() always generates the same number: %f", got)
+		t.Fatalf("GenerateWandEnergy() always generates the same number: %f", got)
 	}
 
-	var emptyBuckets int
-	for _, v := range buckets {
+	var low, high float64
+	for i, v := range buckets {
 		if v == 0 {
-			emptyBuckets++
+			low = float64(i) * bucketSize
+			high = float64(i+1) * bucketSize
+			break
 		}
 	}
-	if emptyBuckets > 1 {
-		t.Errorf("GenerateWandEnergy() results are not uniformly distributed. %d of %d buckets are empty.", emptyBuckets, numBuckets)
+	if high != 0.0 {
+		t.Errorf("GenerateWandEnergy() results are not uniformly distributed. %f to %f should contain values.", low, high)
 	}
 }
 

--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -74,7 +74,7 @@ func TestWandEnergy(t *testing.T) {
 		}
 	}
 	if high != 0.0 {
-		t.Errorf("GenerateWandEnergy() results are not uniformly distributed. %f to %f should contain values.", low, high)
+		t.Errorf("GenerateWandEnergy() results are not uniformly distributed. %.2f to %.2f should contain values.", low, high)
 	}
 }
 

--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -43,10 +43,13 @@ func TestRollADie(t *testing.T) {
 }
 
 func TestWandEnergy(t *testing.T) {
-	const tests = 100
+	const tests = 200
+	const bucketSize float64 = 0.6
 	var got float64
 	foundDifferent := false
 	var last float64
+	numBuckets := int(12.0 / bucketSize)
+	buckets := make([]int, numBuckets)
 	for i := 0; i < tests; i++ {
 		got = GenerateWandEnergy()
 		if got < 0.0 || got >= 12.0 {
@@ -55,10 +58,21 @@ func TestWandEnergy(t *testing.T) {
 		if i > 0 && got != last {
 			foundDifferent = true
 		}
+		buckets[int(got/bucketSize)]++
 		last = got
 	}
 	if !foundDifferent {
 		t.Errorf("GenerateWandEnergy() always generates the same number: %f", got)
+	}
+
+	var emptyBuckets int
+	for _, v := range buckets {
+		if v == 0 {
+			emptyBuckets++
+		}
+	}
+	if emptyBuckets > 1 {
+		t.Errorf("GenerateWandEnergy() results are not uniformly distributed. %d of %d buckets are empty.", emptyBuckets, numBuckets)
 	}
 }
 


### PR DESCRIPTION
Proposed test case to improve testing of GenerateWandEnergy() task of Animal Magic.
The tests currently pass if a student uses randomly generated ints and then typecasts the result to float64 which doesn't meet the requirements.

`tests` was bumped to ensure that even if a random seed is used, the test should pass. For grins, I ran the bucket test 1M times with various values for `tests` and it passed at 150. I bumped to 200 for extra margin.

Assuming no issues, I will give the same treatment to the other two tasks in the exercise.
#2417 