### PR TITLE
doc: fix example data description

### DIFF
--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -12,11 +12,13 @@ Or it might have one, or even several.
 
 Here is a grid that has exactly one candidate tree.
 
+```
     1  2  3  4
   |-----------
 1 | 9  8  7  8
 2 | 5  3  2  4  <--- potential tree house at row 2, column 1, for tree with height 5
 3 | 6  6  7  1
+```
 
 - Row 2 has values 5, 3, and 1. The largest value is 5.
 - Column 1 has values 9, 5, and 6. The smallest value is 5.


### PR DESCRIPTION
Hi everyone!

I'm going through the go track and found that the instructions in the exercise [saddle points](https://exercism.org/tracks/go/exercises/saddle-points) have a little error in the markdown. 

**Before**:

![image](https://github.com/exercism/go/assets/4480634/eda21ce7-30fe-4a71-aba9-1e05f6ba8cc6)


**After**

![image](https://github.com/exercism/go/assets/4480634/1e35fd36-4b18-40aa-979f-b49b2198897f)

Please let me know if there is a better way to correct the markdown.