### PR TITLE
Fix error message in NewTrack test case

### DIFF
--- a/exercises/concept/need-for-speed/need_for_speed_test.go
+++ b/exercises/concept/need-for-speed/need_for_speed_test.go
@@ -65,7 +65,7 @@ func TestNewTrack(t *testing.T) {
 			got := NewTrack(tt.track.distance)
 
 			if got != tt.expected {
-				t.Errorf("NewTrack(%+v) = %+v; expected %+v", tt.track.distance, tt.track, tt.expected)
+				t.Errorf("NewTrack(%+v) = %+v; expected %+v", tt.track.distance, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
noticed that the error message did not make sense when doing a local `go test`:
<img width="920" height="69" alt="image" src="https://github.com/user-attachments/assets/e16e885a-76db-4586-82bb-e72cd08e0ed8" />
my output value and the expected value output as the same, and it took awhile for me to realise i hardcoded a value in the NewTrack struct that was causing the error.
the correct test case should compare against the instantiated struc got