### PR TITLE
Update links.json for Go -> Comments concept

### DIFF
--- a/concepts/comments/links.json
+++ b/concepts/comments/links.json
@@ -12,7 +12,11 @@
     "description": "Go tools: godoc"
   },
   {
-    "url": "https://github.com/golang/lint",
-    "description": "Go tools: golint"
+    "url": "https://pkg.go.dev/cmd/vet",
+    "description": "Go tools: go vet"
+  }
+  {
+    "url": "https://staticcheck.io/",
+    "description": "Go tools: Staticcheck"
   }
 ]


### PR DESCRIPTION
Proposal: Replace the link of deprecated and frozen 'golint' project with 'go vet' and 'Staticcheck', recommended by the author of golint. See notes at https://github.com/golang/lint and https://github.com/golang/go/issues/38968 for details.