### PR TITLE
cardtricks exercise GetItem bounds check

### DIFF
--- a/exercises/concept/card-tricks/card_tricks_test.go
+++ b/exercises/concept/card-tricks/card_tricks_test.go
@@ -135,9 +135,9 @@ func TestSetItem(t *testing.T) {
 			args: args{
 				slice: []int{-2, -1, 0, 1, 2},
 				index: 1,
-				value: -1,
+				value: 5,
 			},
-			want: []int{-2, -1, 0, 1, 2},
+			want: []int{-2, 5, 0, 1, 2},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
[no important files changed]

per the discussion here:
https://forum.exercism.org/t/card-tricks-test-expansion/34520

The card-trick exercise awards a pass when students are using GetItem() as a bounds checker. This approach seems like a good place for students to practice code re-use but GetItem() doesn't work because its return is -1 when out of bounds.  If `slice[index] = -1`  SetItem() will append instead of edit.  This PR adds a test to check if GetItem() is being used as a bounds checker.