### PR TITLE
Added Additional Hint for Processing Parts of a Date

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.docs/hints.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/hints.md
@@ -7,7 +7,7 @@
 ## 1. Parse appointment date
 
 - There is a [method][time.parse] for parsing a `string` into a `Time`.
-- Additional information for formatting parts of a date are in the [time format source][time.format.source]
+- Additional information for formatting parts of a date are in the [time package constants][time.package.constants]
 
 ## 2. Check if an appointment has already passed
 
@@ -31,4 +31,4 @@
 [after]: https://golang.org/pkg/time/#Time.After
 [now]: https://golang.org/pkg/time/#Now
 [hour]: https://golang.org/pkg/time/#Time.Hour
-[time.format.source]: https://go.dev/src/time/format.go
+[time.package.constants]: https://pkg.go.dev/time#pkg-constants

--- a/exercises/concept/booking-up-for-beauty/.docs/hints.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/hints.md
@@ -7,6 +7,7 @@
 ## 1. Parse appointment date
 
 - There is a [method][time.parse] for parsing a `string` into a `Time`.
+- Additional information for formatting parts of a date are in the [time format source][time.format.source]
 
 ## 2. Check if an appointment has already passed
 
@@ -30,3 +31,4 @@
 [after]: https://golang.org/pkg/time/#Time.After
 [now]: https://golang.org/pkg/time/#Now
 [hour]: https://golang.org/pkg/time/#Time.Hour
+[time.format.source]: https://go.dev/src/time/format.go

--- a/exercises/concept/booking-up-for-beauty/.docs/hints.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/hints.md
@@ -7,7 +7,7 @@
 ## 1. Parse appointment date
 
 - There is a [method][time.parse] for parsing a `string` into a `Time`.
-- Additional information for formatting parts of a date are in the [time package constants][time.package.constants]
+- Additional information for formatting parts of a date can be found in the constants section of the [time package documentation][time-package-constants].
 
 ## 2. Check if an appointment has already passed
 
@@ -31,4 +31,4 @@
 [after]: https://golang.org/pkg/time/#Time.After
 [now]: https://golang.org/pkg/time/#Now
 [hour]: https://golang.org/pkg/time/#Time.Hour
-[time.package.constants]: https://pkg.go.dev/time#pkg-constants
+[time-package-constants]: https://pkg.go.dev/time#pkg-constants


### PR DESCRIPTION
Hint for `time.Parse` alone is not helpful. Even minor changes can render the time incorrect. This could be frustrating for learners.