### PR TITLE
Update introduction.md

### DIFF
--- a/exercises/concept/elons-toys/.docs/introduction.md
+++ b/exercises/concept/elons-toys/.docs/introduction.md
@@ -49,7 +49,7 @@ type circle struct {
 	radius int
 }
 func (c circle) area() float64 {
-	return math.Pow(c.radius, 2) * math.Pi
+	return math.Pow(float64(c.radius), 2) * math.Pi
 }
 ```
 


### PR DESCRIPTION
math.Pow takes float64 as arguments

https://forum.exercism.org/t/bug-wrong-formula-in-elons-toys-exercise/5174