### PR TITLE
Make "complex-numbers" package name not be the same as a builtin

### DIFF
--- a/exercises/practice/complex-numbers/.meta/example.go
+++ b/exercises/practice/complex-numbers/.meta/example.go
@@ -1,4 +1,4 @@
-package complex
+package complexnumbers
 
 import (
 	"math"

--- a/exercises/practice/complex-numbers/.meta/gen.go
+++ b/exercises/practice/complex-numbers/.meta/gen.go
@@ -128,7 +128,7 @@ var stringToNumber = map[string]float64{
 }
 
 // Template to generate two sets of test cases, one for Score tests and one for Roll tests.
-var tmpl = `package complex
+var tmpl = `package complexnumbers
 
 {{.Header}}
 

--- a/exercises/practice/complex-numbers/cases_test.go
+++ b/exercises/practice/complex-numbers/cases_test.go
@@ -1,4 +1,4 @@
-package complex
+package complexnumbers
 
 // Source: exercism/problem-specifications
 // Commit: 24a7bfa Add exponential resulting in a number with real and imaginary part (#2052)

--- a/exercises/practice/complex-numbers/complex_numbers.go
+++ b/exercises/practice/complex-numbers/complex_numbers.go
@@ -1,4 +1,4 @@
-package complex
+package complexnumbers
 
 // Define the Number type here.
 

--- a/exercises/practice/complex-numbers/complex_numbers_test.go
+++ b/exercises/practice/complex-numbers/complex_numbers_test.go
@@ -1,4 +1,4 @@
-package complex
+package complexnumbers
 
 import (
 	"math"


### PR DESCRIPTION
The package name is the same as a [builtin "function" to create complex numbers](https://pkg.go.dev/builtin#complex).

In this particular case, this doesn't cause any problems for the exercise - the builtin function is not shadowed, but it's probably a good idea not to have package names conflict with builtins anyway.