### PR TITLE
Transpose: Fix empty slice test

### DIFF
--- a/exercises/practice/transpose/transpose_test.go
+++ b/exercises/practice/transpose/transpose_test.go
@@ -9,7 +9,7 @@ func TestTranspose(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			actual := Transpose(tc.input)
-			if len(actual) == 0 || len(tc.expected) == 0 {
+			if len(actual) == 0 && len(tc.expected) == 0 {
 				return
 			}
 			if !reflect.DeepEqual(actual, tc.expected) {


### PR DESCRIPTION
For the Go Transpose problem returning an empty slice in this exercise would pass all the tests. This modifies the TestTranspose function so it only passes an empty slice when such a slice is expected by the test.

Fixes #2502