### PR TITLE
verify-exercises-in-docker: show results on failure

### DIFF
--- a/bin/verify-exercises-in-docker
+++ b/bin/verify-exercises-in-docker
@@ -55,7 +55,7 @@ verify_exercise() {
         trap 'rm -rf "${tmpdir}"' EXIT    # remove tmpdir when subshell ends
         cp -r "${dir}/." "${tmpdir}" || exit
         copy_example "${tmpdir}"
-        run_tests "${slug}" "${tmpdir}" || { cat "${PWD}/results.json"; exit 1; }
+        run_tests "${slug}" "${tmpdir}" || { cat "${tmpdir}/results.json"; exit 1; }
     )
 }
 


### PR DESCRIPTION



If we introduce an exercise bug, we previously had

```text
$ cd ...
$ bin/verify-exercises-in-docker leap
Using default tag: latest
latest: Pulling from exercism/go-test-runner
Digest: sha256:0955d976e4507dca38caba5dcfb726b5fe89c5457231c5068276783e6e83ffd1
Status: Image is up to date for exercism/go-test-runner:latest
docker.io/exercism/go-test-runner:latest
Verifying leap exercise...
cat: .../results.json: No such file or directory
```

Now we have

```text
$ bin/verify-exercises-in-docker leap
Using default tag: latest
latest: Pulling from exercism/go-test-runner
Digest: sha256:0955d976e4507dca38caba5dcfb726b5fe89c5457231c5068276783e6e83ffd1
Status: Image is up to date for exercism/go-test-runner:latest
docker.io/exercism/go-test-runner:latest
Verifying leap exercise...
{
        "status": "fail",
        "version": 3,
        "tests": [
        ...
        ]
}
```
