### PR TITLE
improve nth_prime benchmark a little bit

### DIFF
--- a/exercises/practice/nth-prime/nth_prime_test.go
+++ b/exercises/practice/nth-prime/nth_prime_test.go
@@ -25,6 +25,6 @@ func BenchmarkNth(b *testing.B) {
 		b.Skip("skipping benchmark in short mode.")
 	}
 	for i := 0; i < b.N; i++ {
-		Nth(10001)
+		Nth(i%30000 + 1)
 	}
 }


### PR DESCRIPTION
Implementation with calling function being tested with constant argument provides ridiculous results (1-2 ns) when solution uses cache for yet found primes. This way is's hard to define if code changing makes code faster / slower.
By calling function being tested over a range of arguments we force code to do some work.