### PR TITLE
added usage of subtests for two-fer

### DIFF
--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -12,7 +12,8 @@
     "R4wm",
     "robphoenix",
     "sebito91",
-    "ZapAnton"
+    "ZapAnton",
+    "eklatzer"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/two-fer/two_fer_test.go
+++ b/exercises/practice/two-fer/two_fer_test.go
@@ -2,21 +2,36 @@ package twofer
 
 import "testing"
 
-// Define a function ShareWith(string) string.
+type testCase struct {
+	description, input, expected string
+}
 
-var tests = []struct {
-	name, expected string
-}{
-	{"", "One for you, one for me."},
-	{"Alice", "One for Alice, one for me."},
-	{"Bob", "One for Bob, one for me."},
+var testCases = []testCase{
+	{
+		description: "empty name",
+		input:       "",
+		expected:    "One for you, one for me.",
+	},
+	{
+		description: "name is Alice",
+		input:       "Alice",
+		expected:    "One for Alice, one for me.",
+	},
+	{
+		description: "name is Bob",
+		input:       "Bob",
+		expected:    "One for Bob, one for me.",
+	},
 }
 
 func TestShareWith(t *testing.T) {
-	for _, test := range tests {
-		if observed := ShareWith(test.name); observed != test.expected {
-			t.Fatalf("ShareWith(%s) = \"%v\", want \"%v\"", test.name, observed, test.expected)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			got := ShareWith(tc.input)
+			if got != tc.expected {
+				t.Fatalf("ShareWith(%q)\n got: %q\nwant: %q", tc.input, got, tc.expected)
+			}
+		})
 	}
 }
 
@@ -26,8 +41,8 @@ func BenchmarkShareWith(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 
-		for _, test := range tests {
-			ShareWith(test.name)
+		for _, test := range testCases {
+			ShareWith(test.input)
 		}
 
 	}


### PR DESCRIPTION
One of #2098 

What is `example_two_fer_test.go` for? Can we delete it?