### PR TITLE
Remove semicolon from a Go code example

### DIFF
--- a/exercises/concept/parsing-log-files/.docs/instructions.md
+++ b/exercises/concept/parsing-log-files/.docs/instructions.md
@@ -22,11 +22,11 @@ To be considered valid a line should begin with one of the following strings:
 Implement the `IsValidLine` function to return `false` if a string is not valid otherwise `true`.
 
 ```go 
-IsValidLine("[ERR] A good error here");
+IsValidLine("[ERR] A good error here")
 // => true
-IsValidLine("Any old [ERR] text");
+IsValidLine("Any old [ERR] text")
 // => false
-IsValidLine("[BOB] Any old text");
+IsValidLine("[BOB] Any old text")
 // => false
 ```
 


### PR DESCRIPTION
Hi 👋

I noticed that a code example in the `instructions.md` file of one of the Go exercise had semicolons (`;`) which are usually not part of the language. I made a PR to remove them.

Cheers