### PR TITLE
Add an extra test case catching edge case from using integer division

### DIFF
--- a/exercises/concept/need-for-speed/need_for_speed_test.go
+++ b/exercises/concept/need-for-speed/need_for_speed_test.go
@@ -253,6 +253,19 @@ func TestCanFinish(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Implementation should take into account rounding errors from using integer division",
+			car: Car{
+				speed:        3,
+				batteryDrain: 5,
+				battery:      51,
+				distance:     0,
+			},
+			track: Track{
+				distance: 31,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
While checking out some of the alternative solutions when working through the curriculum I realised the top answers to this exercise are actually defective. They don't take into account that integer division in Go rounds the number down to the natural number.

This edge case introduces a test that should force students into considering these edge cases. Note that learning about integer division is a prerequisite to reaching this exercise.