### PR TITLE
refactor: use any instead of interface{}

### DIFF
--- a/exercises/concept/airport-robot/.docs/introduction.md
+++ b/exercises/concept/airport-robot/.docs/introduction.md
@@ -67,7 +67,7 @@ It only needs to have all the necessary methods defined.
 
 There is one very special interface type in Go, the **empty interface** type that contains zero methods.
 The empty interface is written like this: `interface{}`.
-In Go 1.18 or higher, `any` can be used as well. It was defined as an alias.
+Since Go 1.18, `any` is an alias for `interface{}`, and is more commonly used.
 
 Since the empty interface has no methods, every type implements it implicitly.
 This is helpful for defining a function that can generically accept any value.

--- a/exercises/concept/sorting-room/.docs/instructions.md
+++ b/exercises/concept/sorting-room/.docs/instructions.md
@@ -61,7 +61,7 @@ NOTE: we should use the `ExtractFancyNumber` function!
 
 ## 5. Implement `DescribeAnything` which uses them all
 
-This is the main function Jen needs which takes any input (the empty interface means any value at all: `interface{}`).
+This is the main function Jen needs which takes any input.
 `DescribeAnything` should delegate to the other functions based on the type of the value passed in.
 More specifically:
 

--- a/exercises/concept/sorting-room/.docs/introduction.md
+++ b/exercises/concept/sorting-room/.docs/introduction.md
@@ -33,7 +33,7 @@ A type assertion allows us to extract the interface value's underlying concrete 
 For example:
 
 ```go
-var input interface{} = 12
+var input any = 12
 number := input.(int)
 ```
 
@@ -57,7 +57,7 @@ It has the same syntax as a type assertion (`interfaceVariable.(concreteType)`),
 Here is an example:
 
 ```go
-var i interface{} = 12 // try: 12.3, true, int64(12), []int{}, map[string]int{}
+var i any = 12 // try: 12.3, true, int64(12), []int{}, map[string]int{}
 
 switch v := i.(type) {
 case int:

--- a/exercises/concept/sorting-room/.meta/exemplar.go
+++ b/exercises/concept/sorting-room/.meta/exemplar.go
@@ -52,7 +52,7 @@ func DescribeFancyNumberBox(fnb FancyNumberBox) string {
 }
 
 // DescribeAnything should return a string describing whatever it contains.
-func DescribeAnything(i interface{}) string {
+func DescribeAnything(i any) string {
 	switch v := i.(type) {
 	case int:
 		return DescribeNumber(float64(v))

--- a/exercises/concept/sorting-room/sorting_room.go
+++ b/exercises/concept/sorting-room/sorting_room.go
@@ -38,6 +38,6 @@ func DescribeFancyNumberBox(fnb FancyNumberBox) string {
 }
 
 // DescribeAnything should return a string describing whatever it contains.
-func DescribeAnything(i interface{}) string {
+func DescribeAnything(i any) string {
 	panic("Please implement DescribeAnything")
 }

--- a/exercises/concept/sorting-room/sorting_room_test.go
+++ b/exercises/concept/sorting-room/sorting_room_test.go
@@ -155,7 +155,7 @@ func TestDescribeFancyNumberBox(t *testing.T) {
 func TestDescribeAnything(t *testing.T) {
 	tests := []struct {
 		description string
-		input       interface{}
+		input       any
 		want        string
 	}{
 		{

--- a/exercises/practice/acronym/.meta/gen.go
+++ b/exercises/practice/acronym/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"abbreviate": &[]testCase{},
 	}
 	if err := gen.Gen("acronym", j, t); err != nil {

--- a/exercises/practice/all-your-base/.meta/gen.go
+++ b/exercises/practice/all-your-base/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"rebase": &[]testCase{},
 	}
 	if err := gen.Gen("all-your-base", j, t); err != nil {
@@ -26,11 +26,11 @@ type testCase struct {
 		Digits     []int `json:"digits"`
 		OutputBase int   `json:"outputBase"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (o testCase) Result() []int {
-	s, ok := o.Expected.([]interface{})
+	s, ok := o.Expected.([]any)
 	if !ok {
 		return nil
 	}
@@ -43,7 +43,7 @@ func (o testCase) Result() []int {
 }
 
 func (o testCase) Err() string {
-	m, ok := o.Expected.(map[string]interface{})
+	m, ok := o.Expected.(map[string]any)
 	if !ok {
 		return ""
 	}

--- a/exercises/practice/allergies/.meta/gen.go
+++ b/exercises/practice/allergies/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"allergicTo": &[]allergicToCase{},
 		"list":       &[]listCase{},
 	}

--- a/exercises/practice/alphametics/.meta/gen.go
+++ b/exercises/practice/alphametics/.meta/gen.go
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"solve": &[]testCase{},
 	}
 	if err := gen.Gen("alphametics", j, t); err != nil {

--- a/exercises/practice/anagram/.meta/gen.go
+++ b/exercises/practice/anagram/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"findAnagrams": &[]testCase{},
 	}
 	if err := gen.Gen("anagram", j, t); err != nil {

--- a/exercises/practice/armstrong-numbers/.meta/gen.go
+++ b/exercises/practice/armstrong-numbers/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"isArmstrongNumber": &[]testCase{},
 	}
 	if err := gen.Gen("armstrong-numbers", j, t); err != nil {

--- a/exercises/practice/atbash-cipher/.meta/gen.go
+++ b/exercises/practice/atbash-cipher/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"encode": &[]testCase{},
 		"decode": &[]testCase{},
 	}

--- a/exercises/practice/binary-search/.meta/gen.go
+++ b/exercises/practice/binary-search/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"find": &[]testCase{},
 	}
 	if err := gen.Gen("binary-search", j, t); err != nil {
@@ -27,7 +27,7 @@ type testCase struct {
 		Array []int `json:"array"`
 		Value int   `json:"value"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) Value() int {
@@ -40,7 +40,7 @@ func (t testCase) Value() int {
 
 func (t testCase) Error() string {
 	if _, ok := t.Expected.(float64); !ok {
-		m, ok := t.Expected.(map[string]interface{})
+		m, ok := t.Expected.(map[string]any)
 		if !ok {
 			return ""
 		}

--- a/exercises/practice/bob/.meta/gen.go
+++ b/exercises/practice/bob/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"response": &[]testCase{},
 	}
 	if err := gen.Gen("bob", j, t); err != nil {

--- a/exercises/practice/book-store/.meta/gen.go
+++ b/exercises/practice/book-store/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"total": &[]testCase{},
 	}
 	if err := gen.Gen("book-store", j, t); err != nil {

--- a/exercises/practice/bottle-song/.meta/gen.go
+++ b/exercises/practice/bottle-song/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"recite": &[]testCase{},
 	}
 	if err := gen.Gen("bottle-song", j, t); err != nil {

--- a/exercises/practice/bowling/.meta/gen.go
+++ b/exercises/practice/bowling/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"roll":  &[]Case{},
 		"score": &[]Case{},
 	}
@@ -26,7 +26,7 @@ type Case struct {
 		PreviousRolls []int `json:"previousRolls"`
 		Roll          int   `json:"roll"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t Case) Score() int {
@@ -44,7 +44,7 @@ func (t Case) Valid() bool {
 
 func (t Case) ExplainText() string {
 	if !t.Valid() {
-		m, ok := t.Expected.(map[string]interface{})
+		m, ok := t.Expected.(map[string]any)
 		if !ok {
 			return ""
 		}

--- a/exercises/practice/change/.meta/gen.go
+++ b/exercises/practice/change/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"findFewestCoins": &[]testCase{},
 	}
 	if err := gen.Gen("change", j, t); err != nil {
@@ -25,11 +25,11 @@ type testCase struct {
 		Coins  []int `json:"coins"`
 		Target int   `json:"target"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValues() []int {
-	values, ok := t.Expected.([]interface{})
+	values, ok := t.Expected.([]any)
 	if !ok {
 		return nil
 	}

--- a/exercises/practice/clock/.meta/gen.go
+++ b/exercises/practice/clock/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"create":   &[]defaultTestCase{},
 		"add":      &[]defaultTestCase{},
 		"subtract": &[]defaultTestCase{},

--- a/exercises/practice/collatz-conjecture/.meta/gen.go
+++ b/exercises/practice/collatz-conjecture/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"steps": &[]testCase{},
 	}
 	if err := gen.Gen("collatz-conjecture", j, t); err != nil {
@@ -24,7 +24,7 @@ type testCase struct {
 	Input       struct {
 		Number int `json:"number"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValue() int {

--- a/exercises/practice/complex-numbers/.meta/gen.go
+++ b/exercises/practice/complex-numbers/.meta/gen.go
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"real":      &[]Case{},
 		"imaginary": &[]Case{},
 		"mul":       &[]Case{},
@@ -34,11 +34,11 @@ type Case struct {
 	Description string `json:"description"`
 	Property    string `json:"property"`
 	Input       struct {
-		Z  interface{} `json:"z"`
-		Z1 interface{} `json:"z1"`
-		Z2 interface{} `json:"z2"`
+		Z  any `json:"z"`
+		Z1 any `json:"z1"`
+		Z2 any `json:"z2"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 type complexNumber struct {
@@ -88,12 +88,12 @@ func (c Case) GetExpected() complexNumber {
 	return getComplex(c.Expected)
 }
 
-func getComplex(in interface{}) complexNumber {
+func getComplex(in any) complexNumber {
 	v, ok := in.(float64)
 	if ok {
 		return complexNumber{A: v}
 	}
-	s, ok := in.([]interface{})
+	s, ok := in.([]any)
 	if !ok {
 		panic(fmt.Sprintf("unknown value for field: %v", in))
 	}

--- a/exercises/practice/connect/.meta/gen.go
+++ b/exercises/practice/connect/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"winner": &[]testCase{},
 	}
 	if err := gen.Gen("connect", j, t); err != nil {

--- a/exercises/practice/custom-set/.meta/gen.go
+++ b/exercises/practice/custom-set/.meta/gen.go
@@ -12,7 +12,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"empty":        &[]testCase{},
 		"contains":     &[]testCase{},
 		"subset":       &[]testCase{},
@@ -36,7 +36,7 @@ type testCase struct {
 		Set2    []int `json:"set2"`    // "subset"/"disjoint"/"equal"/"difference"/"intersection"/"union" cases
 		Element int   `json:"element"` // "contains"/"add" cases
 	}
-	Expected interface{} `json:"expected"` // bool or []int
+	Expected any `json:"expected"` // bool or []int
 }
 
 // There's some extra complexity because canonical-data.json uses integers, but we are using strings.
@@ -68,7 +68,7 @@ func (t testCase) GetExpectedBool() bool {
 }
 
 func (t testCase) GetExpectedList() []string {
-	v, ok := t.Expected.([]interface{})
+	v, ok := t.Expected.([]any)
 	if !ok {
 		log.Fatal("[ERROR] invalid type for field `expected`")
 	}

--- a/exercises/practice/darts/.meta/gen.go
+++ b/exercises/practice/darts/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"score": &[]testCase{},
 	}
 	if err := gen.Gen("darts", j, t); err != nil {

--- a/exercises/practice/diamond/.meta/gen.go
+++ b/exercises/practice/diamond/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"rows": &[]testCase{},
 	}
 	if err := gen.Gen("diamond", j, t); err != nil {

--- a/exercises/practice/dnd-character/.meta/gen.go
+++ b/exercises/practice/dnd-character/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"modifier":  &[]modifierTestCase{},
 		"ability":   &[]emptyTestCase{},
 		"character": &[]emptyTestCase{},

--- a/exercises/practice/dominoes/.meta/gen.go
+++ b/exercises/practice/dominoes/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"canChain": &[]testCase{},
 	}
 	if err := gen.Gen("dominoes", j, t); err != nil {

--- a/exercises/practice/flatten-array/.meta/example.go
+++ b/exercises/practice/flatten-array/.meta/example.go
@@ -3,9 +3,9 @@ package flatten
 import "reflect"
 
 // Flatten recursively flattens slices and ignores nil values
-func Flatten(nested interface{}) []interface{} {
-	flattened := []interface{}{}
-	nestedSlice, ok := nested.([]interface{})
+func Flatten(nested any) []any {
+	flattened := []any{}
+	nestedSlice, ok := nested.([]any)
 	if !ok {
 		return flattened
 	}

--- a/exercises/practice/flatten-array/.meta/gen.go
+++ b/exercises/practice/flatten-array/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"flatten": &[]testCase{},
 	}
 	if err := gen.Gen("flatten-array", j, t); err != nil {
@@ -22,9 +22,9 @@ func main() {
 type testCase struct {
 	Description string `json:"description"`
 	Input       struct {
-		Array interface{} `json:"array"`
+		Array any `json:"array"`
 	} `json:"input"`
-	Expected []interface{} `json:"expected"`
+	Expected []any `json:"expected"`
 }
 
 // Template to generate test cases.
@@ -34,8 +34,8 @@ var tmpl = `package flatten
 
 var testCases = []struct {
 	description	string
-	input		interface{}
-	expected	[]interface{}
+	input		any
+	expected	[]any
 }{ {{range .J.flatten}}
 {
 	description:	{{printf "%q"  .Description}},

--- a/exercises/practice/flatten-array/cases_test.go
+++ b/exercises/practice/flatten-array/cases_test.go
@@ -7,62 +7,62 @@ package flatten
 
 var testCases = []struct {
 	description string
-	input       interface{}
-	expected    []interface{}
+	input       any
+	expected    []any
 }{
 	{
 		description: "empty",
-		input:       []interface{}{},
-		expected:    []interface{}{},
+		input:       []any{},
+		expected:    []any{},
 	},
 	{
 		description: "no nesting",
-		input:       []interface{}{0, 1, 2},
-		expected:    []interface{}{0, 1, 2},
+		input:       []any{0, 1, 2},
+		expected:    []any{0, 1, 2},
 	},
 	{
 		description: "flattens a nested array",
-		input:       []interface{}{[]interface{}{[]interface{}{}}},
-		expected:    []interface{}{},
+		input:       []any{[]any{[]any{}}},
+		expected:    []any{},
 	},
 	{
 		description: "flattens array with just integers present",
-		input:       []interface{}{1, []interface{}{2, 3, 4, 5, 6, 7}, 8},
-		expected:    []interface{}{1, 2, 3, 4, 5, 6, 7, 8},
+		input:       []any{1, []any{2, 3, 4, 5, 6, 7}, 8},
+		expected:    []any{1, 2, 3, 4, 5, 6, 7, 8},
 	},
 	{
 		description: "5 level nesting",
-		input:       []interface{}{0, 2, []interface{}{[]interface{}{2, 3}, 8, 100, 4, []interface{}{[]interface{}{[]interface{}{50}}}}, -2},
-		expected:    []interface{}{0, 2, 2, 3, 8, 100, 4, 50, -2},
+		input:       []any{0, 2, []any{[]any{2, 3}, 8, 100, 4, []any{[]any{[]any{50}}}}, -2},
+		expected:    []any{0, 2, 2, 3, 8, 100, 4, 50, -2},
 	},
 	{
 		description: "6 level nesting",
-		input:       []interface{}{1, []interface{}{2, []interface{}{[]interface{}{3}}, []interface{}{4, []interface{}{[]interface{}{5}}}, 6, 7}, 8},
-		expected:    []interface{}{1, 2, 3, 4, 5, 6, 7, 8},
+		input:       []any{1, []any{2, []any{[]any{3}}, []any{4, []any{[]any{5}}}, 6, 7}, 8},
+		expected:    []any{1, 2, 3, 4, 5, 6, 7, 8},
 	},
 	{
 		description: "null values are omitted from the final result",
-		input:       []interface{}{1, 2, interface{}(nil)},
-		expected:    []interface{}{1, 2},
+		input:       []any{1, 2, any(nil)},
+		expected:    []any{1, 2},
 	},
 	{
 		description: "consecutive null values at the front of the list are omitted from the final result",
-		input:       []interface{}{interface{}(nil), interface{}(nil), 3},
-		expected:    []interface{}{3},
+		input:       []any{any(nil), any(nil), 3},
+		expected:    []any{3},
 	},
 	{
 		description: "consecutive null values in the middle of the list are omitted from the final result",
-		input:       []interface{}{1, interface{}(nil), interface{}(nil), 4},
-		expected:    []interface{}{1, 4},
+		input:       []any{1, any(nil), any(nil), 4},
+		expected:    []any{1, 4},
 	},
 	{
 		description: "6 level nest list with null values",
-		input:       []interface{}{0, 2, []interface{}{[]interface{}{2, 3}, 8, []interface{}{[]interface{}{100}}, interface{}(nil), []interface{}{[]interface{}{interface{}(nil)}}}, -2},
-		expected:    []interface{}{0, 2, 2, 3, 8, 100, -2},
+		input:       []any{0, 2, []any{[]any{2, 3}, 8, []any{[]any{100}}, any(nil), []any{[]any{any(nil)}}}, -2},
+		expected:    []any{0, 2, 2, 3, 8, 100, -2},
 	},
 	{
 		description: "all values in nested list are null",
-		input:       []interface{}{interface{}(nil), []interface{}{[]interface{}{[]interface{}{interface{}(nil)}}}, interface{}(nil), interface{}(nil), []interface{}{[]interface{}{interface{}(nil), interface{}(nil)}, interface{}(nil)}, interface{}(nil)},
-		expected:    []interface{}{},
+		input:       []any{any(nil), []any{[]any{[]any{any(nil)}}}, any(nil), any(nil), []any{[]any{any(nil), any(nil)}, any(nil)}, any(nil)},
+		expected:    []any{},
 	},
 }

--- a/exercises/practice/flatten-array/flatten_array.go
+++ b/exercises/practice/flatten-array/flatten_array.go
@@ -1,5 +1,5 @@
 package flatten
 
-func Flatten(nested interface{}) []interface{} {
+func Flatten(nested any) []any {
 	panic("Please implement the Flatten function")
 }

--- a/exercises/practice/forth/.meta/gen.go
+++ b/exercises/practice/forth/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"evaluate": &[]testCase{},
 		// TODO: add test with property `evaluateBoth` to forth_test.go and generate cases in cases_test.go
 	}
@@ -25,11 +25,11 @@ type testCase struct {
 	Input       struct {
 		Instructions []string `json:"instructions"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedNumbers() []int {
-	numbers, ok := t.Expected.([]interface{})
+	numbers, ok := t.Expected.([]any)
 	if !ok {
 		return nil
 	}
@@ -48,7 +48,7 @@ func (t testCase) ExplainText() string {
 	if t.ExpectedNumbers() != nil {
 		return ""
 	}
-	m, ok := t.Expected.(map[string]interface{})
+	m, ok := t.Expected.(map[string]any)
 	if !ok {
 		return ""
 	}

--- a/exercises/practice/gigasecond/.meta/gen.go
+++ b/exercises/practice/gigasecond/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"add": &[]testCase{},
 	}
 	if err := gen.Gen("gigasecond", j, t); err != nil {

--- a/exercises/practice/grains/.meta/gen.go
+++ b/exercises/practice/grains/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"square": &[]testCase{},
 		"total":  &[]testCase{}, // expected value for Total() not used from `canonical-data.json`
 	}
@@ -25,7 +25,7 @@ type testCase struct {
 	Input       struct {
 		Square int `json:"square"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValue() uint64 {

--- a/exercises/practice/grep/.meta/gen.go
+++ b/exercises/practice/grep/.meta/gen.go
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"grep": &[]testCase{},
 	}
 	if err := gen.Gen("grep", j, t); err != nil {

--- a/exercises/practice/hamming/.meta/gen.go
+++ b/exercises/practice/hamming/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"distance": &[]testCase{},
 	}
 	if err := gen.Gen("hamming", j, t); err != nil {
@@ -25,7 +25,7 @@ type testCase struct {
 		Strand1 string `json:"strand1"`
 		Strand2 string `json:"strand2"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValue() int {

--- a/exercises/practice/isbn-verifier/.meta/gen.go
+++ b/exercises/practice/isbn-verifier/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"isValid": &[]testCase{},
 	}
 	if err := gen.Gen("isbn-verifier", j, t); err != nil {

--- a/exercises/practice/isogram/.meta/gen.go
+++ b/exercises/practice/isogram/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"isIsogram": &[]testCase{},
 	}
 	if err := gen.Gen("isogram", j, t); err != nil {

--- a/exercises/practice/knapsack/.meta/gen.go
+++ b/exercises/practice/knapsack/.meta/gen.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"maximumValue": &[]maximumValueCase{},
 	}
 	if err := gen.Gen("knapsack", j, t); err != nil {

--- a/exercises/practice/largest-series-product/.meta/gen.go
+++ b/exercises/practice/largest-series-product/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"largestProduct": &[]testCase{},
 	}
 	if err := gen.Gen("largest-series-product", j, t); err != nil {
@@ -25,7 +25,7 @@ type testCase struct {
 		Digits string `json:"digits"`
 		Span   int    `json:"span"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValue() int {
@@ -37,7 +37,7 @@ func (t testCase) ExpectedValue() int {
 }
 
 func (t testCase) ExpectedError() string {
-	v, ok := t.Expected.(map[string]interface{})
+	v, ok := t.Expected.(map[string]any)
 	if ok {
 		e, ok := v["error"].(string)
 		if ok {

--- a/exercises/practice/leap/.meta/gen.go
+++ b/exercises/practice/leap/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"leapYear": &[]testCase{},
 	}
 	if err := gen.Gen("leap", j, t); err != nil {

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -7,20 +7,20 @@ offers functions for adding and removing items.
 
 Your `Node` should have the following fields and methods:
 
-* `Value`: the node's value (we will use `interface{}`).
+* `Value`: the node's value (we will use `any`).
 * `Next() *Node`: pointer to the next node.
 * `Prev() *Node`: pointer to the previous node.
 
 You should have a function `NewList()` that creates and returns a `List`:
 
-* `NewList(args ...interface{}) *List`: creates a new linked list preserving the order of the values.
+* `NewList(args ...any) *List`: creates a new linked list preserving the order of the values.
 
 Your `List` should have the following methods:
 
 * `First() *Node`: returns a pointer to the first node (head).
 * `Last() *Node`: returns a pointer to the last node (tail).
-* `Push(v interface{})`: insert value at the back of the list.
-* `Pop() (interface{}, error)`: remove value from the back of the list.
-* `Unshift(v interface{}) `: insert value at the front of the list.
-* `Shift() (interface{}, error)`: remove value from the front of the list.
+* `Push(v any)`: insert value at the back of the list.
+* `Pop() (any, error)`: remove value from the back of the list.
+* `Unshift(v any) `: insert value at the front of the list.
+* `Shift() (any, error)`: remove value from the front of the list.
 * `Reverse()`: reverse the linked list.

--- a/exercises/practice/linked-list/.meta/example.go
+++ b/exercises/practice/linked-list/.meta/example.go
@@ -6,13 +6,13 @@ import (
 
 // Node is a node in a linked list.
 type Node struct {
-	Value interface{}
+	Value any
 	next  *Node
 	prev  *Node
 }
 
 // NewNode constructs a new Node with the given value & no next/prev links.
-func NewNode(v interface{}) *Node {
+func NewNode(v any) *Node {
 	return &Node{
 		Value: v,
 		next:  nil,
@@ -55,7 +55,7 @@ type List struct {
 }
 
 // NewList constructs a doubly linked list from a sequence of integers.
-func NewList(elements ...interface{}) *List {
+func NewList(elements ...any) *List {
 	ll := &List{
 		head: nil,
 		tail: nil,
@@ -109,7 +109,7 @@ func (ll *List) Reverse() {
 }
 
 // Unshift pushes a new value before Head.
-func (ll *List) Unshift(v interface{}) {
+func (ll *List) Unshift(v any) {
 	n := NewNode(v)
 
 	switch {
@@ -127,7 +127,7 @@ func (ll *List) Unshift(v interface{}) {
 }
 
 // Push pushes a new value after Tail.
-func (ll *List) Push(v interface{}) {
+func (ll *List) Push(v any) {
 	n := NewNode(v)
 
 	switch {
@@ -147,7 +147,7 @@ func (ll *List) Push(v interface{}) {
 var ErrEmptyList = errors.New("list is empty")
 
 // Shift posp the element at Head. It returns error if the linked list is empty.
-func (ll *List) Shift() (interface{}, error) {
+func (ll *List) Shift() (any, error) {
 	switch {
 	default:
 		panic("bad PopFront implementation")
@@ -169,7 +169,7 @@ func (ll *List) Shift() (interface{}, error) {
 }
 
 // Pop pops the element at Tail. It returns error if the linked list is empty.
-func (ll *List) Pop() (interface{}, error) {
+func (ll *List) Pop() (any, error) {
 	switch {
 	default:
 		panic("bad PopBack implementation")

--- a/exercises/practice/linked-list/cases_test.go
+++ b/exercises/practice/linked-list/cases_test.go
@@ -4,129 +4,129 @@ import "testing"
 
 var newListTestCases = []struct {
 	name     string
-	in       []interface{}
-	expected []interface{}
+	in       []any
+	expected []any
 }{
 	{
 		name:     "from 5 elements",
-		in:       []interface{}{1, 2, 3, 4, 5},
-		expected: []interface{}{1, 2, 3, 4, 5},
+		in:       []any{1, 2, 3, 4, 5},
+		expected: []any{1, 2, 3, 4, 5},
 	},
 	{
 		name:     "from 2 elements",
-		in:       []interface{}{1, 2},
-		expected: []interface{}{1, 2},
+		in:       []any{1, 2},
+		expected: []any{1, 2},
 	},
 	{
 		name:     "from no element",
-		in:       []interface{}{},
-		expected: []interface{}{},
+		in:       []any{},
+		expected: []any{},
 	},
 	{
 		name:     "from 1 element",
-		in:       []interface{}{999},
-		expected: []interface{}{999},
+		in:       []any{999},
+		expected: []any{999},
 	},
 }
 
 var reverseTestCases = []struct {
 	name     string
-	in       []interface{}
-	expected []interface{}
+	in       []any
+	expected []any
 }{
 	{
 		name:     "from 5 elements",
-		in:       []interface{}{1, 2, 3, 4, 5},
-		expected: []interface{}{5, 4, 3, 2, 1},
+		in:       []any{1, 2, 3, 4, 5},
+		expected: []any{5, 4, 3, 2, 1},
 	},
 	{
 		name:     "from 2 elements",
-		in:       []interface{}{1, 2},
-		expected: []interface{}{2, 1},
+		in:       []any{1, 2},
+		expected: []any{2, 1},
 	},
 	{
 		name:     "from no element",
-		in:       []interface{}{},
-		expected: []interface{}{},
+		in:       []any{},
+		expected: []any{},
 	},
 	{
 		name:     "from 1 element",
-		in:       []interface{}{999},
-		expected: []interface{}{999},
+		in:       []any{999},
+		expected: []any{999},
 	},
 }
 
 var pushPopTestCases = []struct {
 	name     string
-	in       []interface{}
+	in       []any
 	actions  []checkedAction
-	expected []interface{}
+	expected []any
 }{
 	{
 		name: "PushFront only",
-		in:   []interface{}{},
+		in:   []any{},
 		actions: []checkedAction{
 			unshift(4),
 			unshift(3),
 			unshift(2),
 			unshift(1),
 		},
-		expected: []interface{}{1, 2, 3, 4},
+		expected: []any{1, 2, 3, 4},
 	},
 	{
 		name: "PushBack only",
-		in:   []interface{}{},
+		in:   []any{},
 		actions: []checkedAction{
 			push(1),
 			push(2),
 			push(3),
 			push(4),
 		},
-		expected: []interface{}{1, 2, 3, 4},
+		expected: []any{1, 2, 3, 4},
 	},
 	{
 		name: "PopFront only, pop some elements",
-		in:   []interface{}{1, 2, 3, 4},
+		in:   []any{1, 2, 3, 4},
 		actions: []checkedAction{
 			shift(1, nil),
 			shift(2, nil),
 		},
-		expected: []interface{}{3, 4},
+		expected: []any{3, 4},
 	},
 	{
 		name: "PopFront only, pop till empty",
-		in:   []interface{}{1, 2, 3, 4},
+		in:   []any{1, 2, 3, 4},
 		actions: []checkedAction{
 			shift(1, nil),
 			shift(2, nil),
 			shift(3, nil),
 			shift(4, nil),
 		},
-		expected: []interface{}{},
+		expected: []any{},
 	},
 	{
 		name: "PopBack only, pop some elements",
-		in:   []interface{}{1, 2, 3, 4},
+		in:   []any{1, 2, 3, 4},
 		actions: []checkedAction{
 			pop(4, nil),
 			pop(3, nil),
 		},
-		expected: []interface{}{1, 2},
+		expected: []any{1, 2},
 	},
 	{
 		name: "PopBack only, pop till empty",
-		in:   []interface{}{1, 2, 3, 4},
+		in:   []any{1, 2, 3, 4},
 		actions: []checkedAction{
 			pop(4, nil),
 			pop(3, nil),
 			pop(2, nil),
 			pop(1, nil),
 		},
-		expected: []interface{}{},
+		expected: []any{},
 	},
 	{
 		name: "mixed actions",
-		in:   []interface{}{2, 3},
+		in:   []any{2, 3},
 		actions: []checkedAction{
 			unshift(1),
 			push(4),
@@ -139,26 +139,26 @@ var pushPopTestCases = []struct {
 			unshift(9),
 			push(6),
 		},
-		expected: []interface{}{9, 8, 7, 6},
+		expected: []any{9, 8, 7, 6},
 	},
 }
 
 // checkedAction calls a function of the linked list and (possibly) checks the result
 type checkedAction func(*testing.T, *List)
 
-func unshift(arg interface{}) checkedAction {
+func unshift(arg any) checkedAction {
 	return func(t *testing.T, ll *List) {
 		ll.Unshift(arg)
 	}
 }
 
-func push(arg interface{}) checkedAction {
+func push(arg any) checkedAction {
 	return func(t *testing.T, ll *List) {
 		ll.Push(arg)
 	}
 }
 
-func shift(expected interface{}, expectedErr error) checkedAction {
+func shift(expected any, expectedErr error) checkedAction {
 	return func(t *testing.T, ll *List) {
 		v, err := ll.Shift()
 		if err != expectedErr {
@@ -171,7 +171,7 @@ func shift(expected interface{}, expectedErr error) checkedAction {
 	}
 }
 
-func pop(expected interface{}, expectedErr error) checkedAction {
+func pop(expected any, expectedErr error) checkedAction {
 	return func(t *testing.T, ll *List) {
 		v, err := ll.Pop()
 		if err != expectedErr {

--- a/exercises/practice/linked-list/linked_list.go
+++ b/exercises/practice/linked-list/linked_list.go
@@ -3,7 +3,7 @@ package linkedlist
 // Define List and Node types here.
 // Note: The tests expect Node type to include an exported field with name Value to pass.
 
-func NewList(elements ...interface{}) *List {
+func NewList(elements ...any) *List {
 	panic("Please implement the NewList function")
 }
 
@@ -15,19 +15,19 @@ func (n *Node) Prev() *Node {
 	panic("Please implement the Prev function")
 }
 
-func (l *List) Unshift(v interface{}) {
+func (l *List) Unshift(v any) {
 	panic("Please implement the Unshift function")
 }
 
-func (l *List) Push(v interface{}) {
+func (l *List) Push(v any) {
 	panic("Please implement the Push function")
 }
 
-func (l *List) Shift() (interface{}, error) {
+func (l *List) Shift() (any, error) {
 	panic("Please implement the Shift function")
 }
 
-func (l *List) Pop() (interface{}, error) {
+func (l *List) Pop() (any, error) {
 	panic("Please implement the Pop function")
 }
 

--- a/exercises/practice/linked-list/linked_list_test.go
+++ b/exercises/practice/linked-list/linked_list_test.go
@@ -41,7 +41,7 @@ func TestPushPop(t *testing.T) {
 }
 
 // checkDoublyLinkedList checks that the linked list is constructed correctly.
-func checkDoublyLinkedList(t *testing.T, ll *List, expected []interface{}) {
+func checkDoublyLinkedList(t *testing.T, ll *List, expected []any) {
 	// check that length and elements are correct (scan once from begin -> end)
 	elem, count, idx := ll.First(), 0, 0
 	for ; elem != nil && idx < len(expected); elem, count, idx = elem.Next(), count+1, idx+1 {

--- a/exercises/practice/luhn/.meta/gen.go
+++ b/exercises/practice/luhn/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"valid": &[]testCase{},
 	}
 	if err := gen.Gen("luhn", j, t); err != nil {

--- a/exercises/practice/markdown/.meta/gen.go
+++ b/exercises/practice/markdown/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"parse": &[]testCase{},
 	}
 	if err := gen.Gen("markdown", j, t); err != nil {

--- a/exercises/practice/matching-brackets/.meta/gen.go
+++ b/exercises/practice/matching-brackets/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"isPaired": &[]testCase{},
 	}
 	if err := gen.Gen("matching-brackets", j, t); err != nil {

--- a/exercises/practice/meetup/.meta/gen.go
+++ b/exercises/practice/meetup/.meta/gen.go
@@ -15,7 +15,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"meetup": &[]testCase{},
 	}
 	if err := gen.Gen("meetup", j, t); err != nil {

--- a/exercises/practice/nth-prime/.meta/gen.go
+++ b/exercises/practice/nth-prime/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"prime": &[]testCase{},
 	}
 	if err := gen.Gen("nth-prime", j, t); err != nil {
@@ -24,7 +24,7 @@ type testCase struct {
 	Input       struct {
 		Number int `json:"number"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) GetExpectedValue() int {
@@ -36,7 +36,7 @@ func (t testCase) GetExpectedValue() int {
 }
 
 func (t testCase) GetError() string {
-	v, ok := t.Expected.(map[string]interface{})
+	v, ok := t.Expected.(map[string]any)
 	if ok {
 		e, ok := v["error"].(string)
 		if ok {

--- a/exercises/practice/nucleotide-count/.meta/gen.go
+++ b/exercises/practice/nucleotide-count/.meta/gen.go
@@ -14,7 +14,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"nucleotideCounts": &[]testCase{},
 	}
 	if err := gen.Gen("nucleotide-count", j, t); err != nil {
@@ -27,7 +27,7 @@ type testCase struct {
 	Input       struct {
 		Strand string `json:"strand"`
 	} `json:"input"`
-	Expected map[string]interface{} `json:"expected"`
+	Expected map[string]any `json:"expected"`
 }
 
 func (t testCase) ErrorExpected() bool {

--- a/exercises/practice/pangram/.meta/gen.go
+++ b/exercises/practice/pangram/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"isPangram": &[]testCase{},
 	}
 	if err := gen.Gen("pangram", j, t); err != nil {

--- a/exercises/practice/perfect-numbers/.meta/gen.go
+++ b/exercises/practice/perfect-numbers/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"classify": &[]testCase{},
 	}
 	if err := gen.Gen("perfect-numbers", j, t); err != nil {
@@ -24,7 +24,7 @@ type testCase struct {
 	Input       struct {
 		Number int `json:"number"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) Valid() bool {

--- a/exercises/practice/phone-number/.meta/gen.go
+++ b/exercises/practice/phone-number/.meta/gen.go
@@ -12,7 +12,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"clean": &[]testCase{},
 	}
 	if err := gen.Gen("phone-number", j, t); err != nil {
@@ -25,11 +25,11 @@ type testCase struct {
 	Input       struct {
 		Phrase string `json:"phrase"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectError() bool {
-	v, ok := t.Expected.(map[string]interface{})
+	v, ok := t.Expected.(map[string]any)
 	if ok {
 		_, gotError := v["error"]
 		return gotError

--- a/exercises/practice/pig-latin/.meta/gen.go
+++ b/exercises/practice/pig-latin/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"translate": &[]testCase{},
 	}
 	if err := gen.Gen("pig-latin", j, t); err != nil {

--- a/exercises/practice/poker/.meta/gen.go
+++ b/exercises/practice/poker/.meta/gen.go
@@ -15,7 +15,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"bestHands": &[]testCase{},
 	}
 	if err := gen.Gen("poker", j, t); err != nil {

--- a/exercises/practice/prime-factors/.meta/gen.go
+++ b/exercises/practice/prime-factors/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"factors": &[]testCase{},
 	}
 	if err := gen.Gen("prime-factors", j, t); err != nil {

--- a/exercises/practice/proverb/.meta/gen.go
+++ b/exercises/practice/proverb/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"recite": &[]testCase{},
 	}
 	if err := gen.Gen("proverb", j, t); err != nil {

--- a/exercises/practice/rail-fence-cipher/.meta/gen.go
+++ b/exercises/practice/rail-fence-cipher/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"encode": &[]testCase{},
 		"decode": &[]testCase{},
 	}

--- a/exercises/practice/raindrops/.meta/gen.go
+++ b/exercises/practice/raindrops/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"convert": &[]testCase{},
 	}
 	if err := gen.Gen("raindrops", j, t); err != nil {

--- a/exercises/practice/rectangles/.meta/gen.go
+++ b/exercises/practice/rectangles/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"rectangles": &[]testCase{},
 	}
 	if err := gen.Gen("rectangles", j, t); err != nil {

--- a/exercises/practice/resistor-color-duo/.meta/gen.go
+++ b/exercises/practice/resistor-color-duo/.meta/gen.go
@@ -30,7 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"value": &[]valuePropertyCase{},
 	}
 	if err := gen.Gen("resistor-color-duo", j, t); err != nil {

--- a/exercises/practice/resistor-color-trio/.meta/gen.go
+++ b/exercises/practice/resistor-color-trio/.meta/gen.go
@@ -33,7 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"label": &[]labelPropertyCase{},
 	}
 	if err := gen.Gen("resistor-color-trio", j, t); err != nil {

--- a/exercises/practice/resistor-color/.meta/gen.go
+++ b/exercises/practice/resistor-color/.meta/gen.go
@@ -24,7 +24,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"colorCode": &[]colorCodePropertyCase{},
 		"colors":    &[]colorsPropertyTestCase{},
 	}

--- a/exercises/practice/reverse-string/.meta/gen.go
+++ b/exercises/practice/reverse-string/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"reverse": &[]testCase{},
 	}
 	if err := gen.Gen("reverse-string", j, t); err != nil {

--- a/exercises/practice/rna-transcription/.meta/gen.go
+++ b/exercises/practice/rna-transcription/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"toRna": &[]testCase{},
 	}
 	if err := gen.Gen("rna-transcription", j, t); err != nil {

--- a/exercises/practice/roman-numerals/.meta/gen.go
+++ b/exercises/practice/roman-numerals/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"roman": &[]testCase{},
 	}
 	if err := gen.Gen("roman-numerals", j, t); err != nil {

--- a/exercises/practice/run-length-encoding/.meta/gen.go
+++ b/exercises/practice/run-length-encoding/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"encode":      &[]testCase{},
 		"decode":      &[]testCase{},
 		"consistency": &[]testCase{},

--- a/exercises/practice/saddle-points/.meta/gen.go
+++ b/exercises/practice/saddle-points/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"saddlePoints": &[]Case{},
 	}
 	if err := gen.Gen("saddle-points", j, t); err != nil {

--- a/exercises/practice/say/.meta/gen.go
+++ b/exercises/practice/say/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"say": &[]testCase{},
 	}
 	if err := gen.Gen("say", j, t); err != nil {
@@ -24,7 +24,7 @@ type testCase struct {
 	Input       struct {
 		Number int `json:"number"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValue() string {
@@ -36,7 +36,7 @@ func (t testCase) ExpectedValue() string {
 }
 
 func (t testCase) ExpectError() bool {
-	v, ok := t.Expected.(map[string]interface{})
+	v, ok := t.Expected.(map[string]any)
 	if ok {
 		_, ok := v["error"]
 		return ok

--- a/exercises/practice/scale-generator/.meta/gen.go
+++ b/exercises/practice/scale-generator/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"chromatic": &[]testCase{},
 		"interval":  &[]testCase{},
 	}

--- a/exercises/practice/scrabble-score/.meta/gen.go
+++ b/exercises/practice/scrabble-score/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"score": &[]testCase{},
 	}
 	if err := gen.Gen("scrabble-score", j, t); err != nil {

--- a/exercises/practice/secret-handshake/.meta/gen.go
+++ b/exercises/practice/secret-handshake/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"commands": &[]testCase{},
 	}
 	if err := gen.Gen("secret-handshake", j, t); err != nil {

--- a/exercises/practice/sieve/.meta/gen.go
+++ b/exercises/practice/sieve/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"primes": &[]testCase{},
 	}
 	if err := gen.Gen("sieve", j, t); err != nil {

--- a/exercises/practice/space-age/.meta/gen.go
+++ b/exercises/practice/space-age/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"age": &[]testCase{},
 	}
 	if err := gen.Gen("space-age", j, t); err != nil {
@@ -25,7 +25,7 @@ type testCase struct {
 		Planet  string  `json:"planet"`
 		Seconds float64 `json:"seconds"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectedValue() float64 {

--- a/exercises/practice/state-of-tic-tac-toe/.meta/gen.go
+++ b/exercises/practice/state-of-tic-tac-toe/.meta/gen.go
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"gamestate": &[]testCase{},
 	}
 	if err := gen.Gen("state-of-tic-tac-toe", j, t); err != nil {
@@ -26,7 +26,7 @@ type testCase struct {
 	Input       struct {
 		Board []string `json:"board"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (o testCase) ExpectedResult() string {
@@ -38,7 +38,7 @@ func (o testCase) ExpectedResult() string {
 }
 
 func (o testCase) ExpectError() bool {
-	_, ok := o.Expected.(map[string]interface{})
+	_, ok := o.Expected.(map[string]any)
 	return ok
 }
 

--- a/exercises/practice/sublist/.meta/gen.go
+++ b/exercises/practice/sublist/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"sublist": &[]testCase{},
 	}
 	if err := gen.Gen("sublist", j, t); err != nil {

--- a/exercises/practice/sum-of-multiples/.meta/gen.go
+++ b/exercises/practice/sum-of-multiples/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"sum": &[]testCase{},
 	}
 	if err := gen.Gen("sum-of-multiples", j, t); err != nil {

--- a/exercises/practice/transpose/.meta/gen.go
+++ b/exercises/practice/transpose/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"transpose": &[]testCase{},
 	}
 	if err := gen.Gen("transpose", j, t); err != nil {

--- a/exercises/practice/two-bucket/.meta/gen.go
+++ b/exercises/practice/two-bucket/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"measure": &[]testCase{},
 	}
 	if err := gen.Gen("two-bucket", j, t); err != nil {

--- a/exercises/practice/variable-length-quantity/.meta/gen.go
+++ b/exercises/practice/variable-length-quantity/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"encode": &[]testCase{},
 		"decode": &[]testCase{},
 	}
@@ -25,11 +25,11 @@ type testCase struct {
 	Input       struct {
 		Integers []uint32 `json:"integers"` // supports both []byte and []uint32 in JSON
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ValueSliceByte() []byte {
-	v, ok := t.Expected.([]interface{})
+	v, ok := t.Expected.([]any)
 	var vals []byte
 	if ok {
 		for _, n := range v {
@@ -44,7 +44,7 @@ func (t testCase) ValueSliceByte() []byte {
 }
 
 func (t testCase) ValueSliceUint32() []uint32 {
-	v, ok := t.Expected.([]interface{})
+	v, ok := t.Expected.([]any)
 	var vals []uint32
 	if ok {
 		for _, n := range v {
@@ -59,7 +59,7 @@ func (t testCase) ValueSliceUint32() []uint32 {
 }
 
 func (t testCase) ErrorExpected() bool {
-	v, ok := t.Expected.(map[string]interface{})
+	v, ok := t.Expected.(map[string]any)
 	if ok {
 		_, ok := v["error"].(string)
 		return ok

--- a/exercises/practice/word-count/.meta/gen.go
+++ b/exercises/practice/word-count/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"countWords": &[]testCase{},
 	}
 	if err := gen.Gen("word-count", j, t); err != nil {

--- a/exercises/practice/word-search/.meta/gen.go
+++ b/exercises/practice/word-search/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"search": &[]testCase{},
 	}
 	if err := gen.Gen("word-search", j, t); err != nil {

--- a/exercises/practice/wordy/.meta/gen.go
+++ b/exercises/practice/wordy/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"answer": &[]testCase{},
 	}
 	if err := gen.Gen("wordy", j, t); err != nil {
@@ -24,11 +24,11 @@ type testCase struct {
 	Input       struct {
 		Question string `json:"question"`
 	} `json:"input"`
-	Expected interface{} `json:"expected"`
+	Expected any `json:"expected"`
 }
 
 func (t testCase) ExpectError() bool {
-	v, ok := t.Expected.(map[string]interface{})
+	v, ok := t.Expected.(map[string]any)
 	if ok {
 		_, ok := v["error"].(string)
 		return ok

--- a/exercises/practice/yacht/.meta/gen.go
+++ b/exercises/practice/yacht/.meta/gen.go
@@ -11,7 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := map[string]interface{}{
+	j := map[string]any{
 		"score": &[]testCase{},
 	}
 	if err := gen.Gen("yacht", j, t); err != nil {


### PR DESCRIPTION
This PR replaces instances of `interface{}` with `any`. Since the alias was introduced in Go 1.18, it is more commonly used.

Discussed in https://forum.exercism.org/t/replacing-interface-with-any/19838/7