### PR TITLE
Ignore Security Warnings for math/rand

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gocyclo
     - goimports
     - gofmt
+    - gosec
     - gosimple
     - govet
     - staticcheck

--- a/exercises/concept/animal-magic/.meta/exemplar.go
+++ b/exercises/concept/animal-magic/.meta/exemplar.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package chance
 
 import (

--- a/exercises/concept/animal-magic/.meta/exemplar.go
+++ b/exercises/concept/animal-magic/.meta/exemplar.go
@@ -1,3 +1,4 @@
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package chance
 
 import (

--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package chance
 
 import (

--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package chance
 
 import (

--- a/exercises/practice/binary-search/binary_search_test.go
+++ b/exercises/practice/binary-search/binary_search_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package binarysearch
 
 import (

--- a/exercises/practice/binary-search/binary_search_test.go
+++ b/exercises/practice/binary-search/binary_search_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package binarysearch
 
 import (

--- a/exercises/practice/custom-set/custom_set_test.go
+++ b/exercises/practice/custom-set/custom_set_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package stringset
 
 import (

--- a/exercises/practice/custom-set/custom_set_test.go
+++ b/exercises/practice/custom-set/custom_set_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package stringset
 
 import (

--- a/exercises/practice/custom-set/custom_set_test.go
+++ b/exercises/practice/custom-set/custom_set_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package stringset
 
 import (

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package diamond
 
 import (

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package diamond
 
 import (

--- a/exercises/practice/diamond/diamond_test.go
+++ b/exercises/practice/diamond/diamond_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package diamond
 
 import (

--- a/exercises/practice/diffie-hellman/.meta/example.go
+++ b/exercises/practice/diffie-hellman/.meta/example.go
@@ -1,3 +1,4 @@
+ //nolint:gosec // math.rand is more appropriate than crypto.rand
 package diffiehellman
 
 import (

--- a/exercises/practice/diffie-hellman/.meta/example.go
+++ b/exercises/practice/diffie-hellman/.meta/example.go
@@ -1,4 +1,4 @@
- //nolint:gosec // math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package diffiehellman
 
 import (

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.go
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.go
@@ -1,4 +1,3 @@
- //nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package diffiehellman
 
 import (

--- a/exercises/practice/diffie-hellman/diffie_hellman_test.go
+++ b/exercises/practice/diffie-hellman/diffie_hellman_test.go
@@ -1,3 +1,4 @@
+ //nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package diffiehellman
 
 import (

--- a/exercises/practice/grade-school/grade_school_test.go
+++ b/exercises/practice/grade-school/grade_school_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package school
 
 import (

--- a/exercises/practice/grade-school/grade_school_test.go
+++ b/exercises/practice/grade-school/grade_school_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package school
 
 import (

--- a/exercises/practice/tree-building/tree_building_test.go
+++ b/exercises/practice/tree-building/tree_building_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package tree
 
 import (

--- a/exercises/practice/tree-building/tree_building_test.go
+++ b/exercises/practice/tree-building/tree_building_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec
+//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
 package tree
 
 import (

--- a/exercises/practice/tree-building/tree_building_test.go
+++ b/exercises/practice/tree-building/tree_building_test.go
@@ -1,4 +1,4 @@
-//nolint:gosec // Randomness is part of an exercise where math.rand is more appropriate than crypto.rand
+//nolint:gosec // In the context of this exercise, it is fine to use math.Rand instead of crypto.Rand.
 package tree
 
 import (


### PR DESCRIPTION
Updated test files so that `gosec` ignores `math/rand`.  Files updated based on [this CI job](https://github.com/exercism/go/runs/7734762492?check_suite_focus=true) 

For these exercises `math/rand` is better a better option than `crypto/rand` based on suggestion in PR #2416