### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/variadic-functions/about.md
+++ b/concepts/variadic-functions/about.md
@@ -21,7 +21,7 @@ find(5, 6, 7)
 find(5)
 ```
 
-````exercism/caution
+~~~~exercism/caution
 The variadic parameter must be the last parameter of the function.
 
 If you try to write code like this ...
@@ -35,7 +35,7 @@ func find(...a int, b int) {}
 Imagine the function above would work and we pass multiple arguments.
 Then all those arguments will get assigned to `a` and nothing would be assigned to `b`.
 Hence, variadic parameter must be provided at the end.
-````
+~~~~
 
 The way variadic functions work is by converting the variable number of arguments to a slice of the type of the variadic parameter.
 

--- a/concepts/variadic-functions/introduction.md
+++ b/concepts/variadic-functions/introduction.md
@@ -21,9 +21,9 @@ find(5, 6, 7)
 find(5)
 ```
 
-```exercism/caution
+~~~~exercism/caution
 The variadic parameter must be the last parameter of the function.
-```
+~~~~
 
 The way variadic functions work is by converting the variable number of arguments to a slice of the type of the variadic parameter.
 

--- a/exercises/concept/card-tricks/.docs/introduction.md
+++ b/exercises/concept/card-tricks/.docs/introduction.md
@@ -81,9 +81,9 @@ find(5, 6, 7)
 find(5)
 ```
 
-```exercism/caution
+~~~~exercism/caution
 The variadic parameter must be the last parameter of the function.
-```
+~~~~
 
 The way variadic functions work is by converting the variable number of arguments to a slice of the type of the variadic parameter.
 

--- a/exercises/practice/bob/.approaches/if-statements/content.md
+++ b/exercises/practice/bob/.approaches/if-statements/content.md
@@ -49,19 +49,19 @@ func Hey(remark string) string {
 
 In this approach you have a series of `if` statements using the private functions to evaluate the conditions.
 
-```exercism/note
+~~~~exercism/note
 A private (also called unexported) function is indicated by starting with a lowercase letter.
 More info on exported and unexported functions can be found [here](https://yourbasic.org/golang/public-private/).
-```
+~~~~
 
 
 As soon as the right condition is found, the correct response is returned.
 
-```exercism/note
+~~~~exercism/note
 Note that there are no `else if` or `else` statements.
 If an `if` statement can return, then an `else if` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
-```
+~~~~
 
 In the `isShout()` function, the [`strings`][strings] function [`IndexFunc()`][indexfunc] is used to ensure there is at least one letter character in the input.
 If not, the function returns `false`, because if the input were only `"123"` it would equal itself uppercased, but without letters it would not be a shout.

--- a/exercises/practice/bob/.approaches/switch-statement/content.md
+++ b/exercises/practice/bob/.approaches/switch-statement/content.md
@@ -51,10 +51,10 @@ In this approach you use a [`switch`][switch] statement to test if there is a qu
 The `switch`, with the help of some private functions to evaluate the conditions,
 returns the right response for a question, shout, shouted question, or for not being a shout or a question.
 
-```exercism/note
+~~~~exercism/note
 A private (also called unexported) function is indicated by starting with a lowercase letter.
 More info on exported and unexported functions can be found [here](https://yourbasic.org/golang/public-private/).
-```
+~~~~
 
 In the `isShout()` function, the [`strings`][strings] function [`IndexFunc()`][indexfunc] is used to ensure there is at least one letter character in the input.
 If not, the function returns `false`, because if the input were only `"123"` it would equal itself uppercased, but without letters it would not be a shout.

--- a/exercises/practice/clock/.approaches/clock-as-int/content.md
+++ b/exercises/practice/clock/.approaches/clock-as-int/content.md
@@ -60,7 +60,7 @@ There are other ways to handle rollover, such as the following expression:
 
 Since `normalize()` returns a `Clock`, it can be used by the `New` function as well as the `Add` and `Subtract` [methods][methods].
 
-```exercism/note
+~~~~exercism/note
 Note that, in the `Add` and `Subtract`methods, the received `Clock` argument must be converted to an `int` to be
 added to or subtracted by the `int` minutes, even though the underlying type of `Clock` is an `int`.
 This can be helpful if two `int` values are two different types, such as a meter and a foot.
@@ -68,7 +68,7 @@ The compiler will not allow adding a meter type to a foot type,
 even if both are an `int`, unless one of them is converted to the other.
 For an example of why this is important, see an article on how a $125 million spacecraft crashed because of a 
 [mix-up between English and metric units of measure](https://www.simscale.com/blog/nasa-mars-climate-orbiter-metric/).
-```
+~~~~
 
 The `String()` function uses [`fmt.Sprintf()`][sprintf] to format the hour and minutes with leading zeros.
 If the amount of minutes is `69`, then the hour is `69` divided by `60` (1),

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -58,10 +58,10 @@ By subtracting `1` we get `3`, which is the total amount of grains on the two sq
 |       2 |             0011 |                 3 |
 
 
-```exercism/note
+~~~~exercism/note
 A shortcut would be to use the [`math.MaxUint64`](https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/math/const.go;l=39)
 constant, which is defined as `1<<64 - 1`.
-```
+~~~~
 
 [uint64]: https://pkg.go.dev/builtin#uint64
 [left-shift-operator]: https://www.golangprograms.com/bitwise-operators-in-go-programming-language.html

--- a/exercises/practice/isogram/.approaches/map/content.md
+++ b/exercises/practice/isogram/.approaches/map/content.md
@@ -30,11 +30,11 @@ func IsIsogram(phrase string) bool {
 This approach starts by defining the type `blank` as an empty struct.
 The lookup [`map`][map] is defined with a [`rune`][rune] as the key and `blank` (i.e. an empty struct) as the value.
 
-```exercism/note
+~~~~exercism/note
 By assigning values of an empty struct to the `map`, it essentially makes the keys what is known as a "set" in other languages.
 A set is a collection of unique values.
 More info on implementing a set in Go can be found [here](https://yourbasic.org/golang/implement-set/).
-```
+~~~~
 
 The ways to iterate characters are by Unicode runes, or by each letter being a string, or by each letter being a byte.
 The runes are from [`range`][range] on a string, the strings from [`Split()`][split], and the bytes from indexing into the string.

--- a/exercises/practice/pig-latin/.approaches/map-lookups-with-generics/content.md
+++ b/exercises/practice/pig-latin/.approaches/map-lookups-with-generics/content.md
@@ -60,11 +60,11 @@ This approach starts be defining a void [type][type] that will be used in the pa
 Several [map][map]s for then defined for looking up vowels and special letter combinations.
 The maps have an empty struct as the type for their values.
 
-```exercism/note
+~~~~exercism/note
 By assigning values of an empty struct to the `map`, it essentially makes the keys what is known as a "set" in other languages.
 A set is a collection of unique values.
 More info on implementing a set in Go can be found [here](https://yourbasic.org/golang/implement-set/).
-```
+~~~~
 
 An [interface type][interface-type] is then defined which will be used to constain which types are to be used for the [generics][generics]:
 

--- a/exercises/practice/protein-translation/.approaches/map/content.md
+++ b/exercises/practice/protein-translation/.approaches/map/content.md
@@ -70,13 +70,13 @@ If the error is `nil`, then the protein is appended to the output slice of prote
 
 When the loop successfully finishes, the function returns the slice of proteins and a `nil` error.
 
-```exercism/note
+~~~~exercism/note
 The `err` returned from the call to `FromCodon()` shadows the `err` named return value defined for `from RNA()`.
 If an `err` is returned for a `STOP` codon, it falls out of scope when breaking from the loop,
 and the `err` returned at the end of the function is the `err` named return value with the zero (`nil`) value.
 More info on shadowed variables can be found [here](https://yourbasic.org/golang/gotcha-shadowing-variables/).
 Because shadowing variables can be confusing, it may be preferred to use `return proteins, nil` for the final return statement.
-```
+~~~~
 
 The `FromCodon()` function is also defined with [named return values][named-return-values] which are initialized with their [zero values][zero-values].
 If the look-up of the codon results in an empty `string`, the error is set for an invalid codon.

--- a/exercises/practice/protein-translation/.approaches/switch/content.md
+++ b/exercises/practice/protein-translation/.approaches/switch/content.md
@@ -84,13 +84,13 @@ If the error is `nil`, then the protein is appended to the output slice of prote
 
 When the loop successfully finishes, the function returns the slice of proteins and a `nil` error.
 
-```exercism/note
+~~~~exercism/note
 The `err` returned from the call to `FromCodon()` shadows the `err` named return value defined for `from RNA()`.
 If an `err` is returned for a `STOP` codon, it falls out of scope when breaking from the loop,
 and the `err` returned at the end of the function is the `err` named return value with the zero (`nil`) value.
 More info on shadowed variables can be found [here](https://yourbasic.org/golang/gotcha-shadowing-variables/).
 Because shadowing variables can be confusing, it may be preferred to use `return proteins, nil` for the final return statement.
-```
+~~~~
 
 [switch]: https://go.dev/tour/flowcontrol/9
 [named-return-values]: https://yourbasic.org/golang/named-return-values-parameters/

--- a/exercises/practice/rna-transcription/.approaches/map-object/content.md
+++ b/exercises/practice/rna-transcription/.approaches/map-object/content.md
@@ -40,11 +40,11 @@ This iterates over the runes of the input `string` and passes them as the key to
 For this exercise we are not concerned with validating the letter and handling an error for an illegal character.
 The `map` returns the matching RNA byte value for the DNA rune, which is placed at the same index in the byte slice.
 
-```exercism/caution
+~~~~exercism/caution
 This iterates over the runes of the input `string` and places them at the same index in the byte slice.
 That works in this case, because the input is all single-byte ASCII characters.
 But, if the input included any multi-byte Unicode characters, the indexes would not match.
-```
+~~~~
 
 After the iteration of the input `string` finishes, the function returns the byte slice converted to a `string`.
 

--- a/exercises/practice/strain/.approaches/using-generics/content.md
+++ b/exercises/practice/strain/.approaches/using-generics/content.md
@@ -46,23 +46,23 @@ and if a second name is needed, to use `U`, and so on.
 The type `T` is constrained to be one of the types defined in the `Slicer` interface.
 The arguments to the function are a slice of the generic type `T`, and a function which takes a value of type `T` and returns a boolean value.
 
-```exercism/note
+~~~~exercism/note
 If you haven't passed a function as a parameter before, a short explanation can be found [here](https://golangbyexample.com/func-as-func-argument-go/).
-```
+~~~~
 
 The `Keep()` function is defined to return a slice of type `T`.
 
 If the input is `nil` it is simply returned.
 Otherwise an output slice is made of the same type as `T`, given a length of `0`, and given a capacity that is the length of the input slice.
 
-```exercism/note
+~~~~exercism/note
 Since the returned slice can be no bigger than the input slice,
 the output slice is given a capacity of the length of the input slice to prevent a lot of reallocating of the output slice.
 However, if the usual expected input was large and the usual expected output was small,
 then a lower capacity might be used to define the output slice to save allocating more memory than needed.
 Since this exercise uses a small length for the input slices, then it is okay to make the capacity of the output slice the same length.
 For more information on the length and capacity of slices, see [here](https://go.dev/blog/slices-intro).
-```
+~~~~
 
 [`range`][range] is used to iterate the elements of the input slice.
 Each element is passed to the input `filter` function.


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705