### PR TITLE
Fix: Various spellchecks

### DIFF
--- a/concepts/time/links.json
+++ b/concepts/time/links.json
@@ -9,7 +9,7 @@
   },
   {
     "url": "https://www.pauladamsmith.com/blog/2011/05/go_time.html",
-    "description": "Blog Post: Parsing and formating dates/time in Go"
+    "description": "Blog Post: Parsing and formatting dates/time in Go"
   },
   {
     "url": "https://yourbasic.org/golang/format-parse-string-time-date-example/",

--- a/exercises/practice/anagram/.approaches/frequency-counter/content.md
+++ b/exercises/practice/anagram/.approaches/frequency-counter/content.md
@@ -64,14 +64,14 @@ same string.
 
 A hash map of type `map[rune]int` is initialized as the frequency counter. The
 first string is iterated over and the frequency counter is updated to hold the
-number of occurances of each character in the string. Before a character is
+number of occurrences of each character in the string. Before a character is
 counted in the frequency counter, it's converted to lowercase to account for
 case-insensitive strings that should be anagrams (e.g., `foo` and `OOF`).
 
 The second string is then iterated over and the frequency counter is checked to
 see if the lowercase version of the character exists in the hash map. If it does
 not then the strings cannot possibly be anagrams of one another and the
-implementation returns early. Otherwise, the number of occurances of the current
+implementation returns early. Otherwise, the number of occurrences of the current
 character is decremented and, if the count of that character reaches 0, the
 entry is removed from the hash map.
 
@@ -79,7 +79,7 @@ After iterating through both strings and updating the frequency counter the two
 strings are anagrams if and only if the frequency counter is empty. That is, all
 of the characters that were counted in the first string have been accounted for
 when iterating through the second string. If the second string contained a
-charater that the first string did not, then the implementation would return
+character that the first string did not, then the implementation would return
 early as described above. If the second string contained extra characters or
 different characters than the first string then we'd have a non-empty hash map
 left over at the end signifying a difference between the two strings.

--- a/exercises/practice/bob/.approaches/introduction.md
+++ b/exercises/practice/bob/.approaches/introduction.md
@@ -13,7 +13,7 @@ Regardless of the approach used, some things you could look out for include
 
 - Use the [HasSuffix][hassuffix] `string` method instead of checking the last character by index for `?`.
 
-- Don't copy/paste the logic for determining a shout and for determing a question into determing a shouted question.
+- Don't copy/paste the logic for determining a shout and for determining a question into determining a shouted question.
   Combine the two determinations instead of copying them.
   Not duplicating the code will keep the code [DRY][dry].
 
@@ -175,7 +175,7 @@ For more information, check the [Answer array approach][approach-answer-array].
 
 ## Which approach to use?
 
-Since each approach sometimes gave results slower than the other approaches when benchmarking, which to use could be a matter of stylistic choice. 
+Since each approach sometimes gave results slower than the other approaches when benchmarking, which to use could be a matter of stylistic choice.
 
 - To compare the performance of the approaches, check out the [Performance article][article-performance].
 

--- a/exercises/practice/complex-numbers/.meta/gen.go
+++ b/exercises/practice/complex-numbers/.meta/gen.go
@@ -110,7 +110,7 @@ func getComplex(in interface{}) complexNumber {
 			}
 			result = append(result, v)
 		default:
-			panic("uknown type")
+			panic("unknown type")
 		}
 	}
 	return complexNumber{

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -1,7 +1,7 @@
 # Bit-shifting
 
 ```go
-// Package grains is a small library for determing the squares of a number.
+// Package grains is a small library for determining the squares of a number.
 package grains
 
 import (

--- a/exercises/practice/grains/.approaches/introduction.md
+++ b/exercises/practice/grains/.approaches/introduction.md
@@ -55,7 +55,7 @@ For more information, check the [`math.Pow()` and `big` exponentiation approach]
 ## Approach: Bit-shifting
 
 ```go
-// Package grains is a small library for determing the squares of a number.
+// Package grains is a small library for determining the squares of a number.
 package grains
 
 import (

--- a/exercises/practice/grep/.meta/example.go
+++ b/exercises/practice/grep/.meta/example.go
@@ -78,7 +78,7 @@ func searchFile(pattern, file string, options *options) (output []string) {
 	return output
 }
 
-// getOptions examines flags and nfiles, outputing options.
+// getOptions examines flags and nfiles, outputting options.
 func getOptions(flags []string, nfiles int) (opt *options) {
 	opt = &options{}
 	for _, option := range flags {

--- a/exercises/practice/leap/.approaches/boolean-chain/content.md
+++ b/exercises/practice/leap/.approaches/boolean-chain/content.md
@@ -1,7 +1,7 @@
 # Chain of boolean expressions
 
 ```go
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 // IsLeapYear returns if the passed in year is a leap year.

--- a/exercises/practice/leap/.approaches/boolean-chain/snippet.txt
+++ b/exercises/practice/leap/.approaches/boolean-chain/snippet.txt
@@ -1,4 +1,4 @@
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 // IsLeapYear returns if the passed in year is a leap year.

--- a/exercises/practice/leap/.approaches/introduction.md
+++ b/exercises/practice/leap/.approaches/introduction.md
@@ -12,7 +12,7 @@ For determining that, you will use the [modulus operator][modulus-operator].
 ## Approach: Chain of Boolean expressions
 
 ```go
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 // IsLeapYear returns if the passed in year is a leap year.
@@ -26,7 +26,7 @@ For more information, check the [Boolean chain approach][approach-boolean-chain]
 ## Approach: Maximum of two checks
 
 ```go
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 // IsLeapYear returns if the passed in year is a leap year.

--- a/exercises/practice/leap/.approaches/max-two-checks/content.md
+++ b/exercises/practice/leap/.approaches/max-two-checks/content.md
@@ -1,7 +1,7 @@
 # Maximum of two checks
 
 ```go
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 // IsLeapYear returns if the passed in year is a leap year.

--- a/exercises/practice/leap/.approaches/time-addition/content.md
+++ b/exercises/practice/leap/.approaches/time-addition/content.md
@@ -1,7 +1,7 @@
 # `time.Add()`
 
 ```go
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 import "time"

--- a/exercises/practice/leap/.approaches/time-yearday/content.md
+++ b/exercises/practice/leap/.approaches/time-yearday/content.md
@@ -1,7 +1,7 @@
 # `time.YearDay()`
 
 ```go
-// Package leap is a small library for determing if the passed in year is a leap year.
+// Package leap is a small library for determining if the passed in year is a leap year.
 package leap
 
 import "time"


### PR DESCRIPTION
Just a few fixes for this repo!

There's also this diff, which I think is safe to apply, but I wanted to confirm with you first:
```
--- ./bin/run-tests	2024-10-31 20:56:47.498884149 +0200
+++ ./bin/run-tests.2648567	2024-10-31 21:20:29.397355028 +0200
@@ -118,7 +118,7 @@
       exit 1
     fi
   done
-  echo "SUCESS"
+  echo "SUCCESS"
   exit 0
 fi
 
--- ./exercises/practice/grade-school/grade_school_test.go	2024-10-31 20:56:47.518884242 +0200
+++ ./exercises/practice/grade-school/grade_school_test.go.2648578	2024-10-31 21:20:29.401355045 +0200
@@ -82,7 +82,7 @@
 %q`, got, exp)
 }
 
-func TestNonExistantGrade(t *testing.T) {
+func TestNonExistentGrade(t *testing.T) {
 	s := New()
```