### PR TITLE
card-tricks: Check if index is >= len(slice)

### DIFF
--- a/exercises/concept/card-tricks/card_tricks_test.go
+++ b/exercises/concept/card-tricks/card_tricks_test.go
@@ -51,7 +51,7 @@ func TestGetItem(t *testing.T) {
 			name: "Index out of bounds",
 			args: args{
 				slice: []int{5, 2, 10, 6, 8, 7, 0, 9},
-				index: 8,
+				index: 9,
 			},
 			want: -1,
 		},


### PR DESCRIPTION

Adjusting so the test will now fail if the `index` value is greater than or equal to the size of the `slice`.