### PR TITLE
clock: improve test output for "stringless" tests

### DIFF
--- a/exercises/practice/clock/clock_test.go
+++ b/exercises/practice/clock/clock_test.go
@@ -49,7 +49,8 @@ func TestAddMinutesStringless(t *testing.T) {
 
 			expected := New(wantHour, wantMin)
 			if actual := New(tc.h, tc.m).Add(tc.addedValue); !reflect.DeepEqual(actual, expected) {
-				t.Errorf("New(%d, %d).Add(%d) = %v, want %v", tc.h, tc.m, tc.addedValue, actual, expected)
+				t.Errorf("New(%d, %d).Add(%d)\n\t Got: %q (%#v)\n\tWant: %q (%#v)",
+					tc.h, tc.m, tc.addedValue, actual, actual, expected, expected)
 			}
 		})
 	}
@@ -67,7 +68,8 @@ func TestSubtractMinutesStringless(t *testing.T) {
 
 			expected := New(wantHour, wantMin)
 			if actual := New(tc.h, tc.m).Subtract(tc.subtractedValue); !reflect.DeepEqual(actual, expected) {
-				t.Errorf("New(%d, %d).Subtract(%d) = %v, want %v", tc.h, tc.m, tc.subtractedValue, actual, expected)
+				t.Errorf("New(%d, %d).Subtract(%d)\n\t Got: %q (%#v)\n\tWant: %q (%#v)",
+					tc.h, tc.m, tc.subtractedValue, actual, actual, expected, expected)
 			}
 		})
 	}
@@ -80,7 +82,8 @@ func TestCompareClocks(t *testing.T) {
 			clock2 := New(tc.c2.h, tc.c2.m)
 			actual := clock1 == clock2
 			if actual != tc.expected {
-				t.Errorf("Clock1 == Clock2 is %t, want %t\nClock1: %q\nClock2: %q", actual, tc.expected, clock1, clock2)
+				t.Errorf("Clock1 == Clock2 is %t, want %t\n\tClock1: %q (%#v)\n\tClock2: %q (%#v)",
+					actual, tc.expected, clock1, clock1, clock2, clock2)
 				if reflect.DeepEqual(clock1, clock2) {
 					t.Log("(Hint: see comments in clock_test.go.)")
 				}


### PR DESCRIPTION
Closes #2621

<details>
  <summary>New test output</summary>
<pre>
$ go test
--- FAIL: TestAddMinutesStringless (0.00s)
    --- FAIL: TestAddMinutesStringless/add_across_midnight (0.00s)
        clock_test.go:52: New(23, 59).Add(2)
                 Got: "00:01" (clock.Clock{minutes:1441})
                Want: "00:01" (clock.Clock{minutes:1})
    --- FAIL: TestAddMinutesStringless/add_more_than_one_day_(1500_min_=_25_hrs) (0.00s)
        clock_test.go:52: New(5, 32).Add(1500)
                 Got: "06:32" (clock.Clock{minutes:1832})
                Want: "06:32" (clock.Clock{minutes:392})
    --- FAIL: TestAddMinutesStringless/add_more_than_two_days (0.00s)
        clock_test.go:52: New(1, 1).Add(3500)
                 Got: "11:21" (clock.Clock{minutes:3561})
                Want: "11:21" (clock.Clock{minutes:681})
--- FAIL: TestSubtractMinutesStringless (0.00s)
    --- FAIL: TestSubtractMinutesStringless/subtract_across_midnight (0.00s)
        clock_test.go:71: New(0, 3).Subtract(4)
                 Got: "23:59" (clock.Clock{minutes:-1})
                Want: "23:59" (clock.Clock{minutes:1439})
    --- FAIL: TestSubtractMinutesStringless/subtract_more_than_two_hours (0.00s)
        clock_test.go:71: New(0, 0).Subtract(160)
                 Got: "21:20" (clock.Clock{minutes:-160})
                Want: "21:20" (clock.Clock{minutes:1280})
    --- FAIL: TestSubtractMinutesStringless/subtract_more_than_one_day_(1500_min_=_25_hrs) (0.00s)
        clock_test.go:71: New(5, 32).Subtract(1500)
                 Got: "04:32" (clock.Clock{minutes:-1168})
                Want: "04:32" (clock.Clock{minutes:272})
    --- FAIL: TestSubtractMinutesStringless/subtract_more_than_two_days (0.00s)
        clock_test.go:71: New(2, 20).Subtract(3000)
                 Got: "00:20" (clock.Clock{minutes:-2860})
                Want: "00:20" (clock.Clock{minutes:20})
--- FAIL: TestCompareClocks (0.00s)
    --- FAIL: TestCompareClocks/clocks_with_hour_overflow (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "10:37" (clock.Clock{minutes:637})
                Clock2: "10:37" (clock.Clock{minutes:2077})
    --- FAIL: TestCompareClocks/clocks_with_hour_overflow_by_several_days (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "03:11" (clock.Clock{minutes:191})
                Clock2: "03:11" (clock.Clock{minutes:5951})
    --- FAIL: TestCompareClocks/clocks_with_negative_hour (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "22:40" (clock.Clock{minutes:1360})
                Clock2: "22:40" (clock.Clock{minutes:-80})
    --- FAIL: TestCompareClocks/clocks_with_negative_hour_that_wraps (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "17:03" (clock.Clock{minutes:1023})
                Clock2: "17:03" (clock.Clock{minutes:-1857})
    --- FAIL: TestCompareClocks/clocks_with_negative_hour_that_wraps_multiple_times (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "13:49" (clock.Clock{minutes:829})
                Clock2: "13:49" (clock.Clock{minutes:-4931})
    --- FAIL: TestCompareClocks/clocks_with_minute_overflow (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "00:01" (clock.Clock{minutes:1})
                Clock2: "00:01" (clock.Clock{minutes:1441})
    --- FAIL: TestCompareClocks/clocks_with_minute_overflow_by_several_days (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "02:02" (clock.Clock{minutes:122})
                Clock2: "02:02" (clock.Clock{minutes:4442})
    --- FAIL: TestCompareClocks/clocks_with_negative_minute_that_wraps (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "04:10" (clock.Clock{minutes:250})
                Clock2: "04:10" (clock.Clock{minutes:-1190})
    --- FAIL: TestCompareClocks/clocks_with_negative_minute_that_wraps_multiple_times (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "06:15" (clock.Clock{minutes:375})
                Clock2: "06:15" (clock.Clock{minutes:-3945})
    --- FAIL: TestCompareClocks/clocks_with_negative_hours_and_minutes (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "07:32" (clock.Clock{minutes:452})
                Clock2: "07:32" (clock.Clock{minutes:-988})
    --- FAIL: TestCompareClocks/clocks_with_negative_hours_and_minutes_that_wrap (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "18:07" (clock.Clock{minutes:1087})
                Clock2: "18:07" (clock.Clock{minutes:-14753})
    --- FAIL: TestCompareClocks/full_clock_and_zeroed_clock (0.00s)
        clock_test.go:85: Clock1 == Clock2 is false, want true
                Clock1: "00:00" (clock.Clock{minutes:1440})
                Clock2: "00:00" (clock.Clock{minutes:0})
FAIL
exit status 1
FAIL    clock   0.439s
</pre>
</details>