### PR TITLE
Allow whitespace in comments

### DIFF
--- a/exercises/concept/weather-forecast/weather_forecast_test.go
+++ b/exercises/concept/weather-forecast/weather_forecast_test.go
@@ -112,7 +112,7 @@ func testComment(entityKind, entityName, comment, wantedPrefix string) (ok bool,
 	lowerEntity := strings.ToLower(entityKind)
 
 	// Check if comment has wanted prefix
-	if !strings.HasPrefix(comment, wantedPrefix) {
+	if !strings.HasPrefix(trimmedComment, wantedPrefix) {
 		errorString := fmt.Sprintf("%s comment for %s '%s' should start with '// %s ...': got '// %s'",
 			entityKind, lowerEntity, entityName, wantedPrefix, trimmedComment)
 		return false, errorString


### PR DESCRIPTION
Without updating this test, the comments in go fail. For example, this should be a valid package description comment (assuming it was for weather not builtin): 
/*
	Package builtin provides documentation for Go's predeclared identifiers.
	The items documented here are not actually in package builtin
	but their descriptions here allow godoc to present documentation
	for the language's special identifiers.
*/