### PR TITLE
Migrate OCR numbers to data-driven tests

### DIFF
--- a/exercises/practice/ocr-numbers/ocr_numbers_test.go
+++ b/exercises/practice/ocr-numbers/ocr_numbers_test.go
@@ -99,12 +99,11 @@ var tests = []struct {
          `, []string{"123", "456", "789"}},
 }
 
-var _ = recognizeDigit // step 1.
-
 func TestRecognize(t *testing.T) {
 	for _, test := range tests {
-		if res := Recognize(test.in); !reflect.DeepEqual(res, test.out) {
-			t.Fatalf("Recognize(`%s`) = %q, want %q.", test.in, res, test.out)
-		}
+	    t.Run(test.description, func(t *testing.T) {
+	        res := Recognize(test.in)
+	        assert.DeepEqual(t, res, test.out)
+        }
 	}
 }


### PR DESCRIPTION
Part of https://github.com/exercism/go/issues/2098