### PR TITLE
Exclude insecure rand sources checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,3 +28,6 @@ linters-settings:
         sizeThreshold: 384
   gofmt:
     simplify: true
+  gosec:
+    excludes:
+      - G404 # Insecure random number source (rand)


### PR DESCRIPTION
`gosec` discourages the use of `math/rand` in favor of `crypto/rand` as a more secure source for randomness. This level of concern about the randomness source security is not relevant in the track, so we are disabling this check.