### PR TITLE
Update golangci-lint to 1.52.2

### DIFF
--- a/bin/fetch-golangci-lint
+++ b/bin/fetch-golangci-lint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2

--- a/exercises/practice/linked-list/linked_list_test.go
+++ b/exercises/practice/linked-list/linked_list_test.go
@@ -101,7 +101,7 @@ func checkDoublyLinkedList(t *testing.T, ll *List, expected []interface{}) {
 // debugString prints the linked list with both node's Value, next & prev pointers.
 func (ll *List) debugString() string {
 	buf := bytes.NewBuffer([]byte{'{'})
-	buf.WriteString(fmt.Sprintf("First()= %p; ", ll.First()))
+	fmt.Fprintf(buf, "First()= %p; ", ll.First())
 
 	counter := 0
 
@@ -110,11 +110,10 @@ func (ll *List) debugString() string {
 		if counter > 100 {
 			panic("Possible infinite loop detected and stopped. Check the .Next() implementation")
 		}
-		buf.WriteString(fmt.Sprintf("[Prev()= %p, Value= %p (%v), Next()= %p] <-> ", cur.Prev(), cur, cur.Value, cur.Next()))
+		fmt.Fprintf(buf, "[Prev()= %p, Value= %p (%v), Next()= %p] <-> ", cur.Prev(), cur, cur.Value, cur.Next())
 	}
 
-	buf.WriteString(fmt.Sprintf("; Last()= %p; ", ll.Last()))
-	buf.WriteByte('}')
+	fmt.Fprintf(buf, "; Last()= %p; ", ll.Last())
 
 	return buf.String()
 }


### PR DESCRIPTION
No particular reason for this upgrade other than not letting golangci-lint fall too far behind, so we can solve potential issues with updates early on instead of dealing with a lot of breaking changes at once with big updates, which potentially break a bunch of stuff at once.