### PR TITLE
Remove race test flag from Bank Account due to timeouts

### DIFF
--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -33,10 +33,5 @@
       "go.mod"
     ]
   },
-  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
-  "custom": {
-    "testingFlags": [
-      "-race"
-    ]
-  }
+  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!"
 }


### PR DESCRIPTION
This removes the race test flag due to the timeouts this is apparently causing.

Forum discussion: https://forum.exercism.org/t/bank-account-potential-bug/8326/19

We should keep investigating if there are other ways we can make the use of this flag viable.