### PR TITLE
Improve testing for Animal Magic Exercise

### DIFF
--- a/exercises/concept/animal-magic/animal_magic_test.go
+++ b/exercises/concept/animal-magic/animal_magic_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestRollADie(t *testing.T) {
+	missingRolls := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 	const tests = 100
 	var got int
 	foundDifferent := false
@@ -19,8 +20,19 @@ func TestRollADie(t *testing.T) {
 		if i > 0 && got != last {
 			foundDifferent = true
 		}
+
+		for i := 0; i < len(missingRolls); i++ {
+			if missingRolls[i] == got {
+				missingRolls = append(missingRolls[:i], missingRolls[i+1:]...)
+			}
+		}
 		last = got
 	}
+
+	if len(missingRolls) > 0 {
+		t.Errorf("RollADie() never rolled the numbers: %d", missingRolls)
+	}
+
 	if !foundDifferent {
 		t.Errorf("RollADie() always generates the same number: %d", got)
 	}


### PR DESCRIPTION
I had a conversation with my mentor exercise, Animal Magic, about the tests for the exercise.

I have pasted some of my observations/questions, and added an in my eyes, improved and more correct test.

Me: 
> I have seen multiple community examples like 
> https://exercism.org/tracks/go/exercises/animal-magic/solutions/ro-jc 
> https://exercism.org/tracks/go/exercises/animal-magic/solutions/andrerfcsantos
> 
> Where they do rand.Intn(20) + 1 but still marks as tests passed. I don't get that. That would in my eyes from time to time result in a die roll of 21, and no only between 1 and 20 as stated in the requirements.
> 
> Can someone explain this to me?
> 

Mentor: 
> "Intn returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n) from the default Source. It panics if n <= 0."

Me: 

> I read that, also before posting. But doesn't it say between 0 and 100 if rand.Intn(100) or what am I reading/misunderstanding wrong.
> 
> Despite that either the two examples i linked to should fail or my should fail, they cannot both be right.
> 
> Not my code, this could in my eyes potentially also return 21.
> 
> ```go
> // RollADie returns a random int between 1 and 20
> func RollADie() int {
> 	return 1 + rand.Intn(20)
> }
> ```
> My code:
> ```go
> // RollADie returns a random int d with 1 <= d <= 20.
> func RollADie() int {
> 	return rand.Intn(19) + 1
> }
> ```
> They cannot both be right.

Mentor:
> rand.Intn(20) will return integers from range 0 to 19 - note that the 0 in included in the range while 20 it is not. In order to generate an int that can be in range 1 - 20 you need to use 1 + rand.Intn(20) or rand.Intn(20) + 1. The second example will generate an int in range 0-18 and add 1 to the final, returned value. The clue I meantioned is in the range - half-open interval [0,n)

Me: 
> Thanks for your explanation will check it out tomorrow, and see if I understand it better, or even suggest an improvement to the code base.

So long story short, I think the solutions, my solution, with the `return rand.Intn(19) + 1` are incorrect, and my new improved tests will show that. The tests will now "ensure" more than before that all numbers are rolled, still within the scope of 1-20. Of course, there is still a small statics possibility that e.g. 20 is never rolled on 100 rolls.

I can of course be completely wrong as I'm new to go, but would be happy to discuss this, so that we can get an improved code base.

Let me know what you think. 
