### PR TITLE
Ensure all `instructions.append.md` use an H1 and H2

### DIFF
--- a/exercises/practice/two-bucket/.docs/instructions.append.md
+++ b/exercises/practice/two-bucket/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Implementation
+# Instructions append
+
+## Implementation
 
 In package twobucket, implement a Go func, Solve, with the following signature:
 

--- a/exercises/practice/zebra-puzzle/.docs/instructions.append.md
+++ b/exercises/practice/zebra-puzzle/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Implementation
+# Instructions append
+
+## Implementation
 
 Define a single function, SolvePuzzle, which returns a solution
 containing two strings, whose values are the answers to the


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.