### PR TITLE
Fix incorrect usage of OvenTime function in test cases

### DIFF
--- a/exercises/concept/lasagna/lasagna_test.go
+++ b/exercises/concept/lasagna/lasagna_test.go
@@ -18,8 +18,10 @@ func TestOvenTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := OvenTime; got != tt.expected {
-				t.Errorf("OvenTime(%d)  = %d; want %d", tt.expected, got, tt.expected)
+			// Fixed incorrect usage of OvenTime function in the test case
+
+			if got := OvenTime(); got != tt.expected {
+				t.Errorf("OvenTime() = %d; want %d", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This PR addresses an issue in the test file where the OvenTime function was incorrectly referenced without invocation. Specifically:

Fixed the OvenTime test case to properly call the function.
Ensured all test cases are updated to follow correct syntax and logic.
Verified the changes by running all tests successfully.