### PR TITLE
test generator: include the recursive test descriptions in a test case

### DIFF
--- a/gen/filter.go
+++ b/gen/filter.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 // getAllTestCasesFiltered recursively collects all test cases in a flattened list except the ones excluded by excludedTests.
@@ -13,14 +14,14 @@ func getAllTestCasesFiltered(jSrc []byte, excludedTests map[string]struct{}) (*[
 	jSrc = append([]byte{'['}, append(jSrc, ']')...)
 
 	// recursively get all test cases except the excluded ones
-	err := recursiveFilterCases(jSrc, result, excludedTests)
+	err := recursiveFilterCases(jSrc, result, nil, excludedTests)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get/filter all test cases: %w", err)
 	}
 	return result, nil
 }
 
-func recursiveFilterCases(cases json.RawMessage, result *[]testCase, excludedTests map[string]struct{}) error {
+func recursiveFilterCases(cases json.RawMessage, result *[]testCase, parentDescriptions []string, excludedTests map[string]struct{}) error {
 	var js []map[string]json.RawMessage
 
 	// 'cases' is always an array, where every item is either a single test or an object containing nested cases
@@ -51,7 +52,7 @@ func recursiveFilterCases(cases json.RawMessage, result *[]testCase, excludedTes
 				return err
 			}
 
-			tc := testCase{}
+			tc := testCase{Parents: parentDescriptions}
 			err = json.Unmarshal(jTestCase, &tc)
 			if err != nil {
 				return err
@@ -62,7 +63,17 @@ func recursiveFilterCases(cases json.RawMessage, result *[]testCase, excludedTes
 		}
 
 		// If uuid key is not present, this item is an object containing nested cases.
-		err := recursiveFilterCases(j["cases"], result, excludedTests)
+		// Update the parent description slice.
+		updatedParentDescriptions := slices.Clone(parentDescriptions)
+		if _, ok := j["description"]; ok {
+			var description string
+			err = json.Unmarshal(j["description"], &description)
+			if err != nil {
+				return err
+			}
+			updatedParentDescriptions = append(updatedParentDescriptions, description)
+		}
+		err := recursiveFilterCases(j["cases"], result, updatedParentDescriptions, excludedTests)
 		if err != nil {
 			return err
 		}

--- a/gen/filter_test.go
+++ b/gen/filter_test.go
@@ -33,6 +33,7 @@ var (
 		"uuid": "8snv0f-f781-4c52-b73b-8e76427defd0"
 		},
 		{
+		"description": "nested cases",
 		"cases": [
 			{
 			"description": "test case 3",
@@ -115,7 +116,7 @@ func TestGetAllTestCasesFiltered(t *testing.T) {
 		expectedOutput []testCase
 	}{
 		{
-			description: "Filter valid json successfully",
+			description: "filter valid json successfully",
 			inputJSON:   []byte(validInputJSON),
 			excludeList: excludeList,
 			expectedOutput: []testCase{
@@ -136,6 +137,7 @@ func TestGetAllTestCasesFiltered(t *testing.T) {
 						"integers": []interface{}{64.0},
 					},
 					Expected: []interface{}{64.0},
+					Parents:  []string{"nested cases"},
 				},
 				{
 					UUID:        "dvthrd4-4514-4915-bac0-f7f585e0e59a",
@@ -145,11 +147,12 @@ func TestGetAllTestCasesFiltered(t *testing.T) {
 						"bools": []interface{}{true, false},
 					},
 					Expected: false,
+					Parents:  []string{"some nested cases", "nested cases"},
 				},
 			},
 		},
 		{
-			description:    "Filtering invalid json should fail",
+			description:    "filtering invalid json should fail",
 			inputJSON:      []byte("{\"asd"),
 			excludeList:    excludeList,
 			expectedOutput: nil,
@@ -183,7 +186,7 @@ func TestGetAllTestCasesFiltered(t *testing.T) {
 					t.Errorf("unexpected error %v", err)
 				}
 				if output == nil || !reflect.DeepEqual(tc.expectedOutput, *output) {
-					t.Errorf("wrong output. expected: %v, got %v", tc.expectedOutput, output)
+					t.Errorf("wrong output.\nexpected %#v,\ngot %#v", tc.expectedOutput, output)
 				}
 			}
 		})

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -77,6 +77,9 @@ type testCase struct {
 	Scenarios   []string    `json:"scenarios"`
 	Input       interface{} `json:"input"`
 	Expected    interface{} `json:"expected"`
+	// Group is used when test cases are grouped with a group description.
+	// In practice there should be exactly 0 or 1 group descriptions.
+	Parents     []string
 }
 
 // PackageName gives the Go package name from an exercise slug.


### PR DESCRIPTION
When tests are nested, collect the descriptions at prior levels to have
the complete recursive description.
