### PR TITLE
Update lasagna_test.go

### DIFF
--- a/exercises/concept/lasagna/lasagna_test.go
+++ b/exercises/concept/lasagna/lasagna_test.go
@@ -19,7 +19,7 @@ func TestOvenTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := OvenTime; got != tt.expected {
-				t.Errorf("OvenTime(%d)  = %d; want %d", tt.expected, got, tt.expected)
+				t.Errorf("OvenTime(%d)  = %d; want %d", tt.time, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Fix a typo

Although, both variables hold the same value, and this typo does not cause tests to fail for the wrong reason, it doesn't feel right to use the wrong variable.