### PR TITLE
Fix "First Two Verses" Test case

### DIFF
--- a/exercises/practice/bottle-song/cases_test.go
+++ b/exercises/practice/bottle-song/cases_test.go
@@ -54,7 +54,7 @@ var testCases = []struct {
 			startBottles: 10,
 			takeDown:     2,
 		},
-		expected: []string{"Ten green bottles hanging on the wall,", "Ten green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be nine green bottles hanging on the wall.", "", "Nine green bottles hanging on the wall,", "Nine green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be eight green bottles hanging on the wall."},
+		expected: []string{"Ten green bottles hanging on the wall,", "Ten green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be nine green bottles hanging on the wall.", "Nine green bottles hanging on the wall,", "Nine green bottles hanging on the wall,", "And if one green bottle should accidentally fall,", "There'll be eight green bottles hanging on the wall."},
 	},
 	{
 		description: "last three verses",


### PR DESCRIPTION
There was an extra "" (empty string) inside that test case, which would lead to the test failing on the correct solution.