### PR TITLE
Update test order within gross_store_test.go to match order of steps

### DIFF
--- a/exercises/concept/gross-store/gross_store_test.go
+++ b/exercises/concept/gross-store/gross_store_test.go
@@ -38,6 +38,18 @@ func TestUnits(t *testing.T) {
 	}
 
 }
+
+func TestNewBill(t *testing.T) {
+	// Success, zero out the  bill
+	t.Run("Should reset customerbill", func(t *testing.T) {
+		bill := NewBill()
+
+		if len(bill) != 0 {
+			t.Error("Customer bill must be empty")
+		}
+	})
+}
+
 func TestAddItem(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -177,17 +189,6 @@ func TestRemoveItem(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestNewBill(t *testing.T) {
-	// Success, zero out the  bill
-	t.Run("Should reset customerbill", func(t *testing.T) {
-		bill := NewBill()
-
-		if len(bill) != 0 {
-			t.Error("Customer bill must be empty")
-		}
-	})
 }
 
 func TestGetItem(t *testing.T) {


### PR DESCRIPTION
Re-arrange the order of tests to match the order of the exercises within the UI.

I was a bit confused when I went through this exercise, I usually approach these in a TDD kind of style, where I do one step, run tests, and verify that the step is working as expected. However this exercise the tests seemed to be out of order compared to the steps.

Of note - I have no idea if this is the "right" fix, I'm only assuming that the order of the tests should also match the order of the steps for them to match within the exercism UI.