### PR TITLE
Sieve: Fix empty slice test

### DIFF
--- a/exercises/practice/sieve/sieve_test.go
+++ b/exercises/practice/sieve/sieve_test.go
@@ -10,7 +10,7 @@ func TestSieve(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			actual := Sieve(tc.limit)
 			// use len() to allow either nil or empty list, because they are not equal by DeepEqual
-			if len(actual) == 0 || len(tc.expected) == 0 {
+			if len(actual) == 0 && len(tc.expected) == 0 {
 				return
 			}
 			if !reflect.DeepEqual(actual, tc.expected) {


### PR DESCRIPTION
Previously any code for the Go sieve exercise which returned an empty slice would pass all the tests. This PR modifies the logic so that a test only passes with an empty slice when such an empty slice is expected by the test.

Fixes #2497