### PR TITLE
Remove obsolete information from Go track's Space Age exercise

### DIFF
--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,7 +1,0 @@
-# Instructions append
-
-## Planet Type
-
-The test cases make use of a custom `Planet` type that is sent to your function.
-You will need to implement this custom type yourself.
-Implementing this new custom type as a string should suffice.


### PR DESCRIPTION
This information no longer holds any value as the Planet type is already implemented in _space_age.go_ (line 2).

Approved by @andrerfcsantos on the [Community Forum](https://forum.exercism.org/t/go-tracks-space-age-has-obsolete-information-in-instructions/9394).