### PR TITLE
adds type information for Chessboard and File

### DIFF
--- a/exercises/concept/chessboard/.docs/instructions.md
+++ b/exercises/concept/chessboard/.docs/instructions.md
@@ -26,6 +26,12 @@ It should count the total number of occupied squares by ranging over a map. Retu
 Return a count of zero (`0`) if the given file cannot be found in the map.
 
 ```go
+// File represents a column on the chessboard with boolean values indicating whether a piece is present.
+type File []bool
+
+// Chessboard represents the entire board with a map of files, each identified by a string (like "A", "B", etc.).
+type Chessboard map[string]File
+
 CountInFile(board, "A")
 // => 3
 ```


### PR DESCRIPTION
This lesson is about iterating over maps and slices: every function returns an int. Without asking, you're requiring that the student already know the structure of `Chessboard` and `File`.

If defining the structs based on the test file is not the intention, this should be included in the instructions somewhere as it is with other examples I've seen previously on this journey.

This is also a way of writing Types/Structs that hasn't been introduced in this learning flow yet. The only reason I got this was because I asked ChatGPT to reverse engineer the test file, and this output allowed me to start working on the actual implementations of the functions.