### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -16,18 +16,18 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.20.x]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macOS-latest]
         test-arch: [amd64]
         race: ["-race"]
 
         include:
           - go-version: 1.20.x
             test-arch: "386"
-            os: ubuntu-latest
+            os: ubuntu-22.04
             race: ""
           - go-version: 1.20.x
             test-arch: "386"
-            os: windows-latest
+            os: windows-2022
             race: ""
 
     steps:

--- a/.github/workflows/gomod-sync.yml
+++ b/.github/workflows/gomod-sync.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check:
     name: go.mod check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/stub-tests.yml
+++ b/.github/workflows/stub-tests.yml
@@ -16,18 +16,18 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.20.x]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macOS-latest]
         test-arch: [amd64]
         race: ["-race"]
 
         include:
           - go-version: 1.20.x
             test-arch: "386"
-            os: ubuntu-latest
+            os: ubuntu-22.04
             race: ""
           - go-version: 1.20.x
             test-arch: "386"
-            os: windows-latest
+            os: windows-2022
             race: ""
 
     steps:


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.