### PR TITLE
elons-toys: fix test to cover the edge case it should cover

### DIFF
--- a/exercises/concept/elons-toys/elons_toys_test.go
+++ b/exercises/concept/elons-toys/elons_toys_test.go
@@ -140,13 +140,13 @@ func TestCanFinish(t *testing.T) {
 			expected:      true,
 		},
 		{
-			name: "Car has 50% battery. Car cannot finish the race",
+			name: "Car has 60% battery. Car cannot finish the race",
 			car: Car{
 				speed:        3,
 				batteryDrain: 3,
-				battery:      50,
+				battery:      60,
 			},
-			trackDistance: 51,
+			trackDistance: 61,
 			expected:      false,
 		},
 		{


### PR DESCRIPTION
In my previous PR #2549 by accident I chose a trackdistance that is divisible by 3, which makes this test case useless.
With those fixes, the test case does actually fix the issue #2548.