### PR TITLE
removed unnecesary line of example code in Meteorology exercise

### DIFF
--- a/exercises/concept/meteorology/.docs/instructions.md
+++ b/exercises/concept/meteorology/.docs/instructions.md
@@ -11,8 +11,7 @@ After some discussion, the team have agreed that the unit of temperature will be
 
 Make the `TemperatureUnit` type implement the `Stringer` interface by adding a `String` method to it. This method must return the string `"°C"` if the temperature unit is Celsius or `"°F"` if the temperature unit is Fahrenheit.
 
-```go 
-temperatureUnit := Celsius
+```go
 celsiusUnit := Celsius
 fahrenheitUnit := Fahrenheit
 


### PR DESCRIPTION
I don't really understand why the line of code is there, maybe because of historical reasons?
To me, it makes no sense, the variable is not used anywhere. I've found it confusing when doing the exercise, so I'm proposing to delete it.