### PR TITLE
bird-watcher: Add test case for a week in the end of the log

### DIFF
--- a/exercises/concept/bird-watcher/bird_watcher_test.go
+++ b/exercises/concept/bird-watcher/bird_watcher_test.go
@@ -58,6 +58,12 @@ func TestBirdsInWeek(t *testing.T) {
 			want:       18,
 		},
 		{
+			name:       "calculates the number of birds for a week in the end of the log",
+			birdCounts: []int{4, 7, 3, 2, 1, 1, 2, 0, 2, 3, 2, 7, 1, 3, 0, 6, 5, 3, 7, 2, 3},
+			week:       3,
+			want:       26,
+		},
+		{
 			name:       "works when there is only one week",
 			birdCounts: []int{3, 0, 3, 3, 2, 1, 0},
 			week:       1,


### PR DESCRIPTION
The test cases provided in the exercise for the `BirdsInWeek` function only cover the first week and a week in the middle of the log. An edge case for a week in the end of the log is missing. 