### PR TITLE
Update to Go 1.20

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -15,17 +15,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         test-arch: [amd64]
         race: ["-race"]
 
         include:
-          - go-version: 1.18.x
+          - go-version: 1.20.x
             test-arch: "386"
             os: ubuntu-latest
             race: ""
-          - go-version: 1.18.x
+          - go-version: 1.20.x
             test-arch: "386"
             os: windows-latest
             race: ""

--- a/.github/workflows/stub-tests.yml
+++ b/.github/workflows/stub-tests.yml
@@ -15,17 +15,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         test-arch: [amd64]
         race: ["-race"]
 
         include:
-          - go-version: 1.18.x
+          - go-version: 1.20.x
             test-arch: "386"
             os: ubuntu-latest
             race: ""
-          - go-version: 1.18.x
+          - go-version: 1.20.x
             test-arch: "386"
             os: windows-latest
             race: ""

--- a/bin/fetch-golangci-lint
+++ b/bin/fetch-golangci-lint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2

--- a/exercises/concept/airport-robot/go.mod
+++ b/exercises/concept/airport-robot/go.mod
@@ -1,3 +1,3 @@
 module airportrobot
 
-go 1.16
+go 1.18

--- a/exercises/concept/animal-magic/go.mod
+++ b/exercises/concept/animal-magic/go.mod
@@ -1,3 +1,3 @@
 module chance
 
-go 1.16
+go 1.18

--- a/exercises/concept/annalyns-infiltration/go.mod
+++ b/exercises/concept/annalyns-infiltration/go.mod
@@ -1,3 +1,3 @@
 module annalyn
 
-go 1.16
+go 1.18

--- a/exercises/concept/bird-watcher/go.mod
+++ b/exercises/concept/bird-watcher/go.mod
@@ -1,3 +1,3 @@
 module birdwatcher
 
-go 1.16
+go 1.18

--- a/exercises/concept/blackjack/go.mod
+++ b/exercises/concept/blackjack/go.mod
@@ -1,3 +1,3 @@
 module blackjack
 
-go 1.16
+go 1.18

--- a/exercises/concept/booking-up-for-beauty/go.mod
+++ b/exercises/concept/booking-up-for-beauty/go.mod
@@ -1,3 +1,3 @@
 module booking
 
-go 1.16
+go 1.18

--- a/exercises/concept/card-tricks/go.mod
+++ b/exercises/concept/card-tricks/go.mod
@@ -1,3 +1,3 @@
 module cards
 
-go 1.16
+go 1.18

--- a/exercises/concept/cars-assemble/go.mod
+++ b/exercises/concept/cars-assemble/go.mod
@@ -1,3 +1,3 @@
 module cars
 
-go 1.16
+go 1.18

--- a/exercises/concept/census/go.mod
+++ b/exercises/concept/census/go.mod
@@ -1,3 +1,3 @@
 module census
 
-go 1.16
+go 1.18

--- a/exercises/concept/chessboard/go.mod
+++ b/exercises/concept/chessboard/go.mod
@@ -1,3 +1,3 @@
 module chessboard
 
-go 1.16
+go 1.18

--- a/exercises/concept/deep-thought/go.mod
+++ b/exercises/concept/deep-thought/go.mod
@@ -1,3 +1,3 @@
 module deepthought
 
-go 1.16
+go 1.18

--- a/exercises/concept/election-day/go.mod
+++ b/exercises/concept/election-day/go.mod
@@ -1,3 +1,3 @@
 module electionday
 
-go 1.16
+go 1.18

--- a/exercises/concept/elons-toys/go.mod
+++ b/exercises/concept/elons-toys/go.mod
@@ -1,4 +1,4 @@
 module elon
 
-go 1.16
+go 1.18
 

--- a/exercises/concept/expenses/go.mod
+++ b/exercises/concept/expenses/go.mod
@@ -1,3 +1,3 @@
 module expenses
 
-go 1.16
+go 1.18

--- a/exercises/concept/gross-store/go.mod
+++ b/exercises/concept/gross-store/go.mod
@@ -1,3 +1,3 @@
 module gross
 
-go 1.16
+go 1.18

--- a/exercises/concept/interest-is-interesting/go.mod
+++ b/exercises/concept/interest-is-interesting/go.mod
@@ -1,3 +1,3 @@
 module interest
 
-go 1.16
+go 1.18

--- a/exercises/concept/lasagna-master/go.mod
+++ b/exercises/concept/lasagna-master/go.mod
@@ -1,3 +1,3 @@
 module lasagna
 
-go 1.16
+go 1.18

--- a/exercises/concept/lasagna/go.mod
+++ b/exercises/concept/lasagna/go.mod
@@ -1,3 +1,3 @@
 module lasagna
 
-go 1.16
+go 1.18

--- a/exercises/concept/logs-logs-logs/go.mod
+++ b/exercises/concept/logs-logs-logs/go.mod
@@ -1,3 +1,3 @@
 module logs
 
-go 1.16
+go 1.18

--- a/exercises/concept/meteorology/go.mod
+++ b/exercises/concept/meteorology/go.mod
@@ -1,3 +1,3 @@
 module meteorology
 
-go 1.16
+go 1.18

--- a/exercises/concept/need-for-speed/go.mod
+++ b/exercises/concept/need-for-speed/go.mod
@@ -1,3 +1,3 @@
 module speed
 
-go 1.16
+go 1.18

--- a/exercises/concept/parsing-log-files/go.mod
+++ b/exercises/concept/parsing-log-files/go.mod
@@ -1,3 +1,3 @@
 module parsinglogfiles
 
-go 1.16
+go 1.18

--- a/exercises/concept/party-robot/go.mod
+++ b/exercises/concept/party-robot/go.mod
@@ -1,3 +1,3 @@
 module partyrobot
 
-go 1.16
+go 1.18

--- a/exercises/concept/savings-account/go.mod
+++ b/exercises/concept/savings-account/go.mod
@@ -1,3 +1,3 @@
 module savings
 
-go 1.16
+go 1.18

--- a/exercises/concept/sorting-room/go.mod
+++ b/exercises/concept/sorting-room/go.mod
@@ -1,3 +1,3 @@
 module sorting
 
-go 1.16
+go 1.18

--- a/exercises/concept/the-farm/go.mod
+++ b/exercises/concept/the-farm/go.mod
@@ -1,4 +1,4 @@
 module thefarm
 
-go 1.16
+go 1.18
 

--- a/exercises/concept/vehicle-purchase/go.mod
+++ b/exercises/concept/vehicle-purchase/go.mod
@@ -1,3 +1,3 @@
 module purchase
 
-go 1.16
+go 1.18

--- a/exercises/concept/weather-forecast/go.mod
+++ b/exercises/concept/weather-forecast/go.mod
@@ -1,3 +1,3 @@
 module weather
 
-go 1.16
+go 1.18

--- a/exercises/concept/welcome-to-tech-palace/go.mod
+++ b/exercises/concept/welcome-to-tech-palace/go.mod
@@ -1,3 +1,3 @@
 module techpalace
 
-go 1.16
+go 1.18

--- a/exercises/practice/accumulate/go.mod
+++ b/exercises/practice/accumulate/go.mod
@@ -1,3 +1,3 @@
 module accumulate
 
-go 1.16
+go 1.18

--- a/exercises/practice/acronym/go.mod
+++ b/exercises/practice/acronym/go.mod
@@ -1,3 +1,3 @@
 module acronym
 
-go 1.16
+go 1.18

--- a/exercises/practice/all-your-base/go.mod
+++ b/exercises/practice/all-your-base/go.mod
@@ -1,3 +1,3 @@
 module allyourbase
 
-go 1.16
+go 1.18

--- a/exercises/practice/allergies/go.mod
+++ b/exercises/practice/allergies/go.mod
@@ -1,3 +1,3 @@
 module allergies
 
-go 1.16
+go 1.18

--- a/exercises/practice/alphametics/go.mod
+++ b/exercises/practice/alphametics/go.mod
@@ -1,3 +1,3 @@
 module alphametics
 
-go 1.16
+go 1.18

--- a/exercises/practice/anagram/go.mod
+++ b/exercises/practice/anagram/go.mod
@@ -1,3 +1,3 @@
 module anagram
 
-go 1.16
+go 1.18

--- a/exercises/practice/armstrong-numbers/go.mod
+++ b/exercises/practice/armstrong-numbers/go.mod
@@ -1,3 +1,3 @@
 module armstrong
 
-go 1.16
+go 1.18

--- a/exercises/practice/atbash-cipher/go.mod
+++ b/exercises/practice/atbash-cipher/go.mod
@@ -1,3 +1,3 @@
 module atbash
 
-go 1.16
+go 1.18

--- a/exercises/practice/bank-account/go.mod
+++ b/exercises/practice/bank-account/go.mod
@@ -1,3 +1,3 @@
 module account
 
-go 1.16
+go 1.18

--- a/exercises/practice/beer-song/go.mod
+++ b/exercises/practice/beer-song/go.mod
@@ -1,3 +1,3 @@
 module beer
 
-go 1.16
+go 1.18

--- a/exercises/practice/binary-search-tree/go.mod
+++ b/exercises/practice/binary-search-tree/go.mod
@@ -1,3 +1,3 @@
 module binarysearchtree
 
-go 1.16
+go 1.18

--- a/exercises/practice/binary-search/go.mod
+++ b/exercises/practice/binary-search/go.mod
@@ -1,3 +1,3 @@
 module binarysearch
 
-go 1.16
+go 1.18

--- a/exercises/practice/binary/go.mod
+++ b/exercises/practice/binary/go.mod
@@ -1,3 +1,3 @@
 module binary
 
-go 1.16
+go 1.18

--- a/exercises/practice/bob/go.mod
+++ b/exercises/practice/bob/go.mod
@@ -1,3 +1,3 @@
 module bob
 
-go 1.16
+go 1.18

--- a/exercises/practice/book-store/go.mod
+++ b/exercises/practice/book-store/go.mod
@@ -1,3 +1,3 @@
 module bookstore
 
-go 1.16
+go 1.18

--- a/exercises/practice/bottle-song/go.mod
+++ b/exercises/practice/bottle-song/go.mod
@@ -1,3 +1,3 @@
 module bottlesong
 
-go 1.16
+go 1.18

--- a/exercises/practice/bowling/go.mod
+++ b/exercises/practice/bowling/go.mod
@@ -1,3 +1,3 @@
 module bowling
 
-go 1.16
+go 1.18

--- a/exercises/practice/change/go.mod
+++ b/exercises/practice/change/go.mod
@@ -1,3 +1,3 @@
 module change
 
-go 1.16
+go 1.18

--- a/exercises/practice/circular-buffer/go.mod
+++ b/exercises/practice/circular-buffer/go.mod
@@ -1,3 +1,3 @@
 module standard
 
-go 1.16
+go 1.18

--- a/exercises/practice/clock/go.mod
+++ b/exercises/practice/clock/go.mod
@@ -1,3 +1,3 @@
 module clock
 
-go 1.16
+go 1.18

--- a/exercises/practice/collatz-conjecture/go.mod
+++ b/exercises/practice/collatz-conjecture/go.mod
@@ -1,3 +1,3 @@
 module collatzconjecture
 
-go 1.16
+go 1.18

--- a/exercises/practice/complex-numbers/go.mod
+++ b/exercises/practice/complex-numbers/go.mod
@@ -1,3 +1,3 @@
 module complex
 
-go 1.16
+go 1.18

--- a/exercises/practice/connect/go.mod
+++ b/exercises/practice/connect/go.mod
@@ -1,3 +1,3 @@
 module connect
 
-go 1.16
+go 1.18

--- a/exercises/practice/counter/go.mod
+++ b/exercises/practice/counter/go.mod
@@ -1,3 +1,3 @@
 module counter
 
-go 1.16
+go 1.18

--- a/exercises/practice/crypto-square/go.mod
+++ b/exercises/practice/crypto-square/go.mod
@@ -1,3 +1,3 @@
 module cryptosquare
 
-go 1.16
+go 1.18

--- a/exercises/practice/custom-set/go.mod
+++ b/exercises/practice/custom-set/go.mod
@@ -1,3 +1,3 @@
 module stringset
 
-go 1.16
+go 1.18

--- a/exercises/practice/darts/go.mod
+++ b/exercises/practice/darts/go.mod
@@ -1,3 +1,3 @@
 module darts
 
-go 1.16
+go 1.18

--- a/exercises/practice/diamond/go.mod
+++ b/exercises/practice/diamond/go.mod
@@ -1,3 +1,3 @@
 module diamond
 
-go 1.16
+go 1.18

--- a/exercises/practice/difference-of-squares/go.mod
+++ b/exercises/practice/difference-of-squares/go.mod
@@ -1,3 +1,3 @@
 module diffsquares
 
-go 1.16
+go 1.18

--- a/exercises/practice/diffie-hellman/go.mod
+++ b/exercises/practice/diffie-hellman/go.mod
@@ -1,3 +1,3 @@
 module diffiehellman
 
-go 1.16
+go 1.18

--- a/exercises/practice/dominoes/go.mod
+++ b/exercises/practice/dominoes/go.mod
@@ -1,3 +1,3 @@
 module dominoes
 
-go 1.16
+go 1.18

--- a/exercises/practice/error-handling/go.mod
+++ b/exercises/practice/error-handling/go.mod
@@ -1,3 +1,3 @@
 module erratum
 
-go 1.16
+go 1.18

--- a/exercises/practice/etl/go.mod
+++ b/exercises/practice/etl/go.mod
@@ -1,3 +1,3 @@
 module etl
 
-go 1.16
+go 1.18

--- a/exercises/practice/flatten-array/go.mod
+++ b/exercises/practice/flatten-array/go.mod
@@ -1,3 +1,3 @@
 module flatten
 
-go 1.16
+go 1.18

--- a/exercises/practice/food-chain/go.mod
+++ b/exercises/practice/food-chain/go.mod
@@ -1,3 +1,3 @@
 module foodchain
 
-go 1.16
+go 1.18

--- a/exercises/practice/forth/go.mod
+++ b/exercises/practice/forth/go.mod
@@ -1,3 +1,3 @@
 module forth
 
-go 1.16
+go 1.18

--- a/exercises/practice/gigasecond/go.mod
+++ b/exercises/practice/gigasecond/go.mod
@@ -1,3 +1,3 @@
 module gigasecond
 
-go 1.16
+go 1.18

--- a/exercises/practice/grade-school/go.mod
+++ b/exercises/practice/grade-school/go.mod
@@ -1,3 +1,3 @@
 module school
 
-go 1.16
+go 1.18

--- a/exercises/practice/grains/go.mod
+++ b/exercises/practice/grains/go.mod
@@ -1,3 +1,3 @@
 module grains
 
-go 1.16
+go 1.18

--- a/exercises/practice/grep/go.mod
+++ b/exercises/practice/grep/go.mod
@@ -1,3 +1,3 @@
 module grep
 
-go 1.16
+go 1.18

--- a/exercises/practice/hamming/go.mod
+++ b/exercises/practice/hamming/go.mod
@@ -1,3 +1,3 @@
 module hamming
 
-go 1.16
+go 1.18

--- a/exercises/practice/hello-world/go.mod
+++ b/exercises/practice/hello-world/go.mod
@@ -1,3 +1,3 @@
 module greeting
 
-go 1.16
+go 1.18

--- a/exercises/practice/hexadecimal/go.mod
+++ b/exercises/practice/hexadecimal/go.mod
@@ -1,3 +1,3 @@
 module hexadecimal
 
-go 1.16
+go 1.18

--- a/exercises/practice/house/go.mod
+++ b/exercises/practice/house/go.mod
@@ -1,3 +1,3 @@
 module house
 
-go 1.16
+go 1.18

--- a/exercises/practice/isbn-verifier/go.mod
+++ b/exercises/practice/isbn-verifier/go.mod
@@ -1,3 +1,3 @@
 module isbn
 
-go 1.16
+go 1.18

--- a/exercises/practice/isogram/go.mod
+++ b/exercises/practice/isogram/go.mod
@@ -1,3 +1,3 @@
 module isogram
 
-go 1.16
+go 1.18

--- a/exercises/practice/kindergarten-garden/go.mod
+++ b/exercises/practice/kindergarten-garden/go.mod
@@ -1,3 +1,3 @@
 module kindergarten
 
-go 1.16
+go 1.18

--- a/exercises/practice/largest-series-product/go.mod
+++ b/exercises/practice/largest-series-product/go.mod
@@ -1,3 +1,3 @@
 module lsproduct
 
-go 1.16
+go 1.18

--- a/exercises/practice/leap/go.mod
+++ b/exercises/practice/leap/go.mod
@@ -1,3 +1,3 @@
 module leap
 
-go 1.16
+go 1.18

--- a/exercises/practice/ledger/go.mod
+++ b/exercises/practice/ledger/go.mod
@@ -1,3 +1,3 @@
 module ledger
 
-go 1.16
+go 1.18

--- a/exercises/practice/linked-list/go.mod
+++ b/exercises/practice/linked-list/go.mod
@@ -1,3 +1,3 @@
 module linkedlist
 
-go 1.16
+go 1.18

--- a/exercises/practice/list-ops/go.mod
+++ b/exercises/practice/list-ops/go.mod
@@ -1,3 +1,3 @@
 module listops
 
-go 1.16
+go 1.18

--- a/exercises/practice/luhn/go.mod
+++ b/exercises/practice/luhn/go.mod
@@ -1,3 +1,3 @@
 module luhn
 
-go 1.16
+go 1.18

--- a/exercises/practice/markdown/go.mod
+++ b/exercises/practice/markdown/go.mod
@@ -1,3 +1,3 @@
 module markdown
 
-go 1.16
+go 1.18

--- a/exercises/practice/matching-brackets/go.mod
+++ b/exercises/practice/matching-brackets/go.mod
@@ -1,3 +1,3 @@
 module brackets
 
-go 1.16
+go 1.18

--- a/exercises/practice/matrix/go.mod
+++ b/exercises/practice/matrix/go.mod
@@ -1,3 +1,3 @@
 module matrix
 
-go 1.16
+go 1.18

--- a/exercises/practice/meetup/go.mod
+++ b/exercises/practice/meetup/go.mod
@@ -1,3 +1,3 @@
 module meetup
 
-go 1.16
+go 1.18

--- a/exercises/practice/minesweeper/go.mod
+++ b/exercises/practice/minesweeper/go.mod
@@ -1,3 +1,3 @@
 module minesweeper
 
-go 1.16
+go 1.18

--- a/exercises/practice/nth-prime/go.mod
+++ b/exercises/practice/nth-prime/go.mod
@@ -1,3 +1,3 @@
 module prime
 
-go 1.16
+go 1.18

--- a/exercises/practice/nucleotide-count/go.mod
+++ b/exercises/practice/nucleotide-count/go.mod
@@ -1,3 +1,3 @@
 module dna
 
-go 1.16
+go 1.18

--- a/exercises/practice/ocr-numbers/go.mod
+++ b/exercises/practice/ocr-numbers/go.mod
@@ -1,3 +1,3 @@
 module ocr
 
-go 1.16
+go 1.18

--- a/exercises/practice/octal/go.mod
+++ b/exercises/practice/octal/go.mod
@@ -1,3 +1,3 @@
 module octal
 
-go 1.16
+go 1.18

--- a/exercises/practice/paasio/go.mod
+++ b/exercises/practice/paasio/go.mod
@@ -1,3 +1,3 @@
 module paasio
 
-go 1.16
+go 1.18

--- a/exercises/practice/palindrome-products/go.mod
+++ b/exercises/practice/palindrome-products/go.mod
@@ -1,3 +1,3 @@
 module palindrome
 
-go 1.16
+go 1.18

--- a/exercises/practice/pangram/go.mod
+++ b/exercises/practice/pangram/go.mod
@@ -1,3 +1,3 @@
 module pangram
 
-go 1.16
+go 1.18

--- a/exercises/practice/parallel-letter-frequency/go.mod
+++ b/exercises/practice/parallel-letter-frequency/go.mod
@@ -1,3 +1,3 @@
 module letter
 
-go 1.16
+go 1.18

--- a/exercises/practice/pascals-triangle/go.mod
+++ b/exercises/practice/pascals-triangle/go.mod
@@ -1,3 +1,3 @@
 module pascal
 
-go 1.16
+go 1.18

--- a/exercises/practice/perfect-numbers/go.mod
+++ b/exercises/practice/perfect-numbers/go.mod
@@ -1,3 +1,3 @@
 module perfect
 
-go 1.16
+go 1.18

--- a/exercises/practice/phone-number/go.mod
+++ b/exercises/practice/phone-number/go.mod
@@ -1,3 +1,3 @@
 module phonenumber
 
-go 1.16
+go 1.18

--- a/exercises/practice/pig-latin/.approaches/introduction.md
+++ b/exercises/practice/pig-latin/.approaches/introduction.md
@@ -110,11 +110,6 @@ func Sentence(phrase string) string {
 }
 ```
 
-```exercism/note
-As of this writing, the Go version defined in the `go.mod` file is `1.16`.
-To use generics, the `go.mod` file needs to be updated to version `1.18` or higher.
-```
-
 For more information, check the [map lookups with generics approach][approach-map-lookups-with-generics].
 
 ## Which approach to use?

--- a/exercises/practice/pig-latin/.approaches/map-lookups-with-generics/content.md
+++ b/exercises/practice/pig-latin/.approaches/map-lookups-with-generics/content.md
@@ -53,11 +53,6 @@ func Sentence(phrase string) string {
 }
 ```
 
-```exercism/note
-As of this writing, the Go version defined in the `go.mod` file is `1.16`.
-To use generics, the `go.mod` file needs to be updated to version `1.18` or higher.
-```
-
 The approach imports the `strings` package so it can use [`strings.Builder`][builder] as an efficient way to build the output string.
 
 This approach starts be defining a void [type][type] that will be used in the package.
@@ -73,12 +68,12 @@ More info on implementing a set in Go can be found [here](https://yourbasic.org/
 
 An [interface type][interface-type] is then defined which will be used to constain which types are to be used for the [generics][generics]:
 
->Generics are a way of writing code that is independent of the specific types being used. Functions and types may now be written to use any of a set of types.
+> Generics are a way of writing code that is independent of the specific types being used. Functions and types may now be written to use any of a set of types.
 
 Since there can not be multiple [`if` with short statements][if-with-short-statement] on the same line,
 the `contains()` function is defined which takes a generic type parameter of `[T container]`.
 `T` is the name of the parameter.
-The name does not have to be `T`, but it is a common convention in Go (and  other languages) to start with `T`,
+The name does not have to be `T`, but it is a common convention in Go (and other languages) to start with `T`,
 and if a second name is needed, to use `U`, and so on.
 The type of `T` is constrained to be one of the types defined in the `container` interface.
 The arguments to the function are a map of the generic type `T` with void values, and a value of type `T`.

--- a/exercises/practice/pig-latin/go.mod
+++ b/exercises/practice/pig-latin/go.mod
@@ -1,3 +1,3 @@
 module piglatin
 
-go 1.16
+go 1.18

--- a/exercises/practice/poker/go.mod
+++ b/exercises/practice/poker/go.mod
@@ -1,3 +1,3 @@
 module poker
 
-go 1.16
+go 1.18

--- a/exercises/practice/pov/go.mod
+++ b/exercises/practice/pov/go.mod
@@ -1,3 +1,3 @@
 module pov
 
-go 1.16
+go 1.18

--- a/exercises/practice/prime-factors/go.mod
+++ b/exercises/practice/prime-factors/go.mod
@@ -1,3 +1,3 @@
 module prime
 
-go 1.16
+go 1.18

--- a/exercises/practice/protein-translation/go.mod
+++ b/exercises/practice/protein-translation/go.mod
@@ -1,3 +1,3 @@
 module protein
 
-go 1.16
+go 1.18

--- a/exercises/practice/proverb/go.mod
+++ b/exercises/practice/proverb/go.mod
@@ -1,3 +1,3 @@
 module proverb
 
-go 1.16
+go 1.18

--- a/exercises/practice/pythagorean-triplet/go.mod
+++ b/exercises/practice/pythagorean-triplet/go.mod
@@ -1,3 +1,3 @@
 module pythagorean
 
-go 1.16
+go 1.18

--- a/exercises/practice/queen-attack/go.mod
+++ b/exercises/practice/queen-attack/go.mod
@@ -1,3 +1,3 @@
 module queenattack
 
-go 1.16
+go 1.18

--- a/exercises/practice/rail-fence-cipher/go.mod
+++ b/exercises/practice/rail-fence-cipher/go.mod
@@ -1,3 +1,3 @@
 module railfence
 
-go 1.16
+go 1.18

--- a/exercises/practice/raindrops/go.mod
+++ b/exercises/practice/raindrops/go.mod
@@ -1,3 +1,3 @@
 module raindrops
 
-go 1.16
+go 1.18

--- a/exercises/practice/react/go.mod
+++ b/exercises/practice/react/go.mod
@@ -1,3 +1,3 @@
 module react
 
-go 1.16
+go 1.18

--- a/exercises/practice/rectangles/go.mod
+++ b/exercises/practice/rectangles/go.mod
@@ -1,3 +1,3 @@
 module rectangles
 
-go 1.16
+go 1.18

--- a/exercises/practice/reverse-string/go.mod
+++ b/exercises/practice/reverse-string/go.mod
@@ -1,3 +1,3 @@
 module reverse
 
-go 1.16
+go 1.18

--- a/exercises/practice/rna-transcription/go.mod
+++ b/exercises/practice/rna-transcription/go.mod
@@ -1,3 +1,3 @@
 module strand
 
-go 1.16
+go 1.18

--- a/exercises/practice/robot-name/go.mod
+++ b/exercises/practice/robot-name/go.mod
@@ -1,3 +1,3 @@
 module robotname
 
-go 1.16
+go 1.18

--- a/exercises/practice/robot-simulator/go.mod
+++ b/exercises/practice/robot-simulator/go.mod
@@ -1,3 +1,3 @@
 module robot
 
-go 1.16
+go 1.18

--- a/exercises/practice/roman-numerals/go.mod
+++ b/exercises/practice/roman-numerals/go.mod
@@ -1,3 +1,3 @@
 module romannumerals
 
-go 1.16
+go 1.18

--- a/exercises/practice/rotational-cipher/go.mod
+++ b/exercises/practice/rotational-cipher/go.mod
@@ -1,3 +1,3 @@
 module rotationalcipher
 
-go 1.16
+go 1.18

--- a/exercises/practice/run-length-encoding/go.mod
+++ b/exercises/practice/run-length-encoding/go.mod
@@ -1,3 +1,3 @@
 module encode
 
-go 1.16
+go 1.18

--- a/exercises/practice/saddle-points/go.mod
+++ b/exercises/practice/saddle-points/go.mod
@@ -1,3 +1,3 @@
 module matrix
 
-go 1.16
+go 1.18

--- a/exercises/practice/say/go.mod
+++ b/exercises/practice/say/go.mod
@@ -1,3 +1,3 @@
 module say
 
-go 1.16
+go 1.18

--- a/exercises/practice/scale-generator/go.mod
+++ b/exercises/practice/scale-generator/go.mod
@@ -1,3 +1,3 @@
 module scale
 
-go 1.16
+go 1.18

--- a/exercises/practice/scrabble-score/go.mod
+++ b/exercises/practice/scrabble-score/go.mod
@@ -1,3 +1,3 @@
 module scrabble
 
-go 1.16
+go 1.18

--- a/exercises/practice/secret-handshake/go.mod
+++ b/exercises/practice/secret-handshake/go.mod
@@ -1,3 +1,3 @@
 module secret
 
-go 1.16
+go 1.18

--- a/exercises/practice/series/go.mod
+++ b/exercises/practice/series/go.mod
@@ -1,3 +1,3 @@
 module series
 
-go 1.16
+go 1.18

--- a/exercises/practice/sieve/go.mod
+++ b/exercises/practice/sieve/go.mod
@@ -1,3 +1,3 @@
 module sieve
 
-go 1.16
+go 1.18

--- a/exercises/practice/simple-cipher/go.mod
+++ b/exercises/practice/simple-cipher/go.mod
@@ -1,3 +1,3 @@
 module cipher
 
-go 1.16
+go 1.18

--- a/exercises/practice/simple-linked-list/go.mod
+++ b/exercises/practice/simple-linked-list/go.mod
@@ -1,3 +1,3 @@
 module linkedlist
 
-go 1.16
+go 1.18

--- a/exercises/practice/space-age/go.mod
+++ b/exercises/practice/space-age/go.mod
@@ -1,3 +1,3 @@
 module space
 
-go 1.16
+go 1.18

--- a/exercises/practice/spiral-matrix/go.mod
+++ b/exercises/practice/spiral-matrix/go.mod
@@ -1,3 +1,3 @@
 module spiralmatrix
 
-go 1.16
+go 1.18

--- a/exercises/practice/state-of-tic-tac-toe/go.mod
+++ b/exercises/practice/state-of-tic-tac-toe/go.mod
@@ -1,3 +1,3 @@
 module stateoftictactoe
 
-go 1.16
+go 1.18

--- a/exercises/practice/strain/go.mod
+++ b/exercises/practice/strain/go.mod
@@ -1,3 +1,3 @@
 module strain
 
-go 1.16
+go 1.18

--- a/exercises/practice/sublist/go.mod
+++ b/exercises/practice/sublist/go.mod
@@ -1,3 +1,3 @@
 module sublist
 
-go 1.16
+go 1.18

--- a/exercises/practice/sum-of-multiples/go.mod
+++ b/exercises/practice/sum-of-multiples/go.mod
@@ -1,3 +1,3 @@
 module summultiples
 
-go 1.16
+go 1.18

--- a/exercises/practice/tournament/go.mod
+++ b/exercises/practice/tournament/go.mod
@@ -1,3 +1,3 @@
 module tournament
 
-go 1.16
+go 1.18

--- a/exercises/practice/transpose/go.mod
+++ b/exercises/practice/transpose/go.mod
@@ -1,3 +1,3 @@
 module transpose
 
-go 1.16
+go 1.18

--- a/exercises/practice/tree-building/go.mod
+++ b/exercises/practice/tree-building/go.mod
@@ -1,3 +1,3 @@
 module tree
 
-go 1.16
+go 1.18

--- a/exercises/practice/triangle/go.mod
+++ b/exercises/practice/triangle/go.mod
@@ -1,3 +1,3 @@
 module triangle
 
-go 1.16
+go 1.18

--- a/exercises/practice/trinary/go.mod
+++ b/exercises/practice/trinary/go.mod
@@ -1,3 +1,3 @@
 module trinary
 
-go 1.16
+go 1.18

--- a/exercises/practice/twelve-days/go.mod
+++ b/exercises/practice/twelve-days/go.mod
@@ -1,3 +1,3 @@
 module twelve
 
-go 1.16
+go 1.18

--- a/exercises/practice/two-bucket/go.mod
+++ b/exercises/practice/two-bucket/go.mod
@@ -1,3 +1,3 @@
 module twobucket
 
-go 1.16
+go 1.18

--- a/exercises/practice/two-fer/go.mod
+++ b/exercises/practice/two-fer/go.mod
@@ -1,3 +1,3 @@
 module twofer
 
-go 1.16
+go 1.18

--- a/exercises/practice/variable-length-quantity/go.mod
+++ b/exercises/practice/variable-length-quantity/go.mod
@@ -1,3 +1,3 @@
 module variablelengthquantity
 
-go 1.16
+go 1.18

--- a/exercises/practice/word-count/go.mod
+++ b/exercises/practice/word-count/go.mod
@@ -1,3 +1,3 @@
 module wordcount
 
-go 1.16
+go 1.18

--- a/exercises/practice/word-search/go.mod
+++ b/exercises/practice/word-search/go.mod
@@ -1,3 +1,3 @@
 module wordsearch
 
-go 1.16
+go 1.18

--- a/exercises/practice/wordy/go.mod
+++ b/exercises/practice/wordy/go.mod
@@ -1,3 +1,3 @@
 module wordy
 
-go 1.16
+go 1.18

--- a/exercises/practice/yacht/go.mod
+++ b/exercises/practice/yacht/go.mod
@@ -1,3 +1,3 @@
 module yacht
 
-go 1.16
+go 1.18

--- a/exercises/practice/zebra-puzzle/go.mod
+++ b/exercises/practice/zebra-puzzle/go.mod
@@ -1,3 +1,3 @@
 module zebra
 
-go 1.16
+go 1.18

--- a/gomod-sync/config.json
+++ b/gomod-sync/config.json
@@ -1,4 +1,4 @@
 {
-  "default": "1.16",
+  "default": "1.18",
   "exceptions": []
 }


### PR DESCRIPTION
## Description

This PR prepares the main repo for the track upgrade to Go 1.20:

- Updated CI to run Go 1.20
- Set default version to 1.18 in the config file of `gomod-sync`
  - This means CI will also now require new exercises to have a `go.mod` set to 1.18
- Updated all `go.mod` files to 1.18 (`gomod-sync update`)
- Removed two notes mentioning the track is on Go 1.16
- Updated golanci-lint to the most recent version

## Related

PR that also should be merged for the track to be considered "upgraded":

- [ ] Update test runner: https://github.com/exercism/go-test-runner/pull/97

This PR should be merged eventually, but there's no rush since Go currently doesn't have the representer or the analyzer enabled:

- [ ] Update representer: https://github.com/exercism/go-representer/pull/34
- [ ] Update analyzer: https://github.com/exercism/go-analyzer/pull/40
