### PR TITLE
Update resistor color exercises go.mod to 1.18

### DIFF
--- a/exercises/practice/resistor-color-duo/go.mod
+++ b/exercises/practice/resistor-color-duo/go.mod
@@ -1,3 +1,3 @@
 module resistorcolorduo
 
-go 1.16
+go 1.18

--- a/exercises/practice/resistor-color-trio/go.mod
+++ b/exercises/practice/resistor-color-trio/go.mod
@@ -1,3 +1,3 @@
 module resistorcolortrio
 
-go 1.16
+go 1.18

--- a/exercises/practice/resistor-color/go.mod
+++ b/exercises/practice/resistor-color/go.mod
@@ -1,3 +1,3 @@
 module resistorcolor
 
-go 1.16
+go 1.18


### PR DESCRIPTION
These exercises were added after I made https://github.com/exercism/go/pull/2609 and I forgot to update that PR to also bumping the go.mod version in these new exercises too. This PR fixes that.