### PR TITLE
Fix the test to match with Matrix value type

### DIFF
--- a/exercises/practice/matrix/matrix_test.go
+++ b/exercises/practice/matrix/matrix_test.go
@@ -162,8 +162,6 @@ func TestNew(t *testing.T) {
 				}
 			case err != nil:
 				t.Fatalf("New(%q) returned error %q.  Error not expected", tc.in, err)
-			case got == nil:
-				t.Fatalf("New(%q) = %v, want non-nil *Matrix", tc.in, got)
 			}
 		})
 	}
@@ -282,7 +280,7 @@ func BenchmarkNew(b *testing.B) {
 			b.Fatalf("Failed to create the matrix: %v", err)
 		}
 	}
-	if matrix == nil {
+	if reflect.DeepEqual(matrix, Matrix{}) {
 		b.Fatalf("No matrix parsed")
 	}
 }


### PR DESCRIPTION
It looks like the Matrix excercise was changed from reference to value type, but the test was not adjusted. Adding a fix.
Tested in place with current matrix implementation.
I think it has been discussed in forum at: https://forum.exercism.org/t/go-track-matrix-problem/3655