### PR TITLE
Set up lasagna master for test runner version 3

### DIFF
--- a/exercises/concept/lasagna-master/.meta/config.json
+++ b/exercises/concept/lasagna-master/.meta/config.json
@@ -19,5 +19,8 @@
   "forked_from": [
     "javascript/lasagna-master"
   ],
-  "blurb": "Dive deeper into Go functions while preparing to cook the perfect lasagna."
+  "blurb": "Dive deeper into Go functions while preparing to cook the perfect lasagna.",
+  "custom": {
+    "taskIdsEnabled": true
+  }
 }


### PR DESCRIPTION
For now, we only set this for one exercise so we can confirm it works before enabling it for more.

This will not do anything until the new version of the test runner is deployed: https://github.com/exercism/go-test-runner/pull/93