### PR TITLE
Correct expected output in Welcome To Tech Palace! - 2. Add a fancy border

### DIFF
--- a/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
+++ b/exercises/concept/welcome-to-tech-palace/.docs/instructions.md
@@ -31,10 +31,10 @@ AddBorder("Welcome!", 10)
 
 Should return the following:
 
-```go
-// **********
-// Welcome!
-// **********
+```
+**********
+Welcome!
+**********
 ```
 
 ## 3. Clean up old marketing messages


### PR DESCRIPTION
#### Context

I am enjoying the #12in23 challenge and in March I am pursuing the Go track. Today's early morning exercise was [Welcome To Tech Palace! ](https://exercism.org/tracks/go/exercises/welcome-to-tech-palace). Part 2, "Add a fancy border" took a little longer than expected because I tried to add leading forward strokes as in the example. It looks like these were left-overs from when the output was included as a comment, rather than a separate block of text (b1461325).

#### Change

See individual commits for finer details.

#### Considerations

An alternative would be to revert #2404 but I think this example is clearer as others were confused by the newline.