### PR TITLE
Update test dependencies and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need a github account and you will need to fork exercism/go to your acc
 See [GitHub Help](https://help.github.com/articles/fork-a-repo/) if you are unfamiliar with the process.
 Clone your fork with the command: `git clone https://github.com/<you>/go`.
 Test your clone by cding to the go directory and typing `bin/fetch-golangci-lint` and then
-`bin/test-without-stubs`. You should see tests pass for all exercises.
+`bin/run-tests`. You should see tests pass for all exercises.
 
 Note that unlike most other Go code, it is not necessary to clone this to your GOPATH.
 This is because this repo only imports from the standard library and isn't expected to be imported by other packages.

--- a/bin/fetch-golangci-lint
+++ b/bin/fetch-golangci-lint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0


### PR DESCRIPTION
Fixes #2499

### Changes

- update golangci-lint to version 1.49.0 (most recent release)
- update contributor documentation with correct script name for running the test suite

Credit to @mikejoh12 for discovering that tests were not working locally for M1 Macs and prompting me to dig into it further.