### PR TITLE
Exercise grep : fix test case which incorrectly fails on nil slice, but expect empty slice

### DIFF
--- a/exercises/practice/grep/grep_test.go
+++ b/exercises/practice/grep/grep_test.go
@@ -64,7 +64,13 @@ func TestSearch(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			actual := Search(tc.pattern, tc.flags, tc.files)
-			if !reflect.DeepEqual(actual, tc.expected) && !(len(actual) == 0 && len(tc.expected) == 0) {
+
+			// We do not care whether the result is nil or an empty slice.
+			if len(tc.expected) == 0 && len(actual) == 0 {
+				return
+			}
+
+			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf("Search(%q,%v,%v)\ngot: %v\nwant: %v", tc.pattern, tc.flags, tc.files, actual, tc.expected)
 			}
 		})

--- a/exercises/practice/grep/grep_test.go
+++ b/exercises/practice/grep/grep_test.go
@@ -64,7 +64,7 @@ func TestSearch(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			actual := Search(tc.pattern, tc.flags, tc.files)
-			if !reflect.DeepEqual(actual, tc.expected) {
+			if !reflect.DeepEqual(actual, tc.expected) && !(len(actual) == 0 && len(tc.expected) == 0) {
 				t.Errorf("Search(%q,%v,%v)\ngot: %v\nwant: %v", tc.pattern, tc.flags, tc.files, actual, tc.expected)
 			}
 		})


### PR DESCRIPTION
This commit addresses an incorrectly failing test case.
	grep_test.go:68: Search("may",[-x],[midsummer-night.txt])
	   got: []
	   want: []

Although both slices are zero length, one is initialized, and one is not.
	expected: []string len: 0, cap: 0, []
	actual:   []string len: 0, cap: 0, nil

Added logic to test for zero length for actual and expected if DeepEqual is false.