### PR TITLE
[linked-list] Add test generator and canonical test cases

### DIFF
--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -24,7 +24,8 @@
       ".meta/example.go"
     ],
     "editor": [
-      "cases_test.go"
+      "cases_test.go",
+      "extra_cases_test.go"
     ],
     "invalidator": [
       "go.mod"

--- a/exercises/practice/linked-list/.meta/example.go
+++ b/exercises/practice/linked-list/.meta/example.go
@@ -189,3 +189,33 @@ func (ll *List) Pop() (any, error) {
 		return v, nil
 	}
 }
+
+// Count returns the number of nodes in the list.
+func (ll *List) Count() int {
+	var count int
+	for cur := ll.head; cur != nil; cur = cur.Next() {
+		count++
+	}
+	return count
+}
+
+// Delete removes the first node in a list with a given value.
+// Returns true if a node was removed.
+func (ll *List) Delete(v any) bool {
+	for cur := ll.head; cur != nil; cur = cur.Next() {
+		if cur.Value == v {
+			if cur.prev == nil {
+				ll.head = cur.next
+			} else {
+				cur.prev.next = cur.next
+			}
+			if cur.next == nil {
+				ll.tail = cur.prev
+			} else {
+				cur.next.prev = cur.prev
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/exercises/practice/linked-list/.meta/gen.go
+++ b/exercises/practice/linked-list/.meta/gen.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"../../../../gen"
+	"fmt"
+	"log"
+	"slices"
+	"strings"
+	"text/template"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	j := map[string]any{
+		"list": &[]testCase{},
+	}
+	if err := gen.Gen("linked-list", j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type Operation struct {
+	Operation string `json:"operation"`
+	Value int `json:"value"`
+	Expected int `json:"expected"`
+}
+
+func (op Operation) String() string {
+	hasInput := []string{"push", "unshift", "delete"}
+	opFunc := strings.ToUpper(op.Operation[0:1]) + op.Operation[1:]
+	if slices.Contains(hasInput, op.Operation) {
+		return fmt.Sprintf("{operation: %q, value: %d}", opFunc, op.Value)
+	}
+	return fmt.Sprintf("{operation: %q, expected: %d}", opFunc, op.Expected)
+}
+
+type testCase struct {
+	Description string `json:"description"`
+	Input       struct{
+		Operations []Operation `json:"operations"`
+	} `json:"input"`
+}
+
+var tmpl = `// This file contains tests from the shared problem specifications repo.
+{{.Header}}
+
+type Operation struct{
+	operation string
+	value int
+	expected int
+}
+
+var testCases = []struct{
+	description string
+	operations []Operation
+}{ {{range .J.list}}
+	{
+		description: 	{{printf "%q" .Description}},
+		operations:     []Operation{ {{range .Input.Operations}}
+			{{.String}},{{end}}
+		},
+	},{{end}}
+}`

--- a/exercises/practice/linked-list/.meta/tests.toml
+++ b/exercises/practice/linked-list/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[7f7e3987-b954-41b8-8084-99beca08752c]
+description = "pop gets element from the list"
+
+[c3f67e5d-cfa2-4c3e-a18f-7ce999c3c885]
+description = "push/pop respectively add/remove at the end of the list"
+
+[00ea24ce-4f5c-4432-abb4-cc6e85462657]
+description = "shift gets an element from the list"
+
+[37962ee0-3324-4a29-b588-5a4c861e6564]
+description = "shift gets first element from the list"
+
+[30a3586b-e9dc-43fb-9a73-2770cec2c718]
+description = "unshift adds element at start of the list"
+
+[042f71e4-a8a7-4cf0-8953-7e4f3a21c42d]
+description = "pop, push, shift, and unshift can be used in any order"
+
+[88f65c0c-4532-4093-8295-2384fb2f37df]
+description = "count an empty list"
+
+[fc055689-5cbe-4cd9-b994-02e2abbb40a5]
+description = "count a list with items"
+
+[8272cef5-130d-40ea-b7f6-5ffd0790d650]
+description = "count is correct after mutation"
+
+[229b8f7a-bd8a-4798-b64f-0dc0bb356d95]
+description = "popping to empty doesn't break the list"
+
+[4e1948b4-514e-424b-a3cf-a1ebbfa2d1ad]
+description = "shifting to empty doesn't break the list"
+
+[e8f7c600-d597-4f79-949d-8ad8bae895a6]
+description = "deletes the only element"
+
+[fd65e422-51f3-45c0-9fd0-c33da638f89b]
+description = "deletes the element with the specified value from the list"
+
+[59db191a-b17f-4ab7-9c5c-60711ec1d013]
+description = "deletes the element with the specified value from the list, re-assigns tail"
+
+[58242222-5d39-415b-951d-8128247f8993]
+description = "deletes the element with the specified value from the list, re-assigns head"
+
+[ee3729ee-3405-4bd2-9bad-de0d4aa5d647]
+description = "deletes the first of two elements"
+
+[47e3b3b4-b82c-4c23-8c1a-ceb9b17cb9fb]
+description = "deletes the second of two elements"
+
+[7b420958-f285-4922-b8f9-10d9dcab5179]
+description = "delete does not modify the list if the element is not found"
+
+[7e04828f-6082-44e3-a059-201c63252a76]
+description = "deletes only the first occurrence"

--- a/exercises/practice/linked-list/cases_test.go
+++ b/exercises/practice/linked-list/cases_test.go
@@ -1,185 +1,212 @@
+// This file contains tests from the shared problem specifications repo.
 package linkedlist
 
-import "testing"
+// This is an auto-generated file. Do not change it manually. Run the generator to update the file.
+// See https://github.com/exercism/go#synchronizing-tests-and-instructions
+// Source: exercism/problem-specifications
+// Commit: 738e1e2 Rename canonical-schema to canonical-data.schema.json (#1908)
 
-var newListTestCases = []struct {
-	name     string
-	in       []any
-	expected []any
+type Operation struct {
+	operation string
+	value     int
+	expected  int
+}
+
+var testCases = []struct {
+	description string
+	operations  []Operation
 }{
 	{
-		name:     "from 5 elements",
-		in:       []any{1, 2, 3, 4, 5},
-		expected: []any{1, 2, 3, 4, 5},
-	},
-	{
-		name:     "from 2 elements",
-		in:       []any{1, 2},
-		expected: []any{1, 2},
-	},
-	{
-		name:     "from no element",
-		in:       []any{},
-		expected: []any{},
-	},
-	{
-		name:     "from 1 element",
-		in:       []any{999},
-		expected: []any{999},
-	},
-}
-
-var reverseTestCases = []struct {
-	name     string
-	in       []any
-	expected []any
-}{
-	{
-		name:     "from 5 elements",
-		in:       []any{1, 2, 3, 4, 5},
-		expected: []any{5, 4, 3, 2, 1},
-	},
-	{
-		name:     "from 2 elements",
-		in:       []any{1, 2},
-		expected: []any{2, 1},
-	},
-	{
-		name:     "from no element",
-		in:       []any{},
-		expected: []any{},
-	},
-	{
-		name:     "from 1 element",
-		in:       []any{999},
-		expected: []any{999},
-	},
-}
-
-var pushPopTestCases = []struct {
-	name     string
-	in       []any
-	actions  []checkedAction
-	expected []any
-}{
-	{
-		name: "PushFront only",
-		in:   []any{},
-		actions: []checkedAction{
-			unshift(4),
-			unshift(3),
-			unshift(2),
-			unshift(1),
+		description: "pop gets element from the list",
+		operations: []Operation{
+			{operation: "Push", value: 7},
+			{operation: "Pop", expected: 7},
 		},
-		expected: []any{1, 2, 3, 4},
 	},
 	{
-		name: "PushBack only",
-		in:   []any{},
-		actions: []checkedAction{
-			push(1),
-			push(2),
-			push(3),
-			push(4),
+		description: "push/pop respectively add/remove at the end of the list",
+		operations: []Operation{
+			{operation: "Push", value: 11},
+			{operation: "Push", value: 13},
+			{operation: "Pop", expected: 13},
+			{operation: "Pop", expected: 11},
 		},
-		expected: []any{1, 2, 3, 4},
 	},
 	{
-		name: "PopFront only, pop some elements",
-		in:   []any{1, 2, 3, 4},
-		actions: []checkedAction{
-			shift(1, nil),
-			shift(2, nil),
+		description: "shift gets an element from the list",
+		operations: []Operation{
+			{operation: "Push", value: 17},
+			{operation: "Shift", expected: 17},
 		},
-		expected: []any{3, 4},
 	},
 	{
-		name: "PopFront only, pop till empty",
-		in:   []any{1, 2, 3, 4},
-		actions: []checkedAction{
-			shift(1, nil),
-			shift(2, nil),
-			shift(3, nil),
-			shift(4, nil),
+		description: "shift gets first element from the list",
+		operations: []Operation{
+			{operation: "Push", value: 23},
+			{operation: "Push", value: 5},
+			{operation: "Shift", expected: 23},
+			{operation: "Shift", expected: 5},
 		},
-		expected: []any{},
 	},
 	{
-		name: "PopBack only, pop some elements",
-		in:   []any{1, 2, 3, 4},
-		actions: []checkedAction{
-			pop(4, nil),
-			pop(3, nil),
+		description: "unshift adds element at start of the list",
+		operations: []Operation{
+			{operation: "Unshift", value: 23},
+			{operation: "Unshift", value: 5},
+			{operation: "Shift", expected: 5},
+			{operation: "Shift", expected: 23},
 		},
-		expected: []any{1, 2},
 	},
 	{
-		name: "PopBack only, pop till empty",
-		in:   []any{1, 2, 3, 4},
-		actions: []checkedAction{
-			pop(4, nil),
-			pop(3, nil),
-			pop(2, nil),
-			pop(1, nil),
+		description: "pop, push, shift, and unshift can be used in any order",
+		operations: []Operation{
+			{operation: "Push", value: 1},
+			{operation: "Push", value: 2},
+			{operation: "Pop", expected: 2},
+			{operation: "Push", value: 3},
+			{operation: "Shift", expected: 1},
+			{operation: "Unshift", value: 4},
+			{operation: "Push", value: 5},
+			{operation: "Shift", expected: 4},
+			{operation: "Pop", expected: 5},
+			{operation: "Shift", expected: 3},
 		},
-		expected: []any{},
 	},
 	{
-		name: "mixed actions",
-		in:   []any{2, 3},
-		actions: []checkedAction{
-			unshift(1),
-			push(4),
-			shift(1, nil),
-			shift(2, nil),
-			pop(4, nil),
-			pop(3, nil),
-			unshift(8),
-			push(7),
-			unshift(9),
-			push(6),
+		description: "count an empty list",
+		operations: []Operation{
+			{operation: "Count", expected: 0},
 		},
-		expected: []any{9, 8, 7, 6},
 	},
-}
-
-// checkedAction calls a function of the linked list and (possibly) checks the result
-type checkedAction func(*testing.T, *List)
-
-func unshift(arg any) checkedAction {
-	return func(t *testing.T, ll *List) {
-		ll.Unshift(arg)
-	}
-}
-
-func push(arg any) checkedAction {
-	return func(t *testing.T, ll *List) {
-		ll.Push(arg)
-	}
-}
-
-func shift(expected any, expectedErr error) checkedAction {
-	return func(t *testing.T, ll *List) {
-		v, err := ll.Shift()
-		if err != expectedErr {
-			t.Errorf("PopFront() returned wrong, expected no error, got= %v", err)
-		}
-
-		if expectedErr == nil && v != expected {
-			t.Errorf("PopFront() returned wrong, expected= %v, got= %v", expected, v)
-		}
-	}
-}
-
-func pop(expected any, expectedErr error) checkedAction {
-	return func(t *testing.T, ll *List) {
-		v, err := ll.Pop()
-		if err != expectedErr {
-			t.Errorf("PopBack() returned wrong, expected no error, got= %v", err)
-		}
-
-		if expectedErr == nil && v != expected {
-			t.Errorf("PopBack() returned wrong, expected= %v, got= %v", expected, v)
-		}
-	}
+	{
+		description: "count a list with items",
+		operations: []Operation{
+			{operation: "Push", value: 37},
+			{operation: "Push", value: 1},
+			{operation: "Count", expected: 2},
+		},
+	},
+	{
+		description: "count is correct after mutation",
+		operations: []Operation{
+			{operation: "Push", value: 31},
+			{operation: "Count", expected: 1},
+			{operation: "Unshift", value: 43},
+			{operation: "Count", expected: 2},
+			{operation: "Shift", expected: 0},
+			{operation: "Count", expected: 1},
+			{operation: "Pop", expected: 0},
+			{operation: "Count", expected: 0},
+		},
+	},
+	{
+		description: "popping to empty doesn't break the list",
+		operations: []Operation{
+			{operation: "Push", value: 41},
+			{operation: "Push", value: 59},
+			{operation: "Pop", expected: 0},
+			{operation: "Pop", expected: 0},
+			{operation: "Push", value: 47},
+			{operation: "Count", expected: 1},
+			{operation: "Pop", expected: 47},
+		},
+	},
+	{
+		description: "shifting to empty doesn't break the list",
+		operations: []Operation{
+			{operation: "Push", value: 41},
+			{operation: "Push", value: 59},
+			{operation: "Shift", expected: 0},
+			{operation: "Shift", expected: 0},
+			{operation: "Push", value: 47},
+			{operation: "Count", expected: 1},
+			{operation: "Shift", expected: 47},
+		},
+	},
+	{
+		description: "deletes the only element",
+		operations: []Operation{
+			{operation: "Push", value: 61},
+			{operation: "Delete", value: 61},
+			{operation: "Count", expected: 0},
+		},
+	},
+	{
+		description: "deletes the element with the specified value from the list",
+		operations: []Operation{
+			{operation: "Push", value: 71},
+			{operation: "Push", value: 83},
+			{operation: "Push", value: 79},
+			{operation: "Delete", value: 83},
+			{operation: "Count", expected: 2},
+			{operation: "Pop", expected: 79},
+			{operation: "Shift", expected: 71},
+		},
+	},
+	{
+		description: "deletes the element with the specified value from the list, re-assigns tail",
+		operations: []Operation{
+			{operation: "Push", value: 71},
+			{operation: "Push", value: 83},
+			{operation: "Push", value: 79},
+			{operation: "Delete", value: 83},
+			{operation: "Count", expected: 2},
+			{operation: "Pop", expected: 79},
+			{operation: "Pop", expected: 71},
+		},
+	},
+	{
+		description: "deletes the element with the specified value from the list, re-assigns head",
+		operations: []Operation{
+			{operation: "Push", value: 71},
+			{operation: "Push", value: 83},
+			{operation: "Push", value: 79},
+			{operation: "Delete", value: 83},
+			{operation: "Count", expected: 2},
+			{operation: "Shift", expected: 71},
+			{operation: "Shift", expected: 79},
+		},
+	},
+	{
+		description: "deletes the first of two elements",
+		operations: []Operation{
+			{operation: "Push", value: 97},
+			{operation: "Push", value: 101},
+			{operation: "Delete", value: 97},
+			{operation: "Count", expected: 1},
+			{operation: "Pop", expected: 101},
+		},
+	},
+	{
+		description: "deletes the second of two elements",
+		operations: []Operation{
+			{operation: "Push", value: 97},
+			{operation: "Push", value: 101},
+			{operation: "Delete", value: 101},
+			{operation: "Count", expected: 1},
+			{operation: "Pop", expected: 97},
+		},
+	},
+	{
+		description: "delete does not modify the list if the element is not found",
+		operations: []Operation{
+			{operation: "Push", value: 89},
+			{operation: "Delete", value: 103},
+			{operation: "Count", expected: 1},
+		},
+	},
+	{
+		description: "deletes only the first occurrence",
+		operations: []Operation{
+			{operation: "Push", value: 73},
+			{operation: "Push", value: 9},
+			{operation: "Push", value: 9},
+			{operation: "Push", value: 107},
+			{operation: "Delete", value: 9},
+			{operation: "Count", expected: 3},
+			{operation: "Pop", expected: 107},
+			{operation: "Pop", expected: 9},
+			{operation: "Pop", expected: 73},
+		},
+	},
 }

--- a/exercises/practice/linked-list/extra_cases_test.go
+++ b/exercises/practice/linked-list/extra_cases_test.go
@@ -1,0 +1,187 @@
+package linkedlist
+
+// This file contains custom track specific tests.
+
+import "testing"
+
+var newListTestCases = []struct {
+	name     string
+	in       []any
+	expected []any
+}{
+	{
+		name:     "from 5 elements",
+		in:       []any{1, 2, 3, 4, 5},
+		expected: []any{1, 2, 3, 4, 5},
+	},
+	{
+		name:     "from 2 elements",
+		in:       []any{1, 2},
+		expected: []any{1, 2},
+	},
+	{
+		name:     "from no element",
+		in:       []any{},
+		expected: []any{},
+	},
+	{
+		name:     "from 1 element",
+		in:       []any{999},
+		expected: []any{999},
+	},
+}
+
+var reverseTestCases = []struct {
+	name     string
+	in       []any
+	expected []any
+}{
+	{
+		name:     "from 5 elements",
+		in:       []any{1, 2, 3, 4, 5},
+		expected: []any{5, 4, 3, 2, 1},
+	},
+	{
+		name:     "from 2 elements",
+		in:       []any{1, 2},
+		expected: []any{2, 1},
+	},
+	{
+		name:     "from no element",
+		in:       []any{},
+		expected: []any{},
+	},
+	{
+		name:     "from 1 element",
+		in:       []any{999},
+		expected: []any{999},
+	},
+}
+
+var pushPopTestCases = []struct {
+	name     string
+	in       []any
+	actions  []checkedAction
+	expected []any
+}{
+	{
+		name: "PushFront only",
+		in:   []any{},
+		actions: []checkedAction{
+			unshift(4),
+			unshift(3),
+			unshift(2),
+			unshift(1),
+		},
+		expected: []any{1, 2, 3, 4},
+	},
+	{
+		name: "PushBack only",
+		in:   []any{},
+		actions: []checkedAction{
+			push(1),
+			push(2),
+			push(3),
+			push(4),
+		},
+		expected: []any{1, 2, 3, 4},
+	},
+	{
+		name: "PopFront only, pop some elements",
+		in:   []any{1, 2, 3, 4},
+		actions: []checkedAction{
+			shift(1, nil),
+			shift(2, nil),
+		},
+		expected: []any{3, 4},
+	},
+	{
+		name: "PopFront only, pop till empty",
+		in:   []any{1, 2, 3, 4},
+		actions: []checkedAction{
+			shift(1, nil),
+			shift(2, nil),
+			shift(3, nil),
+			shift(4, nil),
+		},
+		expected: []any{},
+	},
+	{
+		name: "PopBack only, pop some elements",
+		in:   []any{1, 2, 3, 4},
+		actions: []checkedAction{
+			pop(4, nil),
+			pop(3, nil),
+		},
+		expected: []any{1, 2},
+	},
+	{
+		name: "PopBack only, pop till empty",
+		in:   []any{1, 2, 3, 4},
+		actions: []checkedAction{
+			pop(4, nil),
+			pop(3, nil),
+			pop(2, nil),
+			pop(1, nil),
+		},
+		expected: []any{},
+	},
+	{
+		name: "mixed actions",
+		in:   []any{2, 3},
+		actions: []checkedAction{
+			unshift(1),
+			push(4),
+			shift(1, nil),
+			shift(2, nil),
+			pop(4, nil),
+			pop(3, nil),
+			unshift(8),
+			push(7),
+			unshift(9),
+			push(6),
+		},
+		expected: []any{9, 8, 7, 6},
+	},
+}
+
+// checkedAction calls a function of the linked list and (possibly) checks the result
+type checkedAction func(*testing.T, *List)
+
+func unshift(arg any) checkedAction {
+	return func(t *testing.T, ll *List) {
+		ll.Unshift(arg)
+	}
+}
+
+func push(arg any) checkedAction {
+	return func(t *testing.T, ll *List) {
+		ll.Push(arg)
+	}
+}
+
+func shift(expected any, expectedErr error) checkedAction {
+	return func(t *testing.T, ll *List) {
+		v, err := ll.Shift()
+		if err != expectedErr {
+			t.Errorf("PopFront() returned wrong, expected no error, got= %v", err)
+		}
+
+		if expectedErr == nil && v != expected {
+			t.Errorf("PopFront() returned wrong, expected= %v, got= %v", expected, v)
+		}
+	}
+}
+
+func pop(expected any, expectedErr error) checkedAction {
+	return func(t *testing.T, ll *List) {
+		v, err := ll.Pop()
+		if err != expectedErr {
+			t.Errorf("PopBack() returned wrong, expected no error, got= %v", err)
+		}
+
+		if expectedErr == nil && v != expected {
+			t.Errorf("PopBack() returned wrong, expected= %v, got= %v", expected, v)
+		}
+	}
+}

--- a/exercises/practice/linked-list/linked_list.go
+++ b/exercises/practice/linked-list/linked_list.go
@@ -42,3 +42,13 @@ func (l *List) First() *Node {
 func (l *List) Last() *Node {
 	panic("Please implement the Last function")
 }
+
+func (l *List) Count() int {
+	panic("Please implement the Count function")
+}
+
+// Delete removes the first node in a list with a given value.
+// Returns true if a node was removed.
+func (ll *List) Delete(v any) bool {
+	panic("Please implement the Delete function")
+}

--- a/exercises/practice/linked-list/linked_list_test.go
+++ b/exercises/practice/linked-list/linked_list_test.go
@@ -3,9 +3,54 @@ package linkedlist
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"strings"
 	"testing"
 )
 
+func TestList(t *testing.T) {
+	hasInput := []string{"push", "unshift", "delete"}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			list := NewList()
+			var calls []string
+			for _, op := range tc.operations {
+				if slices.Contains(hasInput, op.operation) {
+					calls = append(calls, fmt.Sprintf("%s(%v)", op.operation, op.value))
+				} else {
+					calls = append(calls, fmt.Sprintf("%s()", op.operation))
+				}
+
+				var got int
+				switch op.operation {
+				case "Push":
+					list.Push(op.value)
+				case "Unshift":
+					list.Unshift(op.value)
+				case "Delete":
+					list.Delete(op.value)
+				case "Pop":
+					raw, _ := list.Pop()
+					got = raw.(int)
+				case "Shift":
+					raw, _ := list.Shift()
+					got = raw.(int)
+				case "Count":
+					got = list.Count()
+				default:
+					panic(fmt.Sprintf("unknown operation %s", op.operation))
+				}
+
+				checkGot := op.expected != 0 || op.operation == "Count"
+				if checkGot && op.expected != got {
+					t.Fatalf("%s() = %d, want %d\nCalls: %s.", op.operation, got, op.expected, strings.Join(calls, "; "))
+					break
+				}
+			}
+		})
+	}
+}
 func TestNew(t *testing.T) {
 	for _, tc := range newListTestCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The existing tests are not from the problem spec and doesn't cover all the methods in the canonical tests.
This PR adds two methods (`Delete(), Count()`) and extends the tests with the canonical data.
The pre-existing tests are retained, resulting in two sets of tests.