### PR TITLE
Issue# 2484 - Added 1 to the waiting time

### DIFF
--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -18,7 +18,7 @@ func TestSeedWithTime(t *testing.T) {
 			return
 		}
 		last = got
-		time.Sleep((time.Duration(rand.Intn(10))) * time.Millisecond)
+		time.Sleep((time.Duration(rand.Intn(10) + 1)) * time.Millisecond)
 	}
 	t.Errorf("SeedWithTime always sets the same seed")
 }


### PR DESCRIPTION
Issue [#2484](https://github.com/exercism/go/issues/2484)

Add 1 to the wait time so that it never becomes 0 thereby eliminating the scenario where the seed is same as before.