### PR TITLE
Fix: Type error in lasagna_master_test.go by converting portions to float64

### DIFF
--- a/exercises/concept/lasagna-master/lasagna_master_test.go
+++ b/exercises/concept/lasagna-master/lasagna_master_test.go
@@ -202,7 +202,7 @@ func TestScaleRecipe(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputList := make([]float64, len(tt.input))
 			copy(inputList, tt.input)
-			got := ScaleRecipe(inputList, tt.portions)
+			got := ScaleRecipe(inputList, float64(tt.portions))
 			if len(got) != len(tt.expected) {
 				t.Errorf("ScaleRecipe(%v, %d) produced slice of length %d, expected %d", inputList, tt.portions, len(got), len(tt.expected))
 			}


### PR DESCRIPTION
This pull request fixes a type error in lasagna_master_test.go. The test was failing because an integer variable `tt.portions` was being used where a `float64` was expected. This change converts `tt.portions` to `float64` to resolve the error.

Error message:
./lasagna_master_test.go:205:34: cannot use tt.portions (variable of type int) as float64 value in argument to ScaleRecipe

After this change, the tests should pass without any type errors.

![image](https://github.com/exercism/go/assets/32793125/2acaf3ad-2b76-42a6-951c-327477a27a05)
