### PR TITLE
Update interest_is_interesting_test.go

### DIFF
--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.go
@@ -248,7 +248,7 @@ func TestYearsBeforeDesiredBalance(t *testing.T) {
 		{
 			name:          "Result balance would be exactly same as target",
 			balance:       1000.0,
-			targetBalance: 1032.682765146664,
+			targetBalance: 1032.6827641,
 			want:          2,
 		},
 	}


### PR DESCRIPTION
Using Windows Calculator and multiplying 1000 with (1 + 1.621%) 2x yields 1032.6827641 which is off by 0.000001046664 from the original testing value 1032.682765146664.

The issue was originally reported on Discord https://discord.com/channels/854117591135027261/1386697394678136963/1386697394678136963