### PR TITLE
fix typo and 404 links

### DIFF
--- a/exercises/practice/nucleotide-count/.approaches/introduction.md
+++ b/exercises/practice/nucleotide-count/.approaches/introduction.md
@@ -6,7 +6,7 @@ Or you can use `if` with a short statement.
 
 ## General guidance
 
-The key to solving Nucelotide Count is to look up valid nucleotides and to error on invalid input.
+The key to solving Nucleotide Count is to look up valid nucleotides and to error on invalid input.
 
 ## Approach: `switch` statement
 
@@ -76,6 +76,6 @@ For more information, check the [`if` with short statement approach][approach-if
 The `if` with short statement approach benchmarked the fastest.
 To compare performance of the approaches, check the [Performance article][article-performance].
 
-[approach-switch-statement]: https://exercism.org/tracks/go/exercises/nucelotide-count/approaches/switch-statement
-[approach-if-with-short-statement]: https://exercism.org/tracks/go/exercises/nucelotide-count/approaches/if-with-short-statement
-[article-performance]: https://exercism.org/tracks/go/exercises/nucelotide-count/articles/performance
+[approach-switch-statement]: https://exercism.org/tracks/go/exercises/nucleotide-count/approaches/switch-statement
+[approach-if-with-short-statement]: https://exercism.org/tracks/go/exercises/nucleotide-count/approaches/if-with-short-statement
+[article-performance]: https://exercism.org/tracks/go/exercises/nucleotide-count/articles/performance


### PR DESCRIPTION
Fixed typo in the word "nucleotide". The word was previously misspelled and thus some of the links didn't work, throwing 404 error. From forum thread: [link](https://forum.exercism.org/t/404-error-in-provided-performance-article-link-in-dig-deeper-section-of-nucleotide-count-exercise/7878)