### PR TITLE
Bump golangci-lint to 1.50.1

### DIFF
--- a/bin/fetch-golangci-lint
+++ b/bin/fetch-golangci-lint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1


### PR DESCRIPTION
Release notes: https://github.com/golangci/golangci-lint/releases/tag/v1.50.1