### PR TITLE
the-farm: fix small typo

### DIFF
--- a/exercises/concept/the-farm/.docs/instructions.md
+++ b/exercises/concept/the-farm/.docs/instructions.md
@@ -22,7 +22,7 @@ type FodderCalculator interface {
 }
 ```
 
-As you work on your code, you will improve the error handling to make it more robust and easier to debug later on when you use it in your daily farm live.
+As you work on your code, you will improve the error handling to make it more robust and easier to debug later on when you use it in your daily farm life.
 
 ## 1. Divide the food evenly
 


### PR DESCRIPTION
Originally suggested by the PR: https://github.com/exercism/go/pull/2795

Recreating the PR as the original author of the PR deleted the branch.