### PR TITLE
Add missing tests for interest_is_interesting

### DIFF
--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
@@ -239,6 +239,18 @@ func TestYearsBeforeDesiredBalance(t *testing.T) {
 			targetBalance: 2345.0,
 			want:          0,
 		},
+		{
+			name:          "Balance is exactly same as target",
+			balance:       2345.0,
+			targetBalance: 2345.0,
+			want:          0,
+		},
+		{
+			name:          "Result balance would be exactly same as target",
+			balance:       1000.0,
+			targetBalance: 1032.682765146664,
+			want:          2,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Since the wrong logic could clear the tests, I figured that some tests are missing. 
By adding two test scenarios, they covers 

> 1. balance is already the exact same as the target
> 2. result balance would be the exact same as the target

(Following code should have failed the tests, but currently passing. The correct logic should be using < instead of <=)
<img width="1662" alt="image" src="https://user-images.githubusercontent.com/3869257/199088403-a348f7d8-5abd-4737-93c1-7396efe431bb.png">
