### PR TITLE
Add simple example of multi-line comment

### DIFF
--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -75,7 +75,10 @@ func Hello (name string) string {
     return hi(name)
 }
 
-// hi is a private function.
+/*
+hi is a
+private function.
+*/
 func hi (name string) string {
     return "hi " + name
 }


### PR DESCRIPTION
I feel like including a simple example of a multi-line comment after the introduction of the concept would be beneficial.

I understand it's not a great example, and would still be happy if the wording is changed, however the example is simple and concise so I believe it works.