### PR TITLE
Add benchmark to Nucleotide Count

### DIFF
--- a/exercises/practice/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.go
@@ -23,3 +23,12 @@ func TestCounts(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkCounts(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			dna := DNA(tc.strand)
+			dna.Counts()
+		}
+	}
+}


### PR DESCRIPTION
Almost all practice exercises have benchmarks, but for some reason this hadn't.