### PR TITLE
Fix typo in errors concept page

### DIFF
--- a/concepts/errors/introduction.md
+++ b/concepts/errors/introduction.md
@@ -9,7 +9,7 @@ type error interface {
 }
 ```
 
-This means that any type which implements an one simple method `Error()` that returns a `string` implements the `error` interface.
+This means that any type which implements one simple method `Error()` that returns a `string` implements the `error` interface.
 This allows a function with return type `error` to return values of different types as long as all of them satisfy the `error` interface.
 
 ## Creating and Returning Errors


### PR DESCRIPTION
Very grateful for the detailed and helpful framework for learning. 

Spotted and corrected a slight typographical error ('implements an one') which should read 'implements one'. 