### PR TITLE
prime-factors: use slices package to sort and compare test cases

### DIFF
--- a/exercises/practice/prime-factors/prime_factors_test.go
+++ b/exercises/practice/prime-factors/prime_factors_test.go
@@ -1,7 +1,7 @@
 package prime
 
 import (
-	"sort"
+	"slices"
 	"testing"
 )
 
@@ -9,9 +9,9 @@ func TestPrimeFactors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			actual := Factors(tc.input)
-			sort.Slice(actual, ascending(actual))
-			sort.Slice(tc.expected, ascending(tc.expected))
-			if !slicesEqual(actual, tc.expected) {
+			slices.Sort(actual)
+			slices.Sort(tc.expected)
+			if !slices.Equal(actual, tc.expected) {
 				t.Fatalf("Factors(%d)\n got:%#v\nwant:%#v", tc.input, actual, tc.expected)
 			}
 		})
@@ -26,25 +26,5 @@ func BenchmarkPrimeFactors(b *testing.B) {
 		for _, test := range testCases {
 			Factors(test.input)
 		}
-	}
-}
-
-func slicesEqual(a, b []int64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
-func ascending(list []int64) func(int, int) bool {
-	return func(i, j int) bool {
-		return list[i] < list[j]
 	}
 }


### PR DESCRIPTION
> I think this PR would be automatically closed, but wanted to leave it anyway, maybe'll figure out the forum later, but my tiny code reduction PR will be here already. 

In this PR I moved slice sorting and comparison to use standard libs `slices` package, removed helpers that we're necessary before generics were introduced. 

Value of this PR - removes code, enhances readability, showcases useful tools of stdlib :) 