### PR TITLE
Typo fixes for the slices concept

### DIFF
--- a/concepts/slices/about.md
+++ b/concepts/slices/about.md
@@ -1,11 +1,11 @@
 # About
 
 Slices in Go are similar to lists or arrays in other languages.
-They hold a number of elements of a specific type (or interface).
+They hold several elements of a specific type (or interface).
 
 Slices in Go are based on arrays.
 Arrays have a fixed size.
-A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
+A slice, on the other hand, is a dynamically-sized, flexible view of the elements of an array.
 
 A slice is written like `[]T` with `T` being the type of the elements in the slice:
 
@@ -14,7 +14,7 @@ var empty []int                 // an empty slice
 withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
 ```
 
-You can get or set an element at a given zero-based index using square-bracket notation:
+You can get or set an element at a given zero-based index using the square-bracket notation:
 
 ```go
 withData[1] = 5
@@ -29,7 +29,7 @@ If you don't specify an ending index, it defaults to the length of the slice.
 ```go
 newSlice := withData[2:4]
 // => []int{2,3}
-newSlice := withData[:2] 
+newSlice := withData[:2]
 // => []int{0,1}
 newSlice := withData[2:]
 // => []int{2,3,4,5}
@@ -42,18 +42,18 @@ Below we append `4` and `2` to the `a` slice.
 
 ```go
 a := []int{1, 3}
-a = append(a, 4, 2) 
+a = append(a, 4, 2)
 // => []int{1,3,4,2}
 ```
 
-`append` always returns a new slice, and when we just want to append elements to an existing slice, its common to reassign it back to the slice variable we pass as the first argument, like we did above.
+`append` always returns a new slice, and when we just want to append elements to an existing slice, it's common to reassign it back to the slice variable we pass as the first argument as we did above.
 
 `append` can also be used to merge two slices:
 
 ```go
 nextSlice := []int{100,101,102}
 newSlice  := append(withData, nextSlice...)
-// => []int{0,1,2,3,4,5,100,101,102}}
+// => []int{0,1,2,3,4,5,100,101,102}
 ```
 
 ## Indexes in slices
@@ -69,13 +69,13 @@ If creating a new slice prefer `var s []int` (`nil`-slice) over `s := []int{}` (
 
 ## Performance
 
-When creating slices to be filled iteratively, there is a low hanging fruit to improve performance, if the final size of the slice is known.
-The key is to minimize the amount of times memory has to be allocated, which is rather expensive and happens if the slice grows beyond its allocated memory space.
-The safest way to do this is to specify a capacity `cap` for the slice with `s := make([]int, 0, cap)` and then to `append` to the slice as usual.
+When creating slices to be filled iteratively, there is a low-hanging fruit to improve performance, if the final size of the slice is known.
+The key is to minimize the number of times memory has to be allocated, which is rather expensive and happens if the slice grows beyond its allocated memory space.
+The safest way to do this is to specify a capacity `cap` for the slice with `s := make([]int, 0, cap)` and then `append` to the slice as usual.
 This way the space for `cap` amount of items is allocated immediately while the slice length is zero.
 In practice, `cap` is often the length of another slice: `s := make([]int, 0, len(otherSlice))`.
 
 ## Append is not a pure function
 
-The append function of Go is optimized for performance and therefore does not make a copy of the input slice.
+The `append` function of Go is optimized for performance and therefore does not make a copy of the input slice.
 This means that the original slice (1st parameter in `append`) will be changed sometimes.

--- a/concepts/slices/introduction.md
+++ b/concepts/slices/introduction.md
@@ -1,11 +1,11 @@
 # Introduction
 
 Slices in Go are similar to lists or arrays in other languages.
-They hold a number of elements of a specific type (or interface).
+They hold several elements of a specific type (or interface).
 
 Slices in Go are based on arrays.
 Arrays have a fixed size.
-A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
+A slice, on the other hand, is a dynamically-sized, flexible view of the elements of an array.
 
 A slice is written like `[]T` with `T` being the type of the elements in the slice:
 
@@ -14,7 +14,7 @@ var empty []int                 // an empty slice
 withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
 ```
 
-You can get or set an element at a given zero-based index using square-bracket notation:
+You can get or set an element at a given zero-based index using the square-bracket notation:
 
 ```go
 withData[1] = 5
@@ -29,7 +29,7 @@ If you don't specify an ending index, it defaults to the length of the slice.
 ```go
 newSlice := withData[2:4]
 // => []int{2,3}
-newSlice := withData[:2] 
+newSlice := withData[:2]
 // => []int{0,1}
 newSlice := withData[2:]
 // => []int{2,3,4,5}
@@ -42,18 +42,18 @@ Below we append `4` and `2` to the `a` slice.
 
 ```go
 a := []int{1, 3}
-a = append(a, 4, 2) 
+a = append(a, 4, 2)
 // => []int{1,3,4,2}
 ```
 
-`append` always returns a new slice, and when we just want to append elements to an existing slice, its common to reassign it back to the slice variable we pass as the first argument, like we did above.
+`append` always returns a new slice, and when we just want to append elements to an existing slice, it's common to reassign it back to the slice variable we pass as the first argument as we did above.
 
 `append` can also be used to merge two slices:
 
 ```go
 nextSlice := []int{100,101,102}
 newSlice  := append(withData, nextSlice...)
-// => []int{0,1,2,3,4,5,100,101,102}}
+// => []int{0,1,2,3,4,5,100,101,102}
 ```
 
 ## Indexes in slices
@@ -69,13 +69,13 @@ If creating a new slice prefer `var s []int` (`nil`-slice) over `s := []int{}` (
 
 ## Performance
 
-When creating slices to be filled iteratively, there is a low hanging fruit to improve performance, if the final size of the slice is known.
-The key is to minimize the amount of times memory has to be allocated, which is rather expensive and happens if the slice grows beyond its allocated memory space.
-The safest way to do this is to specify a capacity `cap` for the slice with `s := make([]int, 0, cap)` and then to `append` to the slice as usual.
+When creating slices to be filled iteratively, there is a low-hanging fruit to improve performance, if the final size of the slice is known.
+The key is to minimize the number of times memory has to be allocated, which is rather expensive and happens if the slice grows beyond its allocated memory space.
+The safest way to do this is to specify a capacity `cap` for the slice with `s := make([]int, 0, cap)` and then `append` to the slice as usual.
 This way the space for `cap` amount of items is allocated immediately while the slice length is zero.
 In practice, `cap` is often the length of another slice: `s := make([]int, 0, len(otherSlice))`.
 
 ## Append is not a pure function
 
-The append function of Go is optimized for performance and therefore does not make a copy of the input slice.
+The `append` function of Go is optimized for performance and therefore does not make a copy of the input slice.
 This means that the original slice (1st parameter in `append`) will be changed sometimes.

--- a/exercises/concept/card-tricks/.docs/introduction.md
+++ b/exercises/concept/card-tricks/.docs/introduction.md
@@ -3,11 +3,11 @@
 ## Slices
 
 Slices in Go are similar to lists or arrays in other languages.
-They hold a number of elements of a specific type (or interface).
+They hold several elements of a specific type (or interface).
 
 Slices in Go are based on arrays.
 Arrays have a fixed size.
-A slice, on the other hand, is a dynamically-sized, flexible view into the elements of an array.
+A slice, on the other hand, is a dynamically-sized, flexible view of the elements of an array.
 
 A slice is written like `[]T` with `T` being the type of the elements in the slice:
 
@@ -16,7 +16,7 @@ var empty []int                 // an empty slice
 withData := []int{0,1,2,3,4,5}  // a slice pre-filled with some data
 ```
 
-You can get or set an element at a given zero-based index using square-bracket notation:
+You can get or set an element at a given zero-based index using the square-bracket notation:
 
 ```go
 withData[1] = 5
@@ -31,7 +31,7 @@ If you don't specify an ending index, it defaults to the length of the slice.
 ```go
 newSlice := withData[2:4]
 // => []int{2,3}
-newSlice := withData[:2] 
+newSlice := withData[:2]
 // => []int{0,1}
 newSlice := withData[2:]
 // => []int{2,3,4,5}
@@ -44,18 +44,18 @@ Below we append `4` and `2` to the `a` slice.
 
 ```go
 a := []int{1, 3}
-a = append(a, 4, 2) 
+a = append(a, 4, 2)
 // => []int{1,3,4,2}
 ```
 
-`append` always returns a new slice, and when we just want to append elements to an existing slice, its common to reassign it back to the slice variable we pass as the first argument, like we did above.
+`append` always returns a new slice, and when we just want to append elements to an existing slice, it's common to reassign it back to the slice variable we pass as the first argument as we did above.
 
 `append` can also be used to merge two slices:
 
 ```go
 nextSlice := []int{100,101,102}
 newSlice  := append(withData, nextSlice...)
-// => []int{0,1,2,3,4,5,100,101,102}}
+// => []int{0,1,2,3,4,5,100,101,102}
 ```
 
 ## Variadic Functions


### PR DESCRIPTION
Some typo fixes for the slices concept:

- Fixes #2585 in all places.
- Grammarly pass over the contents