### PR TITLE
[react] Refactor API to be less open

### DIFF
--- a/exercises/practice/react/interfaces.go
+++ b/exercises/practice/react/interfaces.go
@@ -1,6 +1,6 @@
 package react
 
-// A Reactor manages linked cells.
+// A reactor manages linked cells.
 type Reactor interface {
 	// CreateInput creates an input cell linked into the reactor
 	// with the given initial value.
@@ -9,16 +9,16 @@ type Reactor interface {
 	// CreateCompute1 creates a compute cell which computes its value
 	// based on one other cell. The compute function will only be called
 	// if the value of the passed cell changes.
-	CreateCompute1(Cell, func(int) int) ComputeCell
+	CreateCompute1(cell, func(int) int) ComputeCell
 
 	// CreateCompute2 is like CreateCompute1, but depending on two cells.
 	// The compute function will only be called if the value of any of the
 	// passed cells changes.
-	CreateCompute2(Cell, Cell, func(int, int) int) ComputeCell
+	CreateCompute2(cell, cell, func(int, int) int) ComputeCell
 }
 
-// A Cell is conceptually a holder of a value.
-type Cell interface {
+// A cell is conceptually a holder of a value.
+type cell interface {
 	// Value returns the current value of the cell.
 	Value() int
 }
@@ -26,7 +26,7 @@ type Cell interface {
 // An InputCell has a changeable value, changing the value triggers updates to
 // other cells.
 type InputCell interface {
-	Cell
+	cell
 
 	// SetValue sets the value of the cell.
 	SetValue(int)
@@ -35,7 +35,7 @@ type InputCell interface {
 // A ComputeCell always computes its value based on other cells and can
 // call callbacks upon changes.
 type ComputeCell interface {
-	Cell
+	cell
 
 	// AddCallback adds a callback which will be called when the value changes.
 	// It returns a Canceler which can be used to remove the callback.

--- a/exercises/practice/react/react.go
+++ b/exercises/practice/react/react.go
@@ -1,21 +1,24 @@
 package react
 
-// Define reactor, cell and canceler types here.
-// These types will implement the Reactor, Cell and Canceler interfaces, respectively.
+// Define types that will provide the Reactor, cell, and Canceler interface here.
+// The prepopulated code assumes types
+// canceler <- Canceler
+// myCell <- cell, ComputeCell, InputCell
+// reactor <- Reactor
 
 func (c *canceler) Cancel() {
 	panic("Please implement the Cancel function")
 }
 
-func (c *cell) Value() int {
+func (c *myCell) Value() int {
 	panic("Please implement the Value function")
 }
 
-func (c *cell) SetValue(value int) {
+func (c *myCell) SetValue(value int) {
 	panic("Please implement the SetValue function")
 }
 
-func (c *cell) AddCallback(callback func(int)) Canceler {
+func (c *myCell) AddCallback(callback func(int)) Canceler {
 	panic("Please implement the AddCallback function")
 }
 
@@ -27,10 +30,10 @@ func (r *reactor) CreateInput(initial int) InputCell {
 	panic("Please implement the CreateInput function")
 }
 
-func (r *reactor) CreateCompute1(dep Cell, compute func(int) int) ComputeCell {
+func (r *reactor) CreateCompute1(dep cell, compute func(int) int) ComputeCell {
 	panic("Please implement the CreateCompute1 function")
 }
 
-func (r *reactor) CreateCompute2(dep1, dep2 Cell, compute func(int, int) int) ComputeCell {
+func (r *reactor) CreateCompute2(dep1, dep2 cell, compute func(int, int) int) ComputeCell {
 	panic("Please implement the CreateCompute2 function")
 }

--- a/exercises/practice/react/react_test.go
+++ b/exercises/practice/react/react_test.go
@@ -9,7 +9,7 @@ import (
 
 type ReactTest struct {
 	r         Reactor
-	cells     map[string]Cell
+	cells     map[string]cell
 	cancelers map[string]Canceler
 	callbacks map[string]int
 }
@@ -17,7 +17,7 @@ type ReactTest struct {
 func NewReactTest() ReactTest {
 	return ReactTest{
 		r:         New(),
-		cells:     make(map[string]Cell),
+		cells:     make(map[string]cell),
 		cancelers: make(map[string]Canceler),
 		callbacks: make(map[string]int),
 	}
@@ -69,7 +69,7 @@ func (rt ReactTest) Operate(op Operation) error {
 		}
 	case "AddCallback":
 		computeCell := rt.cells[op.cell].(ComputeCell)
-		rt.cancelers[op.name] = computeCell.AddCallback(func(x int) {rt.callbacks[op.name] = x})
+		rt.cancelers[op.name] = computeCell.AddCallback(func(x int) { rt.callbacks[op.name] = x })
 	case "Cancel":
 		rt.cancelers[op.name].Cancel()
 	case "Value":


### PR DESCRIPTION
I think the existing API makes it easy to have a brittle implementation that fails when `react` is used as a package.
The proposed change aims to unexport some of the interface as a minimal change.

---

Frankly, I think it is a bad change; my hope is that this PR will be something else entirely before approval, hoping to have the discussion here, but perhaps an issue is more appropriate.

I think a better change would look like an API that doesn't secretly rely on coupling across private types that expose a public only interface.
I'm not certain that this API is unsatisfiable to extend, but I'm suspicious that it is.
Looking at other solutions, I should be able to take someone's Reactor, \[Input|Compute\]Cell and get the interface to work, but I've not been able to do so.

I think I need someone more experienced to tell me if this is
- a correct analysis
- useful thing to notice for Gophers
- useful to point out in Exercism

I think the core of the issue is that none of the Cell types can express state change through the API, but any implementation must accept an arbitrary Cell as an upstream.
I'd be happy to be wrong, but neither mentor nor I figured it out yet.

Some ideas around different API might be generics:
- only allowing a Reactor to have one type that implements Cell.
- extending to have ComputeCell provide a Recompute

