### PR TITLE
elons-toys: add test for elons_toys to cover track with possible remainder

### DIFF
--- a/exercises/concept/elons-toys/elons_toys_test.go
+++ b/exercises/concept/elons-toys/elons_toys_test.go
@@ -140,6 +140,16 @@ func TestCanFinish(t *testing.T) {
 			expected:      true,
 		},
 		{
+			name: "Car has 50% battery. Car cannot finish the race",
+			car: Car{
+				speed:        3,
+				batteryDrain: 3,
+				battery:      50,
+			},
+			trackDistance: 51,
+			expected:      false,
+		},
+		{
 			name: "Car has 30% battery. Car cannot finish the race",
 			car: Car{
 				speed:        5,


### PR DESCRIPTION
The test covers the case when the implementation of `CanFinish` is done in multiple steps where in one of them the result which should be a `float` is assigned to an `int`.

This PR fixes  #2548

example of incorrect solution:

```
func (car Car) CanFinish(trackDistance int) bool {
	neededCycles := trackDistance / car.speed
	return car.battery-(car.batteryDrain*neededCycles) >= 0
}
```
Example of correct solution:
```
func (car *Car) CanFinish(trackDistance int) bool {
	return car.battery-(car.batteryDrain*trackDistance/car.speed) >= 0
}
```