### PR TITLE
Issue 2475 roman numerals max 3999

### DIFF
--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -20,7 +20,7 @@ into stone tablets).
  7  => VII
 ```
 
-The maximum number supported by this this notation is 3,999.
+The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
 Wikipedia says: Modern Roman numerals ... are written by expressing each

--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -20,7 +20,7 @@ into stone tablets).
  7  => VII
 ```
 
-There is no need to be able to convert numbers larger than about 3000.
+The maximum number supported by this this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
 Wikipedia says: Modern Roman numerals ... are written by expressing each

--- a/exercises/practice/roman-numerals/.meta/example.go
+++ b/exercises/practice/roman-numerals/.meta/example.go
@@ -13,7 +13,7 @@ type arabicToRoman struct {
 func ToRomanNumeral(input int) (string, error) {
 	buffer := bytes.NewBufferString("")
 
-	if input <= 0 || input >= 3001 {
+	if input <= 0 || input >= 4000 {
 		return "", fmt.Errorf("the number %d is undefined in the roman numeral system", input)
 	}
 

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -80,3 +80,9 @@ description = "666 is DCLXVI"
 
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/cases_test.go
+++ b/exercises/practice/roman-numerals/cases_test.go
@@ -133,11 +133,6 @@ var validRomanNumeralTests = []romanNumeralTest{
 		expected:    "MDCLXVI",
 	},
 	{
-		description: "3000 is MMM",
-		input:       3000,
-		expected:    "MMM",
-	},
-	{
 		description: "3001 is MMMI",
 		input:       3001,
 		expected:    "MMMI",

--- a/exercises/practice/roman-numerals/cases_test.go
+++ b/exercises/practice/roman-numerals/cases_test.go
@@ -3,7 +3,7 @@ package romannumerals
 // This is an auto-generated file. Do not change it manually. Run the generator to update the file.
 // See https://github.com/exercism/go#synchronizing-tests-and-instructions
 // Source: exercism/problem-specifications
-// Commit: b820099 Allow prettier to format more files (#1966)
+// Commit: 044e6a1 Roman Numerals max out at 3999 (#2094 #2475)
 
 type romanNumeralTest struct {
 	description string

--- a/exercises/practice/roman-numerals/cases_test.go
+++ b/exercises/practice/roman-numerals/cases_test.go
@@ -132,4 +132,19 @@ var validRomanNumeralTests = []romanNumeralTest{
 		input:       1666,
 		expected:    "MDCLXVI",
 	},
+	{
+		description: "3000 is MMM",
+		input:       3000,
+		expected:    "MMM",
+	},
+	{
+		description: "3001 is MMMI",
+		input:       3001,
+		expected:    "MMMI",
+	},
+	{
+		description: "3999 is MMMCMXCIX",
+		input:       3999,
+		expected:    "MMMCMXCIX",
+	},
 }

--- a/exercises/practice/roman-numerals/roman_numerals_test.go
+++ b/exercises/practice/roman-numerals/roman_numerals_test.go
@@ -22,7 +22,7 @@ func TestRomanNumeralsInvalid(t *testing.T) {
 	invalidRomanNumeralTests := []romanNumeralTest{
 		{description: "0 is out of range", input: 0},
 		{description: "-1 is out of range", input: -1},
-		{description: "3001 is out of range", input: 3001},
+		{description: "4000 is out of range", input: 4000},
 	}
 	for _, tc := range invalidRomanNumeralTests {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
Adjust Instructions and Unit Tests to support maximum Roman numeral 3999
Resolves https://github.com/exercism/go/issues/2475

Adjustment to problem specification, instructions, and unit tests to support the max val 3,999 which can be expressed in Roman numerals (without getting into the "Larger number" scenarios)