### PR TITLE
Issue# 2484 - Fix for animal magic exercise test failure

### DIFF
--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -11,14 +11,13 @@ import (
 func TestSeedWithTime(t *testing.T) {
 	const tests = 100
 	var last int64
+	SeedWithTime()
 	for i := 0; i < tests; i++ {
-		SeedWithTime()
 		got := rand.Int63()
 		if i > 0 && got != last {
 			return
 		}
 		last = got
-		time.Sleep((time.Duration(rand.Intn(10))) * time.Millisecond)
 	}
 	t.Errorf("SeedWithTime always sets the same seed")
 }


### PR DESCRIPTION
Fix for Issue [#2484](https://github.com/exercism/go/issues/2484)

If time.Now().UnixNano() is called multiple times within the for loop, chances are the returned time will be the same.
This will produce the same random number as the previous iteration resulting in the failure of test.
The fix will call SeedWithTime() only once before the loop and not for each iteration.