### PR TITLE
Fix flaky animal magic test on windows

### DIFF
--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -17,7 +17,7 @@ func TestSeedWithTime(t *testing.T) {
 			return
 		}
 		last = got
-		time.Sleep((time.Duration(rand.Intn(10))) * time.Microsecond)
+		time.Sleep((time.Duration(rand.Intn(10))) * time.Millisecond)
 	}
 	t.Errorf("SeedWithTime always sets the same seed")
 }


### PR DESCRIPTION
Potential fix for https://github.com/exercism/go/actions/runs/2851358812

I found some indications that there might be issues when calling rand.Seed to close after each other might cause issues here. Maybe leaving some more time between the calls will fix the issue that the test is flaky on windows. Worst case the test case can take 1s now which is ok imo.