### PR TITLE
gross-store: Rephrase error to be more clear

### DIFF
--- a/exercises/concept/gross-store/gross_store_test.go
+++ b/exercises/concept/gross-store/gross_store_test.go
@@ -88,7 +88,7 @@ func TestAddItem(t *testing.T) {
 
 				itemQty, ok := bill[item.name]
 				if ok != tt.expected {
-					t.Errorf("Item %s should not be found in bill, found %s = %d", item.name, item.name, itemQty)
+					t.Errorf("Unexpected item on bill: found %s with quantity %d", item.name, itemQty)
 				}
 
 				if itemQty != item.qty {

--- a/exercises/concept/gross-store/gross_store_test.go
+++ b/exercises/concept/gross-store/gross_store_test.go
@@ -88,7 +88,7 @@ func TestAddItem(t *testing.T) {
 
 				itemQty, ok := bill[item.name]
 				if ok != tt.expected {
-					t.Errorf("Could not find item %s in customer bill", item.name)
+					t.Errorf("Item %s should not be found in bill, found %s = %d", item.name, item.name, itemQty)
 				}
 
 				if itemQty != item.qty {


### PR DESCRIPTION
The error message for the test `TestAddItem/Invalid_measurement_unit` indicated the inverse of what it was checking for.

For example, the following function adds an item to the bill with a value of 0 if the item's unit wasn't found.

```Go
func AddItem(bill, units map[string]int, item, unit string) bool {
	bill[item] += units[unit]
	return units[unit] != 0
}
```

Without this change, the output indicates the inverse of what it seems to intend to:
```
--- FAIL: TestAddItem (0.00s)
    --- FAIL: TestAddItem/Invalid_measurement_unit (0.00s)
        gross_store_test.go:91: Could not find item pasta in customer bill
        gross_store_test.go:91: Could not find item onion in customer bill
        gross_store_test.go:91: Could not find item pasta in customer bill
```

After the change, the output is accurate and helpful:
```
--- FAIL: TestAddItem (0.00s)
    --- FAIL: TestAddItem/Invalid_measurement_unit (0.00s)
        gross_store_test.go:91: Item pasta should not be found in bill, found pasta = 0
        gross_store_test.go:91: Item onion should not be found in bill, found onion = 0
        gross_store_test.go:91: Item pasta should not be found in bill, found pasta = 0
```