### PR TITLE
Remove random.Seed() call from robot-name's approach file

### DIFF
--- a/exercises/practice/robot-name/.approaches/introduction.md
+++ b/exercises/practice/robot-name/.approaches/introduction.md
@@ -20,7 +20,6 @@ package robotname
 import (
 	"fmt"
 	"math/rand"
-	"time"
 )
 
 // Robot is a struct with a string field.
@@ -48,7 +47,6 @@ func generateRobotNames() []string {
 		}
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
 	return names
 }

--- a/exercises/practice/robot-name/.approaches/shuffle/content.md
+++ b/exercises/practice/robot-name/.approaches/shuffle/content.md
@@ -7,7 +7,6 @@ package robotname
 import (
 	"fmt"
 	"math/rand"
-	"time"
 )
 
 // Robot is a struct with a string field.
@@ -35,7 +34,6 @@ func generateRobotNames() []string {
 		}
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
 	return names
 }


### PR DESCRIPTION
From the Go documentation on random.Seed():

Deprecated: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator.