### PR TITLE
clock: update clock exercise instructions to point to correct receiver type documentation

### DIFF
--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -14,4 +14,4 @@ than pointers. Note also how most time.Time methods have value receivers
 rather than pointer receivers.
 
 For some useful guidelines on when to use a value receiver or a pointer
-receiver see [Go Wiki: Receiver Type](https://github.com/golang/go/wiki/CodeReviewComments#receiver-type)
+receiver see [Go Wiki: Receiver Type](https://go.dev/wiki/CodeReviewComments#receiver-type)


### PR DESCRIPTION
The link went to a page which had been relocated. Explicitly linked to the correct section on the new page.