### PR TITLE
custom_set: add test case for unsorted subset

### DIFF
--- a/exercises/practice/custom-set/cases_test.go
+++ b/exercises/practice/custom-set/cases_test.go
@@ -105,6 +105,12 @@ var subsetCases = []binBoolCase{
 		want:        true,
 	},
 	{
+		description: "unsorted set is a subset of larger set with same elements",
+		set1:        []string{"b", "a"},
+		set2:        []string{"a", "b", "c"},
+		want:        true,
+	},
+	{
 		description: "set is a subset of larger set with same elements",
 		set1:        []string{"a", "b", "c"},
 		set2:        []string{"d", "a", "b", "c"},


### PR DESCRIPTION
My approach for the Set type was to make it a string.  So for the existing test cases to pass, all I had to do was:

```
type Set string

func New() Set {
	return "{}"
}

func (s Set) removeBraces() string {
	return s.String()[1 : len(s.String())-1]
}

func Subset(s1, s2 Set) bool {
	return strings.Contains(s2.String(), s1.removeBraces())
}
```

This obviously shouldn't be a correct solution, because if the given sub slice has the same elements, as the superset slice, but in an unsorted manner, then the result should be true. But my approach returns false.