### PR TITLE
Disable task ids

### DIFF
--- a/exercises/concept/election-day/.meta/config.json
+++ b/exercises/concept/election-day/.meta/config.json
@@ -18,6 +18,6 @@
   },
   "blurb": "Learn about pointers by creating a simple voting system.",
   "custom": {
-    "taskIdsEnabled": true
+    "taskIdsEnabled": false
   }
 }

--- a/exercises/concept/lasagna-master/.meta/config.json
+++ b/exercises/concept/lasagna-master/.meta/config.json
@@ -21,6 +21,6 @@
   ],
   "blurb": "Dive deeper into Go functions while preparing to cook the perfect lasagna.",
   "custom": {
-    "taskIdsEnabled": true
+    "taskIdsEnabled": false
   }
 }


### PR DESCRIPTION
I am turning task ids off again because of https://github.com/exercism/go-test-runner/issues/94. Will enable them again later then the problem is addressed.