### PR TITLE
Turn on Representer

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "status": {
     "concept_exercises": true,
     "test_runner": true,
-    "representer": false,
+    "representer": true,
     "analyzer": false
   },
   "blurb": "Go is a compiled, open source programming language with a small, consistent syntax, a powerful standard library, and fantastic tooling. It's a great fit for web backends and command-line tools.",


### PR DESCRIPTION
We're shortly going to be adding a generic representer, which normalises whitespace. As Go's actual representer will be better than the generic one, it makes sense to have it enabled, even if it's not perfect yet.