### PR TITLE
Fix formatedTime typo

### DIFF
--- a/concepts/time/about.md
+++ b/concepts/time/about.md
@@ -32,8 +32,8 @@ import (
 
 func main() {
     t := time.Date(1995,time.September,22,13,0,0,0,time.UTC)
-    formatedTime := t.Format("Mon, 01/02/2006, 15:04") // string
-    fmt.Println(formatedTime)
+    formattedTime := t.Format("Mon, 01/02/2006, 15:04") // string
+    fmt.Println(formattedTime)
 }
 
 // => Fri, 09/22/1995, 13:00

--- a/concepts/time/introduction.md
+++ b/concepts/time/introduction.md
@@ -32,8 +32,8 @@ import (
 
 func main() {
     t := time.Date(1995,time.September,22,13,0,0,0,time.UTC)
-    formatedTime := t.Format("Mon, 01/02/2006, 15:04") // string
-    fmt.Println(formatedTime)
+    formattedTime := t.Format("Mon, 01/02/2006, 15:04") // string
+    fmt.Println(formattedTime)
 }
 
 // => Fri, 09/22/1995, 13:00

--- a/exercises/concept/booking-up-for-beauty/.docs/introduction.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/introduction.md
@@ -32,8 +32,8 @@ import (
 
 func main() {
     t := time.Date(1995,time.September,22,13,0,0,0,time.UTC)
-    formatedTime := t.Format("Mon, 01/02/2006, 15:04") // string
-    fmt.Println(formatedTime)
+    formattedTime := t.Format("Mon, 01/02/2006, 15:04") // string
+    fmt.Println(formattedTime)
 }
 
 // => Fri, 09/22/1995, 13:00


### PR DESCRIPTION
Corrected the typo from formatedTime to formattedTime.

I've extended the corrections from pull request #2711 to encompass all files. The typo was initially identified by another esteemed contributor, but it appeared that not all files had been addressed. I've taken the liberty to ensure its thorough application throughout the project.