### PR TITLE
sublist: Fixes sublist exercise by adding missing Relation type.

### DIFF
--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -23,7 +23,8 @@
       ".meta/example.go"
     ],
     "editor": [
-      "cases_test.go"
+      "cases_test.go",
+      "relations.go"
     ]
   }
 }

--- a/exercises/practice/sublist/.meta/example.go
+++ b/exercises/practice/sublist/.meta/example.go
@@ -2,17 +2,6 @@ package sublist
 
 import "reflect"
 
-// Relation is the comparison between lists
-type Relation string
-
-// Possible relations
-const (
-	RelationEqual     Relation = "equal"
-	RelationSublist   Relation = "sublist"
-	RelationSuperlist Relation = "superlist"
-	RelationUnequal   Relation = "unequal"
-)
-
 // Sublist checks difference of two lists and
 // returns equal, sublist, superlist or unequal according
 // to their relation to each other.

--- a/exercises/practice/sublist/relations.go
+++ b/exercises/practice/sublist/relations.go
@@ -1,0 +1,12 @@
+package sublist
+
+// Relation is the comparison between lists
+type Relation string
+
+// Possible relations
+const (
+	RelationEqual     Relation = "equal"
+	RelationSublist   Relation = "sublist"
+	RelationSuperlist Relation = "superlist"
+	RelationUnequal   Relation = "unequal"
+)

--- a/exercises/practice/sublist/sublist.go
+++ b/exercises/practice/sublist/sublist.go
@@ -1,7 +1,6 @@
 package sublist
 
-// Relation is the comparison between lists
-type Relation string
+// Relation type is defined in relations.go file.
 
 func Sublist(l1, l2 []int) Relation {
 	panic("Please implement the Sublist function")

--- a/exercises/practice/sublist/sublist.go
+++ b/exercises/practice/sublist/sublist.go
@@ -1,5 +1,8 @@
 package sublist
 
-func Sublist(l1, l2 []int) string {
+// Relation is the comparison between lists
+type Relation string
+
+func Sublist(l1, l2 []int) Relation {
 	panic("Please implement the Sublist function")
 }


### PR DESCRIPTION
There is **still** a missing definition for the data type **Relation** of the field expected in file cases_test.go. The exercise in the current state is not solvable.

The issue was not solved by #1335 neither by #1893.