### PR TITLE
Fix golangbyexample links

### DIFF
--- a/exercises/concept/cars-assemble/.docs/hints.md
+++ b/exercises/concept/cars-assemble/.docs/hints.md
@@ -25,4 +25,4 @@
 
 [basic types]: https://tour.golang.org/basics/11
 [type conversions]: https://tour.golang.org/basics/13
-[modulo operator]: https://golangbyexample.com/remainder-modulus-go-golang/
+[modulo operator]: https://golangbyexamples.com/remainder-modulus-go-golang/

--- a/exercises/practice/leap/.approaches/boolean-chain/content.md
+++ b/exercises/practice/leap/.approaches/boolean-chain/content.md
@@ -27,6 +27,6 @@ This approach exhausts after a maximum of three checks.
 | 2000 |          true |           false |            true |         true |
 | 1900 |          true |           false |           false |        false |
 
-[modulus-operator]: https://golangbyexample.com/remainder-modulus-go-golang/
+[modulus-operator]: https://golangbyexamples.com/remainder-modulus-go-golang/
 [logical-and]: https://www.tutorialkart.com/golang-tutorial/golang-and/
 [logical-or]: https://www.tutorialkart.com/golang-tutorial/golang-or/

--- a/exercises/practice/leap/.approaches/introduction.md
+++ b/exercises/practice/leap/.approaches/introduction.md
@@ -62,7 +62,7 @@ but are both much slower than the other approaches.
 
 For more information, check the [Performance article][article-performance].
 
-[modulus-operator]: https://golangbyexample.com/remainder-modulus-go-golang/
+[modulus-operator]: https://golangbyexamples.com/remainder-modulus-go-golang/
 [approach-boolean-chain]: https://exercism.org/tracks/go/exercises/leap/approaches/boolean-chain
 [approach-max-two-checks]: https://exercism.org/tracks/go/exercises/leap/approaches/max-two-checks
 [approach-time-add]: https://exercism.org/tracks/go/exercises/leap/approaches/time-addition

--- a/exercises/practice/leap/.approaches/max-two-checks/content.md
+++ b/exercises/practice/leap/.approaches/max-two-checks/content.md
@@ -31,4 +31,4 @@ If the year is _not_ evenly divisible by `100`, then the expression is `false`, 
 Although it uses a maximum of only two checks, this approach tests an outlier condition of the year being evenly divisible by `100` first,
 which is less likely than the year being evenly divisible by `4`.
 
-[modulus-operator]: https://golangbyexample.com/remainder-modulus-go-golang/
+[modulus-operator]: https://golangbyexamples.com/remainder-modulus-go-golang/

--- a/exercises/practice/strain/.approaches/using-generics/content.md
+++ b/exercises/practice/strain/.approaches/using-generics/content.md
@@ -47,7 +47,7 @@ The type `T` is constrained to be one of the types defined in the `Slicer` inter
 The arguments to the function are a slice of the generic type `T`, and a function which takes a value of type `T` and returns a boolean value.
 
 ~~~~exercism/note
-If you haven't passed a function as a parameter before, a short explanation can be found [here](https://golangbyexample.com/func-as-func-argument-go/).
+If you haven't passed a function as a parameter before, a short explanation can be found [here](https://golangbyexamples.com/func-as-func-argument-go/).
 ~~~~
 
 The `Keep()` function is defined to return a slice of type `T`.


### PR DESCRIPTION
As reported in: http://forum.exercism.org/t/broken-external-link-in-go-track-exercise-cars-assemble-task-3-hint/20118