### PR TITLE
Update simple_linked_list_test.go with an idempotency test

### DIFF
--- a/exercises/practice/simple-linked-list/simple_linked_list_test.go
+++ b/exercises/practice/simple-linked-list/simple_linked_list_test.go
@@ -163,6 +163,16 @@ func TestReverseNonEmptyList(t *testing.T) {
 	}
 }
 
+func TestArrayListIdempotency(t *testing.T) {
+	expected := []int{1, 2, 3}
+	list := New(expected)
+	_ := list.Array()
+	actual := list.Array()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Calling Array() changes list contents: %v, want %v", actual, expected)
+	}
+}
+
 func BenchmarkNewList(b *testing.B) {
 	if testing.Short() {
 		b.Skip("skipping benchmark in short mode.")


### PR DESCRIPTION
If the submitter changes the actual list while iterating through its elements, the existing tests won't catch that. Example of a String() method that changes the underlying list: 
func (l *List) String() string {
	var listString string
	for l.head != nil {
		listString += fmt.Sprintf("%d ", l.head.value)
		l.head = l.head.next
	}
	return listString
}