### PR TITLE
Deprecate beer-song and add bottle-song

### DIFF
--- a/config.json
+++ b/config.json
@@ -1973,7 +1973,12 @@
         "uuid": "e6e1e960-1dcf-44cd-99e1-c26063965d13",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5
+        "topics": [
+          "loops",
+          "strings",
+          "text_formatting"
+        ],
+        "difficulty": 3
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -1966,6 +1966,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5
+      },
+      {
+        "slug": "bottle-song",
+        "name": "Bottle Song",
+        "uuid": "e6e1e960-1dcf-44cd-99e1-c26063965d13",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -1477,7 +1477,8 @@
           "loops",
           "strings",
           "text_formatting"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "food-chain",

--- a/exercises/practice/bottle-song/.docs/instructions.md
+++ b/exercises/practice/bottle-song/.docs/instructions.md
@@ -1,0 +1,57 @@
+# Instructions
+
+Recite the lyrics to that popular children's repetitive song: Ten Green Bottles.
+
+Note that not all verses are identical.
+
+```text
+Ten green bottles hanging on the wall,
+Ten green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be nine green bottles hanging on the wall.
+
+Nine green bottles hanging on the wall,
+Nine green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be eight green bottles hanging on the wall.
+
+Eight green bottles hanging on the wall,
+Eight green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be seven green bottles hanging on the wall.
+
+Seven green bottles hanging on the wall,
+Seven green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be six green bottles hanging on the wall.
+
+Six green bottles hanging on the wall,
+Six green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be five green bottles hanging on the wall.
+
+Five green bottles hanging on the wall,
+Five green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be four green bottles hanging on the wall.
+
+Four green bottles hanging on the wall,
+Four green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be three green bottles hanging on the wall.
+
+Three green bottles hanging on the wall,
+Three green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be two green bottles hanging on the wall.
+
+Two green bottles hanging on the wall,
+Two green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be one green bottle hanging on the wall.
+
+One green bottles hanging on the wall,
+One green bottles hanging on the wall,
+And if one green bottle should accidentally fall,
+There'll be no green bottles hanging on the wall.
+```

--- a/exercises/practice/bottle-song/.meta/config.json
+++ b/exercises/practice/bottle-song/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "authors": [],
+  "authors": ["PakkuDon"],
   "files": {
     "solution": [
       "bottle_song.go"

--- a/exercises/practice/bottle-song/.meta/config.json
+++ b/exercises/practice/bottle-song/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "bottle_song.go"
+    ],
+    "test": [
+      "bottle_song_test.go"
+    ],
+    "example": [
+      ".meta/example.go"
+    ]
+  },
+  "blurb": "Produce the lyrics to the popular children's repetitive song: Ten Green Bottles.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Ten_Green_Bottles"
+}

--- a/exercises/practice/bottle-song/.meta/config.json
+++ b/exercises/practice/bottle-song/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": ["PakkuDon"],
+  "authors": [
+    "PakkuDon"
+  ],
   "files": {
     "solution": [
       "bottle_song.go"

--- a/exercises/practice/bottle-song/.meta/example.go
+++ b/exercises/practice/bottle-song/.meta/example.go
@@ -48,10 +48,14 @@ func verse(n int) []string {
 		}
 	default:
 		return []string{
-			fmt.Sprintf("%s green bottles hanging on the wall,", strings.Title(numberToWord[n])),
-			fmt.Sprintf("%s green bottles hanging on the wall,", strings.Title(numberToWord[n])),
+			fmt.Sprintf("%s green bottles hanging on the wall,", toTitleCase(numberToWord[n])),
+			fmt.Sprintf("%s green bottles hanging on the wall,", toTitleCase(numberToWord[n])),
 			"And if one green bottle should accidentally fall,",
 			fmt.Sprintf("There'll be %s green bottles hanging on the wall.", numberToWord[n-1]),
 		}
 	}
+}
+
+func toTitleCase(s string) string {
+	return strings.ToUpper(s[0:1]) + strings.ToLower(s[1:])
 }

--- a/exercises/practice/bottle-song/.meta/example.go
+++ b/exercises/practice/bottle-song/.meta/example.go
@@ -1,0 +1,57 @@
+package bottlesong
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Recite(startBottles, takeDown int) []string {
+	verses := []string{}
+	for i := startBottles; i > startBottles-takeDown; i -= 1 {
+		verses = append(verses, verse(i)...)
+
+		if i > startBottles-takeDown+1 {
+			verses = append(verses, "")
+		}
+	}
+	return verses
+}
+
+var numberToWord = map[int]string{
+	1:  "one",
+	2:  "two",
+	3:  "three",
+	4:  "four",
+	5:  "five",
+	6:  "six",
+	7:  "seven",
+	8:  "eight",
+	9:  "nine",
+	10: "ten",
+}
+
+func verse(n int) []string {
+	switch {
+	case n == 1:
+		return []string{
+			"One green bottle hanging on the wall,",
+			"One green bottle hanging on the wall,",
+			"And if one green bottle should accidentally fall,",
+			"There'll be no green bottles hanging on the wall.",
+		}
+	case n == 2:
+		return []string{
+			"Two green bottles hanging on the wall,",
+			"Two green bottles hanging on the wall,",
+			"And if one green bottle should accidentally fall,",
+			"There'll be one green bottle hanging on the wall.",
+		}
+	default:
+		return []string{
+			fmt.Sprintf("%s green bottles hanging on the wall,", strings.Title(numberToWord[n])),
+			fmt.Sprintf("%s green bottles hanging on the wall,", strings.Title(numberToWord[n])),
+			"And if one green bottle should accidentally fall,",
+			fmt.Sprintf("There'll be %s green bottles hanging on the wall.", numberToWord[n-1]),
+		}
+	}
+}

--- a/exercises/practice/bottle-song/.meta/example.go
+++ b/exercises/practice/bottle-song/.meta/example.go
@@ -2,7 +2,6 @@ package bottlesong
 
 import (
 	"fmt"
-	"strings"
 )
 
 func Recite(startBottles, takeDown int) []string {
@@ -48,14 +47,10 @@ func verse(n int) []string {
 		}
 	default:
 		return []string{
-			fmt.Sprintf("%s green bottles hanging on the wall,", toTitleCase(numberToWord[n])),
-			fmt.Sprintf("%s green bottles hanging on the wall,", toTitleCase(numberToWord[n])),
+			fmt.Sprintf("%s green bottles hanging on the wall,", Title(numberToWord[n])),
+			fmt.Sprintf("%s green bottles hanging on the wall,", Title(numberToWord[n])),
 			"And if one green bottle should accidentally fall,",
 			fmt.Sprintf("There'll be %s green bottles hanging on the wall.", numberToWord[n-1]),
 		}
 	}
-}
-
-func toTitleCase(s string) string {
-	return strings.ToUpper(s[0:1]) + strings.ToLower(s[1:])
 }

--- a/exercises/practice/bottle-song/.meta/gen.go
+++ b/exercises/practice/bottle-song/.meta/gen.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j = map[string]interface{}{
+		"recite": &[]testCase{},
+	}
+	if err := gen.Gen("bottle-song", j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type testCase struct {
+	Description string `json:"description"`
+	Input       struct {
+		StartBottles int `json:"startBottles"`
+		TakeDown     int `json:"takeDown"`
+	} `json:"input"`
+	Expected []string `json:"expected"`
+}
+
+var tmpl = `package bottlesong
+
+{{.Header}}
+type bottleSongInput struct {
+	startBottles	int
+	takeDown		int
+}
+
+var testCases = []struct {
+	description    string
+	input          bottleSongInput
+	expected       []string       
+}{
+	{{range .J.recite}}
+	{
+		description: {{printf "%q"  .Description}},
+		input: bottleSongInput{
+			startBottles: 	{{printf "%d"  .Input.StartBottles}},
+			takeDown: 		{{printf "%d"  .Input.TakeDown}},
+		},
+		expected: {{printf "%#v"  .Expected}},
+	},{{end}}
+}
+`

--- a/exercises/practice/bottle-song/.meta/tests.toml
+++ b/exercises/practice/bottle-song/.meta/tests.toml
@@ -1,0 +1,31 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d4ccf8fc-01dc-48c0-a201-4fbeb30f2d03]
+description = "verse -> single verse -> first generic verse"
+
+[0f0aded3-472a-4c64-b842-18d4f1f5f030]
+description = "verse -> single verse -> last generic verse"
+
+[f61f3c97-131f-459e-b40a-7428f3ed99d9]
+description = "verse -> single verse -> verse with 2 bottles"
+
+[05eadba9-5dbd-401e-a7e8-d17cc9baa8e0]
+description = "verse -> single verse -> verse with 1 bottle"
+
+[a4a28170-83d6-4dc1-bd8b-319b6abb6a80]
+description = "lyrics -> multiple verses -> first two verses"
+
+[3185d438-c5ac-4ce6-bcd3-02c9ff1ed8db]
+description = "lyrics -> multiple verses -> last three verses"
+
+[28c1584a-0e51-4b65-9ae2-fbc0bf4bbb28]
+description = "lyrics -> multiple verses -> all verses"

--- a/exercises/practice/bottle-song/bottle_song.go
+++ b/exercises/practice/bottle-song/bottle_song.go
@@ -1,0 +1,5 @@
+package bottlesong
+
+func Recite(startBottles, takeDown int) []string {
+	panic("Please implement the Recite function")
+}

--- a/exercises/practice/bottle-song/bottle_song_test.go
+++ b/exercises/practice/bottle-song/bottle_song_test.go
@@ -2,7 +2,6 @@ package bottlesong
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 )
 
@@ -22,7 +21,9 @@ func equal(a, b []string) bool {
 		return false
 	}
 
-	sort.Strings(a)
-	sort.Strings(b)
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+
 	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }

--- a/exercises/practice/bottle-song/bottle_song_test.go
+++ b/exercises/practice/bottle-song/bottle_song_test.go
@@ -2,7 +2,9 @@ package bottlesong
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestRecite(t *testing.T) {
@@ -26,4 +28,51 @@ func equal(a, b []string) bool {
 	}
 
 	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// Title is a copy of strings.Title function of the stdlib.
+// The copy is here because strings.Title is deprecated but we still
+// want to use this function as the alternative would require us to support
+// external dependencies which we don't yet (tracking issue https://github.com/exercism/go/issues/2379).
+// Students should still be able to use strings.Title if they want.
+// Since this exercise is currently deprecated, this shouldn't matter too much.
+func Title(s string) string {
+	// Use a closure here to remember state.
+	// Hackish but effective. Depends on Map scanning in order and calling
+	// the closure once per rune.
+	prev := ' '
+	return strings.Map(
+		func(r rune) rune {
+			if isSeparator(prev) {
+				prev = r
+				return unicode.ToTitle(r)
+			}
+			prev = r
+			return r
+		},
+		s)
+}
+
+// Copy of strings.isSeparator function of the stdlib.
+func isSeparator(r rune) bool {
+	// ASCII alphanumerics and underscore are not separators
+	if r <= 0x7F {
+		switch {
+		case '0' <= r && r <= '9':
+			return false
+		case 'a' <= r && r <= 'z':
+			return false
+		case 'A' <= r && r <= 'Z':
+			return false
+		case r == '_':
+			return false
+		}
+		return true
+	}
+	// Letters and digits are not separators
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return false
+	}
+	// Otherwise, all we can do for now is treat spaces as separators.
+	return unicode.IsSpace(r)
 }

--- a/exercises/practice/bottle-song/bottle_song_test.go
+++ b/exercises/practice/bottle-song/bottle_song_test.go
@@ -1,0 +1,28 @@
+package bottlesong
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func TestRecite(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := Recite(tc.input.startBottles, tc.input.takeDown)
+			if !equal(actual, tc.expected) {
+				t.Errorf("Recite(%d, %d) = %q, want: %q", tc.input.startBottles, tc.input.takeDown, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(b) != len(a) {
+		return false
+	}
+
+	sort.Strings(a)
+	sort.Strings(b)
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}

--- a/exercises/practice/bottle-song/cases_test.go
+++ b/exercises/practice/bottle-song/cases_test.go
@@ -1,0 +1,75 @@
+package bottlesong
+
+// This is an auto-generated file. Do not change it manually. Run the generator to update the file.
+// See https://github.com/exercism/go#synchronizing-tests-and-instructions
+// Source: exercism/problem-specifications
+// Commit: 472204b bottle-song: Reimplement test cases checking for "One green bottles" (#2102)
+
+type bottleSongInput struct {
+	startBottles int
+	takeDown     int
+}
+
+var testCases = []struct {
+	description string
+	input       bottleSongInput
+	expected    []string
+}{
+
+	{
+		description: "first generic verse",
+		input: bottleSongInput{
+			startBottles: 10,
+			takeDown:     1,
+		},
+		expected: []string{"Ten green bottles hanging on the wall,", "Ten green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be nine green bottles hanging on the wall."},
+	},
+	{
+		description: "last generic verse",
+		input: bottleSongInput{
+			startBottles: 3,
+			takeDown:     1,
+		},
+		expected: []string{"Three green bottles hanging on the wall,", "Three green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be two green bottles hanging on the wall."},
+	},
+	{
+		description: "verse with 2 bottles",
+		input: bottleSongInput{
+			startBottles: 2,
+			takeDown:     1,
+		},
+		expected: []string{"Two green bottles hanging on the wall,", "Two green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be one green bottle hanging on the wall."},
+	},
+	{
+		description: "verse with 1 bottle",
+		input: bottleSongInput{
+			startBottles: 1,
+			takeDown:     1,
+		},
+		expected: []string{"One green bottle hanging on the wall,", "One green bottle hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be no green bottles hanging on the wall."},
+	},
+	{
+		description: "first two verses",
+		input: bottleSongInput{
+			startBottles: 10,
+			takeDown:     2,
+		},
+		expected: []string{"Ten green bottles hanging on the wall,", "Ten green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be nine green bottles hanging on the wall.", "", "Nine green bottles hanging on the wall,", "Nine green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be eight green bottles hanging on the wall."},
+	},
+	{
+		description: "last three verses",
+		input: bottleSongInput{
+			startBottles: 3,
+			takeDown:     3,
+		},
+		expected: []string{"Three green bottles hanging on the wall,", "Three green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be two green bottles hanging on the wall.", "", "Two green bottles hanging on the wall,", "Two green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be one green bottle hanging on the wall.", "", "One green bottle hanging on the wall,", "One green bottle hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be no green bottles hanging on the wall."},
+	},
+	{
+		description: "all verses",
+		input: bottleSongInput{
+			startBottles: 10,
+			takeDown:     10,
+		},
+		expected: []string{"Ten green bottles hanging on the wall,", "Ten green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be nine green bottles hanging on the wall.", "", "Nine green bottles hanging on the wall,", "Nine green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be eight green bottles hanging on the wall.", "", "Eight green bottles hanging on the wall,", "Eight green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be seven green bottles hanging on the wall.", "", "Seven green bottles hanging on the wall,", "Seven green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be six green bottles hanging on the wall.", "", "Six green bottles hanging on the wall,", "Six green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be five green bottles hanging on the wall.", "", "Five green bottles hanging on the wall,", "Five green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be four green bottles hanging on the wall.", "", "Four green bottles hanging on the wall,", "Four green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be three green bottles hanging on the wall.", "", "Three green bottles hanging on the wall,", "Three green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be two green bottles hanging on the wall.", "", "Two green bottles hanging on the wall,", "Two green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be one green bottle hanging on the wall.", "", "One green bottle hanging on the wall,", "One green bottle hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be no green bottles hanging on the wall."},
+	},
+}

--- a/exercises/practice/bottle-song/go.mod
+++ b/exercises/practice/bottle-song/go.mod
@@ -1,0 +1,3 @@
+module bottlesong
+
+go 1.16


### PR DESCRIPTION
Closes #2505 

As discussed in https://github.com/exercism/problem-specifications/issues/2066 we would like to replace the beer-song exercise with [bottle-song](https://github.com/exercism/problem-specifications/tree/main/exercises/bottle-song). This PR deprecates the beer-song exercise and adds a new bottle-song exercise
