### PR TITLE
Remove unused 'input' field

### DIFF
--- a/exercises/practice/resistor-color/.meta/gen.go
+++ b/exercises/practice/resistor-color/.meta/gen.go
@@ -16,7 +16,7 @@ type colorCodePropertyCase struct {
 }
 
 type colorsPropertyTestCase struct {
-	Description string `json:"description"`
+	Description string   `json:"description"`
 	Expected    []string `json:"expected"`
 }
 

--- a/exercises/practice/resistor-color/.meta/gen.go
+++ b/exercises/practice/resistor-color/.meta/gen.go
@@ -17,7 +17,6 @@ type colorCodePropertyCase struct {
 
 type colorsPropertyTestCase struct {
 	Description string `json:"description"`
-	Input       interface{}
 	Expected    []string `json:"expected"`
 }
 
@@ -48,7 +47,6 @@ type colorCodeTestCase struct {
 
 type colorsTestCase struct {
 	description	string
-	input		string
 	expected	[]string
 }
 

--- a/exercises/practice/resistor-color/cases_test.go
+++ b/exercises/practice/resistor-color/cases_test.go
@@ -13,7 +13,6 @@ type colorCodeTestCase struct {
 
 type colorsTestCase struct {
 	description string
-	input       string
 	expected    []string
 }
 


### PR DESCRIPTION
The input field is unused and causes a linter warning, which might be confusing for someone doing this exercise.

![Screenshot from 2024-03-06 18-24-03](https://github.com/exercism/go/assets/38408878/3ab8fc96-606e-4745-95d3-fe1d1e5d33f4)
